### PR TITLE
DO NOT MERGE — fix(sync): recover prefix-less remote sync files from .bak (#9627)

### DIFF
--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
@@ -2719,6 +2719,39 @@ describe('FileBasedSyncAdapterService', () => {
       expect(mockSnackService.open).toHaveBeenCalled();
     });
 
+    it('(b) recovers from .bak when the primary file has NO sync file prefix (#9627)', async () => {
+      // #9627: a Nextcloud user hit "Invalid sync file prefix" — the remote
+      // primary's first bytes are not `pf_...__`, so extractSyncFileStateFromPrefix
+      // throws BEFORE the decrypt/decompress/JSON stages the cases above cover.
+      // That makes a head-mangled primary (transport-mangled body, a foreign file
+      // at the path, an interrupted write that lost its head) the ONE corruption
+      // shape excluded from .bak recovery. Same recovery semantics as its
+      // siblings: local data is intact and the .bak is the only readable copy.
+      const backupData = createMockSyncData({
+        syncVersion: 5,
+        recentOps: [compactOp('recovered-from-missing-prefix') as never],
+      });
+      // Prefix-less body: valid JSON, but not a sync file (e.g. a backup export
+      // copied into the sync folder). Nothing downstream ever gets to parse it.
+      const unprefixedMain = JSON.stringify({ version: 2, syncVersion: 9 });
+      mockProvider.downloadFile.and.callFake((path: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE) {
+          return Promise.resolve({
+            dataStr: addPrefix(backupData),
+            rev: 'bak-rev-prefix',
+          });
+        }
+        return Promise.resolve({ dataStr: unprefixedMain, rev: 'corrupt-prefix-rev' });
+      });
+
+      const result = await adapter.downloadOps(0);
+
+      expect(result.ops.length).toBe(1);
+      expect(result.ops[0].op.id).toBe('recovered-from-missing-prefix');
+      expect(result.latestSeq).toBe(5);
+      expect(mockSnackService.open).toHaveBeenCalled();
+    });
+
     it('(b) refuses a PLAINTEXT .bak when encryption is expected (key-suppression vector)', async () => {
       // A plaintext .bak decodes via its own prefix flags even under a
       // wrong/rotated key. Accepting it would suppress the wrong-password

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
@@ -16,6 +16,7 @@ import {
   EncryptNoPasswordError,
   FileSyncTargetChangedError,
   InvalidDataSPError,
+  InvalidFilePrefixError,
   PlaintextWhenEncryptionExpectedError,
   RemoteFileNotFoundAPIError,
   SplitSyncFormatDetectedError,
@@ -2731,9 +2732,10 @@ describe('FileBasedSyncAdapterService', () => {
         syncVersion: 5,
         recentOps: [compactOp('recovered-from-missing-prefix') as never],
       });
-      // Prefix-less body: valid JSON, but not a sync file (e.g. a backup export
-      // copied into the sync folder). Nothing downstream ever gets to parse it.
-      const unprefixedMain = JSON.stringify({ version: 2, syncVersion: 9 });
+      // A TRUNCATED head — the interrupted-write shape this recovery targets. It
+      // exercises the regex's partial-match branch (`pf_` present, separator gone),
+      // which a merely prefix-less body would not.
+      const unprefixedMain = 'pf_2_' + JSON.stringify(createMockSyncData({}));
       mockProvider.downloadFile.and.callFake((path: string) => {
         if (path === FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE) {
           return Promise.resolve({
@@ -2750,6 +2752,59 @@ describe('FileBasedSyncAdapterService', () => {
       expect(result.ops[0].op.id).toBe('recovered-from-missing-prefix');
       expect(result.latestSeq).toBe(5);
       expect(mockSnackService.open).toHaveBeenCalled();
+    });
+
+    it('(b) does NOT adopt .bak when the prefix failure does not reproduce (#9627 transport guard)', async () => {
+      // The dangerous asymmetric case: the STORED primary is fine, but one
+      // RESPONSE was mangled (proxy/captive-portal page, WebDAV 207 body, JSON
+      // error envelope — `isHtmlResponse` only filters three narrow shapes). The
+      // .bak is a separate request and can succeed, so adopting it would heal an
+      // intact primary with one-generation-old data at its REAL rev, silently
+      // dropping ops another device already committed and will never re-push.
+      // The re-read gate must reject this: original error, no adoption, no snack.
+      const goodPrimary = createMockSyncData({
+        syncVersion: 9,
+        recentOps: [compactOp('op-only-in-healthy-primary') as never],
+      });
+      const backupData = createMockSyncData({
+        syncVersion: 5,
+        recentOps: [compactOp('stale-op-from-bak') as never],
+      });
+      let primaryReads = 0;
+      mockProvider.downloadFile.and.callFake((path: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE) {
+          return Promise.resolve({ dataStr: addPrefix(backupData), rev: 'bak-rev' });
+        }
+        primaryReads++;
+        // First read mangled, every later read fine.
+        return Promise.resolve(
+          primaryReads === 1
+            ? { dataStr: '<?xml version="1.0"?><d:multistatus/>', rev: 'primary-rev' }
+            : { dataStr: addPrefix(goodPrimary), rev: 'primary-rev' },
+        );
+      });
+
+      await expectAsync(adapter.downloadOps(0)).toBeRejectedWith(
+        jasmine.any(InvalidFilePrefixError),
+      );
+      expect(primaryReads).toBe(2); // the confirming re-read happened
+      expect(mockSnackService.open).not.toHaveBeenCalled();
+      expect(mockProvider.uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('(b) rethrows the ORIGINAL error when primary and .bak are both prefix-less (#9627)', async () => {
+      // The symmetric case the fix relies on being harmless: whatever destroyed
+      // the primary's head destroyed the .bak's too, so nothing is adoptable and
+      // the user sees the same error as before the fix.
+      const unprefixed = JSON.stringify({ version: 2, syncVersion: 9 });
+      mockProvider.downloadFile.and.returnValue(
+        Promise.resolve({ dataStr: unprefixed, rev: 'corrupt-rev' }),
+      );
+
+      await expectAsync(adapter.downloadOps(0)).toBeRejectedWith(
+        jasmine.any(InvalidFilePrefixError),
+      );
+      expect(mockSnackService.open).not.toHaveBeenCalled();
     });
 
     it('(b) refuses a PLAINTEXT .bak when encryption is expected (key-suppression vector)', async () => {
@@ -4352,6 +4407,29 @@ describe('FileBasedSyncAdapterService', () => {
       await adapter.uploadOps([createMockSyncOp()], 'client1');
       expect(opsRevToMatch).toContain('corrupt-ops-rev');
       expect(opsRevToMatch).not.toContain('ops-bak-rev');
+    });
+
+    it('(i) recovers a prefix-less sync-ops.json from .bak (#9627, split call site)', async () => {
+      // Claim 4 of the fix — both `_isRecoverableCorruption` call sites benefit —
+      // was code-reading only. This exercises the split-format one, including its
+      // own re-read gate (the primary stays prefix-less on the confirming read).
+      const bakOps = makeOpsFile({
+        syncVersion: 4,
+        recentOps: [makeCompactOp({ id: 'op-from-bak-prefixless' })],
+      });
+      const unprefixed = JSON.stringify({ version: 3, syncVersion: 9 });
+      mockProvider.downloadFile.and.callFake(async (path: string) => {
+        if (path === C.OPS_FILE) return { dataStr: unprefixed, rev: 'corrupt-ops-rev' };
+        if (path === C.OPS_BACKUP_FILE) {
+          return { dataStr: addPrefix(bakOps, 3), rev: 'ops-bak-rev' };
+        }
+        throw new RemoteFileNotFoundAPIError(path);
+      });
+
+      const result = await adapter.downloadOps(1, 'client2');
+
+      expect(result.ops.some((o) => o.op.id === 'op-from-bak-prefixless')).toBe(true);
+      expect(mockSnackService.open).toHaveBeenCalled();
     });
 
     it('(i) split .bak recovery never promotes the corrupt ops rev to last-seen (heal cannot wedge)', async () => {

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -1115,7 +1115,17 @@ export class FileBasedSyncAdapterService {
           latestSeq: 0,
         };
       }
-      if (this._isRecoverableCorruption(e)) {
+      if (
+        this._isRecoverableCorruption(e) &&
+        // #9627: prove a prefix failure belongs to the stored file, not to one
+        // response, before letting .bak overwrite a possibly-intact primary.
+        (!(e instanceof InvalidFilePrefixError) ||
+          (await this._isPrefixFailurePersistent(
+            provider,
+            FILE_BASED_SYNC_CONSTANTS.SYNC_FILE,
+            (e as { primaryRev?: string }).primaryRev,
+          )))
+      ) {
         // Primary sync-data.json is corrupt/empty/unparseable (e.g. interrupted
         // write). Try to recover from the .bak artifact before failing.
         const recovered = await this._readBakFile<FileBasedSyncData>(
@@ -2626,7 +2636,16 @@ export class FileBasedSyncAdapterService {
         // (migration WRITES happen on the upload path).
         return this._tryLegacyReadOnlyDownload(provider, cfg, encryptKey, sinceSeq);
       }
-      if (this._isRecoverableCorruption(e)) {
+      if (
+        this._isRecoverableCorruption(e) &&
+        // #9627: same persistence gate as the single-file path.
+        (!(e instanceof InvalidFilePrefixError) ||
+          (await this._isPrefixFailurePersistent(
+            provider,
+            FILE_BASED_SYNC_CONSTANTS.OPS_FILE,
+            (e as { primaryRev?: string }).primaryRev,
+          )))
+      ) {
         // Corrupt/torn sync-ops.json (the hot file, rewritten every op-bearing
         // sync): recover from .bak — same SPAP-8 semantics as the single-file
         // path, including seeding the heal cache with the CORRUPT primary's rev
@@ -3190,11 +3209,59 @@ export class FileBasedSyncAdapterService {
       // #9627: the prefix is parsed FIRST, so a primary whose head is mangled
       // (or that is not a sync file at all) throws here and never reaches the
       // stages above — leaving the most basic corruption shape as the only one
-      // without .bak recovery. Inert when the cause is transport-side rather
-      // than a bad remote file: the .bak download is mangled the same way, so
-      // _readBakFile returns null and the original error still surfaces.
+      // without .bak recovery.
+      //
+      // UNLIKE every other member of this list, this one can fire on a body we
+      // never wrote: the others all prove the object at the path IS a sync file
+      // that failed to decode, this one proves it is NOT — which is also what a
+      // bad RESPONSE looks like (a proxy/captive-portal page, a WebDAV 207 body,
+      // a JSON error envelope; note `isHtmlResponse` only filters three narrow
+      // shapes). The .bak is a SEPARATE request that can succeed while the
+      // primary's response is mangled, and adopting it then heals an intact
+      // primary with one-generation-old data — silently dropping ops another
+      // device already committed and will never re-push.
+      //
+      // So this class alone is gated on `_isPrefixFailurePersistent()`, which
+      // re-reads the primary to prove the failure belongs to the STORED file
+      // rather than to one response. Do not enroll a future error class here
+      // without asking which of the two it proves.
       e instanceof InvalidFilePrefixError
     );
+  }
+
+  /**
+   * Confirms an `InvalidFilePrefixError` is a property of the stored file, not of
+   * a single response, by re-reading the primary once.
+   *
+   * Costs one extra GET on an already-failing path, and buys the distinction that
+   * makes `.bak` adoption safe for this error class: a transient/mangled response
+   * will not reproduce, a genuinely bad file will. Any other outcome (network
+   * error, 404, a body that now parses, or a rev that moved) is treated as NOT
+   * persistent — recovery is skipped and the original error surfaces, exactly as
+   * before #9627.
+   *
+   * This is a heuristic, not a proof: a DETERMINISTIC mangler (a captive portal, a
+   * proxy that always rewrites, a size-keyed transfer bug) reproduces on the second
+   * read and still reaches `.bak`. It buys "not a one-off response", which is the
+   * distinction the cheap round-trip can actually make.
+   */
+  private async _isPrefixFailurePersistent(
+    provider: GuardedFileSyncProvider,
+    path: string,
+    primaryRev: string | undefined,
+  ): Promise<boolean> {
+    try {
+      const retry = await provider.downloadFile(path);
+      // A moved rev means another client rewrote the file mid-cycle, so everything
+      // concluded from the first read is stale. Re-read next cycle rather than
+      // recovering against a remote that is no longer the one we failed on.
+      if (primaryRev !== undefined && retry.rev !== primaryRev) return false;
+      extractSyncFileStateFromPrefix(retry.dataStr);
+      // Second read has a valid prefix → the first response was the problem.
+      return false;
+    } catch (e) {
+      return e instanceof InvalidFilePrefixError;
+    }
   }
 
   /**

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -36,6 +36,7 @@ import {
   DecryptError,
   FileSyncTargetChangedError,
   InvalidDataSPError,
+  InvalidFilePrefixError,
   JsonParseError,
   LegacySyncFormatDetectedError,
   PlaintextWhenEncryptionExpectedError,
@@ -3185,7 +3186,14 @@ export class FileBasedSyncAdapterService {
       // clients. Mixed-fleet caveat: a pre-fix client's snapshot still leaves a
       // stale-key .bak behind until its first op-bearing sync refreshes it.
       e instanceof DecryptError ||
-      e instanceof DecompressError
+      e instanceof DecompressError ||
+      // #9627: the prefix is parsed FIRST, so a primary whose head is mangled
+      // (or that is not a sync file at all) throws here and never reaches the
+      // stages above — leaving the most basic corruption shape as the only one
+      // without .bak recovery. Inert when the cause is transport-side rather
+      // than a bad remote file: the .bak download is mangled the same way, so
+      // _readBakFile returns null and the original error still surfaces.
+      e instanceof InvalidFilePrefixError
     );
   }
 

--- a/src/app/op-log/testing/integration/file-based-sync/edge-cases.integration.spec.ts
+++ b/src/app/op-log/testing/integration/file-based-sync/edge-cases.integration.spec.ts
@@ -85,6 +85,68 @@ describe('File-Based Sync Integration - Edge Cases', () => {
     });
   });
 
+  describe('Corrupt-primary recovery (#9627)', () => {
+    /**
+     * The cross-client data-loss shape the unit tests can only approximate: the
+     * STORED primary is healthy, but ONE response for it is mangled (a proxy or
+     * captive-portal page, a WebDAV 207 body, a JSON error envelope — the WebDAV
+     * layer's `isHtmlResponse` only filters three narrow shapes). The `.bak` is a
+     * SEPARATE request and reads fine, one generation behind.
+     *
+     * Adopting it would heal the intact primary at its real rev and drop the ops
+     * committed since the last backup — from a device that already considers them
+     * synced and will never re-push. The re-read gate must refuse.
+     */
+    it("does not lose another client's ops when ONE primary response is mangled", async () => {
+      const clientA = harness.createClient('client-a');
+      const clientB = harness.createClient('client-b');
+      const provider = harness.getProvider();
+
+      // Two separate uploads, so .bak lags the primary by exactly one generation:
+      // primary holds task-1 + task-2, .bak holds only task-1.
+      await clientA.uploadOps([
+        clientA.createOp('Task', 'task-1', 'CRT', 'TaskActionTypes.ADD_TASK', {
+          title: 'first',
+        }),
+      ]);
+      await clientA.uploadOps([
+        clientA.createOp('Task', 'task-2', 'CRT', 'TaskActionTypes.ADD_TASK', {
+          title: 'second',
+        }),
+      ]);
+
+      const healthyPrimary = provider.getFileContent(FILE_BASED_SYNC_CONSTANTS.SYNC_FILE);
+      expect(healthyPrimary!.data).toContain('task-2');
+      const bak = provider.getFileContent(FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE);
+      expect(bak!.data).not.toContain('task-2'); // .bak really is one behind
+
+      // Mangle only the FIRST read of the primary, and only for this client.
+      const realDownload = provider.downloadFile.bind(provider);
+      let primaryReads = 0;
+      spyOn(provider, 'downloadFile').and.callFake(async (path: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE && ++primaryReads === 1) {
+          return { dataStr: '<?xml version="1.0"?><d:error/>', rev: healthyPrimary!.rev };
+        }
+        return realDownload(path);
+      });
+
+      // The cycle must fail rather than silently recover from the stale .bak.
+      await expectAsync(clientB.downloadOps(0)).toBeRejected();
+      expect(primaryReads).toBe(2); // the confirming re-read happened
+
+      // The remote primary was never rewritten: same rev, still holds task-2.
+      const afterFailure = provider.getFileContent(FILE_BASED_SYNC_CONSTANTS.SYNC_FILE);
+      expect(afterFailure!.rev).toBe(healthyPrimary!.rev);
+      expect(afterFailure!.data).toContain('task-2');
+
+      // And the next cycle converges normally — A's ops both survive.
+      const recovered = await clientB.downloadOps(0);
+      const entityIds = recovered.ops.map((o) => o.op.entityId);
+      expect(entityIds).toContain('task-1');
+      expect(entityIds).toContain('task-2');
+    });
+  });
+
   describe('Provider Error Handling', () => {
     it('should propagate provider download errors', async () => {
       const clientA = harness.createClient('client-a');


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE — parked pending diagnostics on #9627.**
> The code is reviewed, tested and ready. What is missing is the *justification* for
> shipping it. See "Merge criteria" below.

## What this does

`InvalidFilePrefixError` was the one corruption shape with **no recovery path**.
`decompressAndDecrypt()` parses the `pf_[C][E]<v>__` prefix *first*, so a remote file
with a mangled head never reaches the decrypt / decompress / `JSON.parse` stages —
and `_isRecoverableCorruption()` listed all five of those later errors but not this
one. Result: the most basic corruption shape skipped `.bak` recovery entirely and
dead-ended as an unhandled error (the symptom in #9627).

Two commits:

1. `e396702` — enroll `InvalidFilePrefixError` in `_isRecoverableCorruption()`.
2. `66e92aa` — gate it, because (1) alone opens a data-loss window.

## Why (2) exists

Multi-agent review found commit (1)'s safety argument **false**. I had claimed the
change was inert against transport-side failures because a mangled transport would
mangle `sync-data.json.bak` identically. Primary and `.bak` are **separate GETs**;
no such invariant exists.

`InvalidFilePrefixError` is the only member of that allow-list that can fire on a
body **we never wrote**. The other five prove the object at the path *is* a sync file
that failed to decode; this one proves it is *not* — which is also exactly what a bad
*response* looks like (proxy page, captive portal, WebDAV 207 body, JSON error
envelope). Adopting `.bak` then heals an **intact** primary with one-generation-old
data, silently dropping ops another device committed and will never re-push.

So this class alone is gated on `_isPrefixFailurePersistent()`: re-read the primary
once, and recover only if the failure belongs to the *stored file* — same rev, still
no valid prefix. **A heuristic, not a proof.**

## Provider audit

The gap is provider-wide, which is why the guard sits in the adapter rather than in
any one provider:

| Provider | non-2xx | empty body | mangled 200 body |
| --- | --- | --- | --- |
| WebDAV | throws | throws `EmptyRemoteBodySPError` | only `isHtmlResponse`'s 3 patterns |
| Dropbox | throws | throws | **no filter** |
| OneDrive | throws | **no check** | **no filter** |
| LocalFile | n/a | throws | **no filter** |

## Tests

All mutation-verified — each fails under targeted mutation of the code it pins:

- transport-asymmetry rejection (primary mangled once, `.bak` intact → reject, don't adopt)
- both-mangled fallthrough (rethrow the original error)
- split call site (`sync-ops.json`)
- **two-client integration test**: client A's committed ops survive a mangled primary
  response on client B (`edge-cases.integration.spec.ts`)

Unit spec 144/144, integration spec 20/20.

## Reporter evidence (2026-08-21)

The reporter answered. First 40 bytes of their `sync-data.json`, on **iOS with sync
encryption on**:

```
41J7VJwUqK/0k436aSIRL5utdxhyV6WhXWSguANW
```

That is base64 — the *encrypted payload is intact*, but the `pf_E2__` header that
belongs in front of it is gone. This confirms the corruption shape this PR targets
exists in the wild on a real user's remote.

### The write path is exonerated

Stronger than "the app cannot produce it" by enumeration: every WebDAV upload ends in
`_verifyUpload()` (`webdav-api.ts:365`) — re-GET the file, hash the stored body, compare
against what was sent. Shipped in **v18.2.6** (`e571cc2433`, #7300), so it was live in
the reporter's 18.19.0. Any head-strip on the way *up* — mangled request body, partial
PUT, rewriting proxy — makes that hash mismatch and throws `RemoteFileChangedUnexpectedly`
at upload time. It cannot leave a prefix-less file behind silently.

With `compressAndEncrypt()` as the only writer (unconditional `prefix + dataStr`, no
chunked uploads, no site writing raw ciphertext), that closes it: **the body was not
produced by a successful app write.** It was mutated after a verified write, or written
by something that is not this app.

### The `.bak` evidence is gone — destroyed by our own remediation advice

The reporter ran force upload at 17:09 UTC and reported the primary now starts with
`pf_`. Force upload routes to `_uploadSnapshot()` → `_forceUploadWithBakFirst()`
(`file-based-sync-adapter.service.ts:1482`), which writes `sync-data.json.bak` **first**,
by design (a rotated-key `.bak` must not survive a snapshot). So the live `.bak` now
holds a fresh, prefixed payload.

Asking about the live `.bak` would return `pf_…` regardless of what it held during the
failure — worse than no answer, because it reads as confirming evidence and is not. The
original merge criterion 1 is unattainable as written.

## Why this is still parked

- **Residual window not closed.** A *deterministic* mangler reproduces on the re-read
  and passes the gate. The dangerous shape is: primary body deterministically mangled
  while the `.bak` body arrives intact and headers pass through unmangled so the rev
  matches. Narrow — it needs content-dependent mangling — but the reporter's case is
  head-stripping of unknown origin, so it is not yet excluded.
- **The corruption *shape* is still unconfirmed.** A 40-char sample cannot distinguish a
  7-byte head-strip (`pf_E2__`) from a file that lost its first N kilobytes. If it is a
  fragment, this PR is the right fix for the wrong shape and the fragment source stays
  open. Byte size settles it; see criterion 1 below.
- **Asymmetric cost.** Waiting costs one already-unblocked user a few days. Merging blind
  risks silent cross-device op loss for every file-based sync user, auto-shipped to real
  devices from `master` within minutes — and silent loss is structurally
  under-reported, so we would likely not hear about it.

## Merge criteria

Merge when **either** holds:

1. The reporter answers from Nextcloud **file version history** (the live files no longer
   carry the evidence):
   - `sync-data.json.bak`, the version from **before** 2026-08-21 ~17:10 UTC — `pf_` or
     base64? Intact `.bak` proves the heal works end-to-end on real data; prefix-less
     `.bak` proves the change is inert for them, and the enrollment gap is still worth
     closing on its own merits.
   - `sync-data.json`, **byte size** of the corrupt version vs. the one before it. ~7
     bytes smaller ⇒ head-strip, the shape this PR targets. Much smaller ⇒ a fragment,
     which is a different bug and this PR does not address it.
2. ~2 weeks pass with no further response. The gap is real independent of this report,
   and the guard is tested.

Merge **both commits or neither** — commit (1) alone is strictly worse than the pair.

## Follow-up hardening (not in this PR)

`_isPrefixFailurePersistent()` currently accepts "both reads failed prefix parse". Comparing
the two bodies byte-for-byte is free and strictly stronger — it additionally rejects *two
different* garbage responses (rotating captive portal, load-balanced error pages), which
the current gate accepts. It does not beat a deterministic mangler; that stays the
acknowledged residual.

Worth considering separately: for this error class only, surfacing a choice instead of
silently adopting `.bak`. Precedent is already in the file — `AUTO_MERGE_CONCURRENT_SNAPSHOT:
false` is defaulted off on exactly the argument that a user-recoverable dialog beats
undetectable data loss. Silent heal-from-`.bak` is safe for the five errors that prove the
file *is* ours; for the one that proves it is not, a prompt matches the existing risk posture.

## Deliberately not included

A `sync-wrapper.service.ts` snack branch for `InvalidFilePrefixError` (siblings
`JsonParseError` and `EmptyRemoteBodySPError` have one; this falls through to the
generic snack). The reporter's case argues the *message* matters more than the button:
if a server-side transformation is stripping the header, force-upload just recreates
the broken state. Worth doing once the cause is known.

## Separate, unfixed

`SuperSyncBackgroundProvider.kt:121` sets `Accept-Encoding: gzip` explicitly, which
disables OkHttp's transparent gunzip, so `resp.body?.string()` yields raw gzip bytes and
`JSONObject(body)` throws into the blanket catch at :135 — a silent no-op. Unrelated to
this PR; needs its own issue.

Refs #9627

