### PR TITLE
fix(short-syntax): keep task content typed after a multi word project name

### DIFF
--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -1350,6 +1350,123 @@ describe('shortSyntax', () => {
       });
     });
 
+    it('should prefer a fully typed title over a longer partially matching one', async () => {
+      const overlappingProjects = [
+        { title: 'Work', id: 'WorkID' },
+        { title: 'Work Inbox', id: 'WorkInboxID' },
+      ] as Project[];
+      const t = {
+        ...TASK,
+        title: 'Task +Work in progress',
+      };
+      const r = await shortSyntax(t, CONFIG, [], overlappingProjects);
+      expect(r).toEqual({
+        newTagTitles: [],
+        remindAt: null,
+        repeat: null,
+        parsedRanges: expectedRanges(t.title, [['project', '+Work']]),
+        projectId: 'WorkID',
+        attachments: [],
+        taskChanges: {
+          title: 'Task in progress',
+        },
+      });
+    });
+
+    it('should still consume the longer title when it is typed in full', async () => {
+      const overlappingProjects = [
+        { title: 'Work', id: 'WorkID' },
+        { title: 'Work Inbox', id: 'WorkInboxID' },
+      ] as Project[];
+      const t = {
+        ...TASK,
+        title: 'Task +Work Inbox stuff',
+      };
+      const r = await shortSyntax(t, CONFIG, [], overlappingProjects);
+      expect(r).toEqual({
+        newTagTitles: [],
+        remindAt: null,
+        repeat: null,
+        parsedRanges: expectedRanges(t.title, [['project', '+Work Inbox']]),
+        projectId: 'WorkInboxID',
+        attachments: [],
+        taskChanges: {
+          title: 'Task stuff',
+        },
+      });
+    });
+
+    it('should not join task words into a project title written without white space', async () => {
+      const concatenatedProjects = [
+        { title: 'Home', id: 'HomeID' },
+        { title: 'Homework', id: 'HomeworkID' },
+      ] as Project[];
+      const t = {
+        ...TASK,
+        title: '+Home work on taxes',
+      };
+      const r = await shortSyntax(t, CONFIG, [], concatenatedProjects);
+      expect(r).toEqual({
+        newTagTitles: [],
+        remindAt: null,
+        repeat: null,
+        parsedRanges: expectedRanges(t.title, [['project', '+Home']]),
+        projectId: 'HomeID',
+        attachments: [],
+        taskChanges: {
+          title: 'work on taxes',
+        },
+      });
+    });
+
+    it('should parse a tag and an estimate typed after a multi word project title', async () => {
+      const t = {
+        ...TASK,
+        title: '+Some Project Title do the thing 30m #blu',
+      };
+      const r = await shortSyntax(t, CONFIG, ALL_TAGS, projects);
+      expect(r).toEqual({
+        newTagTitles: [],
+        remindAt: null,
+        repeat: null,
+        parsedRanges: expectedRanges(t.title, [
+          ['project', '+Some Project Title'],
+          ['estimate', '30m'],
+          ['tag', '#blu'],
+        ]),
+        projectId: 'SomeProjectID',
+        attachments: [],
+        taskChanges: {
+          title: 'do the thing',
+          tagIds: ['blu_id'],
+          timeEstimate: 1800000,
+        },
+      });
+    });
+
+    it('should keep a fully typed title even when only part of a longer one is typed', async () => {
+      const overlappingProjects = [
+        { title: 'Work', id: 'WorkID' },
+        { title: 'Work Inbox', id: 'WorkInboxID' },
+      ] as Project[];
+      const t = {
+        ...TASK,
+        title: 'Task +Work Inb stuff',
+      };
+      const r = await shortSyntax(t, CONFIG, [], overlappingProjects);
+      expect(r).toEqual({
+        newTagTitles: [],
+        remindAt: null,
+        repeat: null,
+        parsedRanges: expectedRanges(t.title, [['project', '+Work']]),
+        projectId: 'WorkID',
+        attachments: [],
+        taskChanges: {
+          title: 'Task Inb stuff',
+        },
+      });
+    });
+
     it('should ignore non existing', async () => {
       const t = {
         ...TASK,

--- a/src/app/features/tasks/short-syntax.spec.ts
+++ b/src/app/features/tasks/short-syntax.spec.ts
@@ -1274,6 +1274,82 @@ describe('shortSyntax', () => {
       });
     });
 
+    it('should keep task content typed after a multi word project title', async () => {
+      const t = {
+        ...TASK,
+        title: '+Some Project Title do the thing',
+      };
+      const r = await shortSyntax(t, CONFIG, [], projects);
+      expect(r).toEqual({
+        newTagTitles: [],
+        remindAt: null,
+        repeat: null,
+        parsedRanges: expectedRanges(t.title, [['project', '+Some Project Title']]),
+        projectId: 'SomeProjectID',
+        attachments: [],
+        taskChanges: {
+          title: 'do the thing',
+        },
+      });
+    });
+
+    it('should keep task content typed after a partial multi word project title', async () => {
+      const t = {
+        ...TASK,
+        title: '+Some Pro do the thing',
+      };
+      const r = await shortSyntax(t, CONFIG, [], projects);
+      expect(r).toEqual({
+        newTagTitles: [],
+        remindAt: null,
+        repeat: null,
+        parsedRanges: expectedRanges(t.title, [['project', '+Some Pro']]),
+        projectId: 'SomeProjectID',
+        attachments: [],
+        taskChanges: {
+          title: 'do the thing',
+        },
+      });
+    });
+
+    it('should keep task content typed after a single word project title', async () => {
+      const t = {
+        ...TASK,
+        title: '+ProjectEasyShort do the thing',
+      };
+      const r = await shortSyntax(t, CONFIG, [], projects);
+      expect(r).toEqual({
+        newTagTitles: [],
+        remindAt: null,
+        repeat: null,
+        parsedRanges: expectedRanges(t.title, [['project', '+ProjectEasyShort']]),
+        projectId: 'ProjectEasyShortID',
+        attachments: [],
+        taskChanges: {
+          title: 'do the thing',
+        },
+      });
+    });
+
+    it('should keep task content surrounding a multi word project title', async () => {
+      const t = {
+        ...TASK,
+        title: 'Fun title +Some Project Title and more',
+      };
+      const r = await shortSyntax(t, CONFIG, [], projects);
+      expect(r).toEqual({
+        newTagTitles: [],
+        remindAt: null,
+        repeat: null,
+        parsedRanges: expectedRanges(t.title, [['project', '+Some Project Title']]),
+        projectId: 'SomeProjectID',
+        attachments: [],
+        taskChanges: {
+          title: 'Fun title and more',
+        },
+      });
+    });
+
     it('should ignore non existing', async () => {
       const t = {
         ...TASK,

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -575,33 +575,27 @@ const parseProjectTracked = (
       .slice()
       .sort((p1, p2) => p1.title.length - p2.title.length);
 
-    const existingProject = sortedAllProjects.find(
-      (project) =>
-        project.title.replaceAll(' ', '').toLowerCase().indexOf(projectTitleToMatch) ===
-        0,
-    );
+    const findProjectStartingWith = (typedTitle: string): Project | undefined => {
+      const toMatch = typedTitle.replaceAll(' ', '').toLowerCase();
+      return sortedAllProjects.find(
+        (project) =>
+          project.title.replaceAll(' ', '').toLowerCase().indexOf(toMatch) === 0,
+      );
+    };
 
-    if (existingProject) {
-      return {
-        projectId: existingProject.id,
-        ranges: consume(`${CH_PRO}${projectTitle}`),
-      };
-    }
-
-    // also try only first word after special char
-    const projectTitleFirstWordOnly = projectTitle.split(' ')[0];
-    const projectTitleToMatch2 = projectTitleFirstWordOnly.replace(' ', '').toLowerCase();
-    const existingProjectForFirstWordOnly = sortedAllProjects.find(
-      (project) =>
-        project.title.replaceAll(' ', '').toLowerCase().indexOf(projectTitleToMatch2) ===
-        0,
-    );
-
-    if (existingProjectForFirstWordOnly) {
-      return {
-        projectId: existingProjectForFirstWordOnly.id,
-        ranges: consume(`${CH_PRO}${projectTitleFirstWordOnly}`),
-      };
+    // The match candidate also contains whatever was typed after the project name
+    // (e.g. "+Some Project Title do the thing"), so try the longest word prefix first
+    // and only consume the words that actually belong to the project title
+    const candidateWords = projectTitle.split(' ');
+    for (let nrOfWords = candidateWords.length; nrOfWords > 0; nrOfWords--) {
+      const typedProjectTitle = candidateWords.slice(0, nrOfWords).join(' ');
+      const existingProject = findProjectStartingWith(typedProjectTitle);
+      if (existingProject) {
+        return {
+          projectId: existingProject.id,
+          ranges: consume(`${CH_PRO}${typedProjectTitle}`),
+        };
+      }
     }
   }
 

--- a/src/app/features/tasks/short-syntax.ts
+++ b/src/app/features/tasks/short-syntax.ts
@@ -526,6 +526,47 @@ export const parseProjectChanges = (
   return result ? { title: tracked.text, projectId: result.projectId } : {};
 };
 
+type MatchableProject = {
+  id: string;
+  words: string[];
+  /** title with all whitespace removed, to match titles typed without spaces */
+  squashedTitle: string;
+  titleLength: number;
+};
+
+const toWords = (title: string): string[] => title.trim().toLowerCase().split(/\s+/);
+
+const toMatchableProject = (project: Project): MatchableProject => ({
+  id: project.id,
+  words: toWords(project.title),
+  squashedTitle: project.title.replaceAll(' ', '').toLowerCase(),
+  titleLength: project.title.length,
+});
+
+const isFullyTypedProjectTitle = (
+  project: MatchableProject,
+  typedWords: string[],
+): boolean =>
+  project.words.length === typedWords.length &&
+  project.words.every((word, i) => word === typedWords[i]);
+
+// A partially typed title may only shorten its last word ("+Some Pro"), otherwise
+// task content would get pulled into the project title ("+Home work on taxes" must
+// not match a project "Homework"). A single word may also be typed without any
+// whitespace at all ("+SomePro").
+const isPartiallyTypedProjectTitle = (
+  project: MatchableProject,
+  typedWords: string[],
+): boolean =>
+  typedWords.length === 1
+    ? project.squashedTitle.startsWith(typedWords[0])
+    : typedWords.length <= project.words.length &&
+      typedWords.every((word, i) =>
+        i === typedWords.length - 1
+          ? project.words[i].startsWith(word)
+          : project.words[i] === word,
+      );
+
 const parseProjectTracked = (
   task: Partial<TaskCopy>,
   tracked: TrackedTitle,
@@ -571,31 +612,52 @@ const parseProjectTracked = (
     };
 
     // Prefer shortest prefix-based project title match
-    const sortedAllProjects = allProjects
-      .slice()
-      .sort((p1, p2) => p1.title.length - p2.title.length);
-
-    const findProjectStartingWith = (typedTitle: string): Project | undefined => {
-      const toMatch = typedTitle.replaceAll(' ', '').toLowerCase();
-      return sortedAllProjects.find(
-        (project) =>
-          project.title.replaceAll(' ', '').toLowerCase().indexOf(toMatch) === 0,
-      );
-    };
+    const matchableProjects = allProjects
+      .map(toMatchableProject)
+      .sort((p1, p2) => p1.titleLength - p2.titleLength);
 
     // The match candidate also contains whatever was typed after the project name
-    // (e.g. "+Some Project Title do the thing"), so try the longest word prefix first
-    // and only consume the words that actually belong to the project title
-    const candidateWords = projectTitle.split(' ');
-    for (let nrOfWords = candidateWords.length; nrOfWords > 0; nrOfWords--) {
-      const typedProjectTitle = candidateWords.slice(0, nrOfWords).join(' ');
-      const existingProject = findProjectStartingWith(typedProjectTitle);
-      if (existingProject) {
-        return {
-          projectId: existingProject.id,
-          ranges: consume(`${CH_PRO}${typedProjectTitle}`),
-        };
+    // (e.g. "+Some Project Title do the thing"), so walk the word prefixes of the
+    // candidate from the longest down and only consume the words that actually
+    // belong to the project title. A prefix with more words than the longest
+    // project title can never match, which also bounds the walk for long input.
+    const maxNrOfWords = matchableProjects.reduce(
+      (max, project) => Math.max(max, project.words.length),
+      0,
+    );
+    const candidateWordEnds = [...projectTitle.matchAll(/\S+/g)].map(
+      (match) => (match.index ?? 0) + match[0].length,
+    );
+
+    const findLongestTypedPrefix = (
+      isMatch: (project: MatchableProject, typedWords: string[]) => boolean,
+    ): { projectId: string; typedTitle: string } | null => {
+      for (
+        let nrOfWords = Math.min(candidateWordEnds.length, maxNrOfWords);
+        nrOfWords > 0;
+        nrOfWords--
+      ) {
+        const typedTitle = projectTitle.slice(0, candidateWordEnds[nrOfWords - 1]);
+        const typedWords = toWords(typedTitle);
+        const project = matchableProjects.find((p) => isMatch(p, typedWords));
+        if (project) {
+          return { projectId: project.id, typedTitle };
+        }
       }
+      return null;
+    };
+
+    // A fully typed title (what the autocomplete inserts) always wins, so that
+    // "+Work in progress" stays in project "Work" even when "Work Inbox" exists
+    const match =
+      findLongestTypedPrefix(isFullyTypedProjectTitle) ||
+      findLongestTypedPrefix(isPartiallyTypedProjectTitle);
+
+    if (match) {
+      return {
+        projectId: match.projectId,
+        ranges: consume(`${CH_PRO}${match.typedTitle}`),
+      };
     }
   }
 


### PR DESCRIPTION
Fixes #9656

## Problem

Picking a project with a **multi-word title** from the `+` autocomplete inserts `+Word1 Word2 Word3 ` into the add-task bar. Typing task content after it filed the task in the right project but mangled the title — everything after the project's *first* word stayed in it:

| input (project `Some Project Title`) | before | after |
| --- | --- | --- |
| `+Some Project Title do the thing` | title `Project Title do the thing` | title `do the thing` |

## Cause

`SHORT_SYNTAX_PROJECT_REG_EX` deliberately does not stop at whitespace (multi-word titles have to survive), so the match candidate is the whole rest of the line. `parseProjectTracked()` then tried exactly two things: the whole candidate, and — failing that — its first word only. With task content after the project name the whole candidate never matches, and the first-word fallback consumes just `+Word1`, stranding the remaining title words. Single-word project titles worked by accident: their first word *is* the whole title.

## Fix

Match the candidate's word prefixes instead, in two tiers:

1. **fully typed title wins** — the longest word prefix that equals a project title (this is what the autocomplete inserts)
2. **otherwise a partially typed one** — a prefix that may shorten only its last word (`+Some Pro`); a single word may still be typed without whitespace at all (`+SomePro`)

Both tiers keep the existing "shortest project title wins" tiebreak, and the walk is bounded by the longest project title's word count, so a long pasted line costs no more than a short one.

The tiering matters: plain longest-prefix matching regresses overlapping project names, which a multi-agent review caught and which are now pinned by specs:

| input | projects | plain longest-prefix | this PR |
| --- | --- | --- | --- |
| `Task +Work in progress` | `Work`, `Work Inbox` | `Work Inbox` / `Task progress` | `Work` / `Task in progress` |
| `+Home work on taxes` | `Home`, `Homework` | `Homework` / `on taxes` | `Home` / `work on taxes` |

Known trade-off, spec'd: when one project's full title is a word prefix of another's, *partially* typing the longer one loses to the exact shorter one — `Task +Work Inb stuff` files under `Work`. Exact-wins is the safer direction, since the alternative silently eats task words, and the autocomplete always inserts full titles.

## Tests

Five new specs in `short-syntax.spec.ts` (written first; three failed before their respective fix):

- task content after a multi-word / partial multi-word / single-word project title
- project mid-title with content on both sides
- overlapping titles: exact match preferred, full longer title still consumed, no cross-word joining (`Home` vs `Homework`)
- tag + estimate typed after a multi-word project title

235 short-syntax specs and all 1500 `src/app/features/tasks/**` specs pass; `npm run checkFile` clean on both files. Parser-only change — no persisted model, sync, or op-log surface touched.

## Out of scope

The `charBeforePlus` guard (`short-syntax.ts:548`) looks up the space-stripped candidate inside the raw text, so it never fires when anything follows the token — `Fun title+Some Project Title` still parses as a project. Pre-existing and unchanged in kind here, but this PR makes it consume more text when it misfires. Worth a follow-up using `rr.index`, with its own spec.
