### PR TITLE
fix(android): request notification permission on timer starts, stop opening exact-alarm settings at startup (#9648)

### DIFF
--- a/src/app/core/platform/capacitor-reminder.service.spec.ts
+++ b/src/app/core/platform/capacitor-reminder.service.spec.ts
@@ -185,6 +185,110 @@ describe('CapacitorReminderService', () => {
     });
   });
 
+  describe('requestPermissionsInBackground (#9648)', () => {
+    it('does nothing when notifications are unavailable', () => {
+      service.requestPermissionsInBackground();
+      expect(notificationServiceSpy.ensurePermissions).not.toHaveBeenCalled();
+    });
+
+    describe('on a native (non-legacy) platform', () => {
+      let nativeService: CapacitorReminderService;
+
+      beforeEach(() => {
+        const nativePlatformSpy = jasmine.createSpyObj(
+          'CapacitorPlatformService',
+          ['hasCapability', 'isIOS', 'isAndroid'],
+          {
+            platform: 'android',
+            isNative: true,
+            isMobile: true,
+            capabilities: { scheduledNotifications: true },
+          },
+        );
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+          providers: [
+            CapacitorReminderService,
+            provideMockStore(),
+            { provide: CapacitorPlatformService, useValue: nativePlatformSpy },
+            { provide: CapacitorNotificationService, useValue: notificationServiceSpy },
+            { provide: IS_ANDROID_WEB_VIEW_TOKEN, useValue: false },
+          ],
+        });
+        nativeService = TestBed.inject(CapacitorReminderService);
+      });
+
+      it('requests the permission when it has not been granted yet', async () => {
+        notificationServiceSpy.getPermissionState.and.returnValue(
+          Promise.resolve('prompt'),
+        );
+
+        await nativeService.requestPermissionsInBackground();
+
+        expect(notificationServiceSpy.ensurePermissions).toHaveBeenCalledTimes(1);
+      });
+
+      it('resolves true when the permission was newly granted, so the caller re-posts', async () => {
+        notificationServiceSpy.getPermissionState.and.returnValue(
+          Promise.resolve('prompt'),
+        );
+        notificationServiceSpy.ensurePermissions.and.returnValue(Promise.resolve(true));
+
+        await expectAsync(nativeService.requestPermissionsInBackground()).toBeResolvedTo(
+          true,
+        );
+      });
+
+      it('resolves false when already granted — nothing was suppressed, so no re-post', async () => {
+        notificationServiceSpy.getPermissionState.and.returnValue(
+          Promise.resolve('granted'),
+        );
+
+        await expectAsync(nativeService.requestPermissionsInBackground()).toBeResolvedTo(
+          false,
+        );
+        expect(notificationServiceSpy.ensurePermissions).not.toHaveBeenCalled();
+      });
+
+      it('resolves false when the user denies, so the caller does not re-post', async () => {
+        notificationServiceSpy.getPermissionState.and.returnValue(
+          Promise.resolve('prompt'),
+        );
+        notificationServiceSpy.ensurePermissions.and.returnValue(Promise.resolve(false));
+
+        await expectAsync(nativeService.requestPermissionsInBackground()).toBeResolvedTo(
+          false,
+        );
+      });
+
+      it('asks at most once per session so back-to-back service starts cannot stack dialogs', async () => {
+        notificationServiceSpy.getPermissionState.and.returnValue(
+          Promise.resolve('prompt'),
+        );
+
+        await Promise.all([
+          nativeService.requestPermissionsInBackground(),
+          nativeService.requestPermissionsInBackground(),
+          nativeService.requestPermissionsInBackground(),
+        ]);
+
+        expect(notificationServiceSpy.ensurePermissions).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not re-prompt for the rest of the session after a denial', async () => {
+        notificationServiceSpy.getPermissionState.and.returnValue(
+          Promise.resolve('prompt'),
+        );
+        notificationServiceSpy.ensurePermissions.and.returnValue(Promise.resolve(false));
+
+        await nativeService.requestPermissionsInBackground();
+        await nativeService.requestPermissionsInBackground();
+
+        expect(notificationServiceSpy.ensurePermissions).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
   describe('getPermissionState', () => {
     it("should return 'denied' when not available, without prompting", async () => {
       const result = await service.getPermissionState();
@@ -233,6 +337,17 @@ describe('CapacitorReminderService', () => {
         ],
       });
       legacyService = TestBed.inject(CapacitorReminderService);
+    });
+
+    it('requestPermissionsInBackground short-circuits without consulting Capacitor', async () => {
+      // isAvailable is TRUE on the legacy shell (platform resolves to 'android'),
+      // so the #7408 guards are the only thing keeping us off the broken Web
+      // Notifications fallback here.
+      await expectAsync(legacyService.requestPermissionsInBackground()).toBeResolvedTo(
+        false,
+      );
+      expect(notificationServiceSpy.ensurePermissions).not.toHaveBeenCalled();
+      expect(notificationServiceSpy.getPermissionState).not.toHaveBeenCalled();
     });
 
     it('ensurePermissions short-circuits without consulting Capacitor', async () => {

--- a/src/app/core/platform/capacitor-reminder.service.ts
+++ b/src/app/core/platform/capacitor-reminder.service.ts
@@ -59,6 +59,8 @@ export class CapacitorReminderService {
   // Injected (vs reading IS_ANDROID_WEB_VIEW directly) so tests can override
   // it via DI — matches the pattern in `task-reminder.effects.ts`.
   private _isAndroidWebView = inject(IS_ANDROID_WEB_VIEW_TOKEN);
+  // See requestPermissionsInBackground().
+  private _backgroundPermissionRequest?: Promise<boolean>;
 
   /**
    * Observable that emits when a notification action is performed (iOS).
@@ -309,6 +311,64 @@ export class CapacitorReminderService {
     }
 
     return this._notificationService.getPermissionState();
+  }
+
+  /**
+   * Ask for notification permission at most once per session WITHOUT making the
+   * caller wait for the OS dialog.
+   *
+   * For callers that are about to produce a notification but cannot await a
+   * dialog — the Android foreground-service starts (time tracking, focus mode)
+   * run inside synchronous effect taps. Nothing on those paths requested
+   * POST_NOTIFICATIONS, so on Android 13+ their notifications were silently
+   * suppressed and the app looked broken. See #9648.
+   *
+   * Other paths that CAN prompt (none of which a fresh user necessarily hits
+   * before their first timer): reminder scheduling in
+   * `MobileNotificationEffects`, and `NotifyService.notify()` →
+   * `CapacitorNotificationService.schedule()`, used by the estimate-exceeded
+   * notification and the tracking reminder.
+   *
+   * Consistent with the lazy-prompt design (#8120): starting a timer IS a
+   * contextual first use, not an unprompted launch-time dialog. Callers must
+   * keep it that way — only wire this to genuinely user-initiated starts, never
+   * to a cold-start/recovery path.
+   *
+   * Because the request is not awaited, the notification for the session that
+   * triggered it can stay hidden until the service next re-posts (focus mode
+   * within ~5s of elapsed time; tracking only on a >5s jump or task switch,
+   * since it renders via a chronometer — #8243). Later sessions are unaffected.
+   */
+  requestPermissionsInBackground(): Promise<boolean> {
+    if (!this.isAvailable) {
+      return Promise.resolve(false);
+    }
+
+    // Session-scoped: tracking and focus mode can start back-to-back, and a
+    // denial must not re-prompt for the rest of the session.
+    this._backgroundPermissionRequest ??= this._requestAndDetectGrant();
+    return this._backgroundPermissionRequest;
+  }
+
+  /**
+   * Resolves true ONLY when the permission went from not-granted to granted —
+   * i.e. the caller's notification was suppressed and needs re-posting.
+   *
+   * Already-granted resolves false: nothing was suppressed, so re-posting would
+   * be pointless work (and on Android re-anchors the tracking counter). The
+   * `getPermissionState()` probe carries the #7408 legacy-WebView guard, so the
+   * legacy shell reports 'granted' and never reaches the Capacitor call.
+   */
+  private async _requestAndDetectGrant(): Promise<boolean> {
+    try {
+      if ((await this.getPermissionState()) === 'granted') {
+        return false;
+      }
+      return await this.ensurePermissions();
+    } catch (error) {
+      Log.warn('CapacitorReminderService: background permission request failed', error);
+      return false;
+    }
   }
 
   /**

--- a/src/app/core/platform/capacitor-reminder.service.ts
+++ b/src/app/core/platform/capacitor-reminder.service.ts
@@ -334,10 +334,13 @@ export class CapacitorReminderService {
    * keep it that way — only wire this to genuinely user-initiated starts, never
    * to a cold-start/recovery path.
    *
-   * Because the request is not awaited, the notification for the session that
-   * triggered it can stay hidden until the service next re-posts (focus mode
-   * within ~5s of elapsed time; tracking only on a >5s jump or task switch,
-   * since it renders via a chronometer — #8243). Later sessions are unaffected.
+   * Because the request is not awaited, the caller's startForeground() runs
+   * while the permission is still denied, so Android drops that notification —
+   * and both foreground services render steady-state time via a native
+   * chronometer with NO per-tick update pushes (#8243), so nothing re-posts it
+   * organically. Callers must therefore re-post their own notification when
+   * this resolves true (see the _repost*AfterGrant methods in the Android
+   * effects). Later sessions are unaffected.
    */
   requestPermissionsInBackground(): Promise<boolean> {
     if (!this.isAvailable) {

--- a/src/app/features/android/store/android-focus-mode.effects.ts
+++ b/src/app/features/android/store/android-focus-mode.effects.ts
@@ -18,7 +18,7 @@ import {
   selectCurrentTaskId,
   selectIsTaskDataLoaded,
 } from '../../tasks/store/task.selectors';
-import { combineLatest, Observable } from 'rxjs';
+import { combineLatest, firstValueFrom, Observable } from 'rxjs';
 import { FocusModeMode, TimerState } from '../../focus-mode/focus-mode.model';
 import { DroidLog } from '../../../core/log';
 import { HydrationStateService } from '../../../op-log/apply/hydration-state.service';
@@ -203,6 +203,9 @@ export class AndroidFocusModeEffects {
    * `recoverFocusSession$`), and prompting there would put an OS dialog on the
    * launch path — the unprompted launch-time prompt #8120 removed. Only
    * `startFocusSession` is genuinely user-initiated. See #9648.
+   *
+   * Not awaited — see the re-post rationale on
+   * `_repostFocusNotificationAfterGrant()`.
    */
   requestNotificationPermissionOnFocusStart$ =
     IS_ANDROID_WEB_VIEW &&
@@ -210,7 +213,15 @@ export class AndroidFocusModeEffects {
       () =>
         this._actions$.pipe(
           ofType(focusModeActions.startFocusSession),
-          tap(() => this._reminderService.requestPermissionsInBackground()),
+          tap(() => {
+            void this._reminderService
+              .requestPermissionsInBackground()
+              .then((isNewlyGranted) => {
+                if (isNewlyGranted) {
+                  void this._repostFocusNotificationAfterGrant();
+                }
+              });
+          }),
         ),
       { dispatch: false },
     );
@@ -491,6 +502,59 @@ export class AndroidFocusModeEffects {
     }
     const tick = this._globalTrackingInterval.triggerWakeUpTick();
     return timer.elapsed + tick.duration;
+  }
+
+  /**
+   * Re-post the focus notification after a late POST_NOTIFICATIONS grant.
+   *
+   * `startForeground()` already ran while the permission was denied, so Android
+   * dropped that notification and does not replay it. The notification renders
+   * its countdown via a native chronometer, so steady-state elapsed changes
+   * push NO updates at all (`hasFocusNotificationStateChanged` suppresses
+   * consecutive ~1s ticks entirely, #8243) — without this re-post, the
+   * first-ever focus session would stay notification-less until a pause, break
+   * transition, task switch, or resume-tick jump. Mirrors
+   * `_repostTrackingNotificationAfterGrant` in
+   * android-foreground-tracking.effects.ts (#9648).
+   *
+   * Reads the CURRENT timer state rather than values captured at start: the
+   * native service re-anchors its countdown to the pushed remainingMs, so a
+   * stale value would rewind it by the dialog duration. If the session ended
+   * while the dialog was open, purpose is null (skip below) — and the native
+   * side additionally ignores ACTION_UPDATE when the service is not running.
+   */
+  private async _repostFocusNotificationAfterGrant(): Promise<void> {
+    const [timer, mode, currentTask, isBreakActive, isLongBreak, timeRemaining] =
+      await firstValueFrom(
+        combineLatest([
+          this._store.select(selectTimer),
+          this._store.select(selectMode),
+          this._store.select(selectCurrentTask),
+          this._store.select(selectIsBreakActive),
+          this._store.select(selectIsLongBreak),
+          this._store.select(selectTimeRemaining),
+        ]),
+      );
+    if (timer.purpose === null) {
+      return;
+    }
+    const title = this._getNotificationTitle(mode, isBreakActive, isLongBreak);
+    const remainingMs = timer.duration > 0 ? timeRemaining : timer.elapsed; // Flowtime shows elapsed
+    DroidLog.log('AndroidFocusModeEffects: Re-posting notification after grant', {
+      title,
+      remaining: remainingMs,
+    });
+    this._safeNativeCall(
+      () =>
+        androidInterface.updateFocusModeService?.(
+          title,
+          remainingMs,
+          !timer.isRunning,
+          isBreakActive,
+          currentTask?.title || null,
+        ),
+      'Failed to re-post focus notification after permission grant',
+    );
   }
 
   private _safeNativeCall(fn: () => void, errorMsg: string, showSnackbar = false): void {

--- a/src/app/features/android/store/android-focus-mode.effects.ts
+++ b/src/app/features/android/store/android-focus-mode.effects.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { createEffect } from '@ngrx/effects';
+import { createEffect, ofType } from '@ngrx/effects';
 import { Action, Store } from '@ngrx/store';
 import { filter, map, pairwise, startWith, tap, withLatestFrom } from 'rxjs/operators';
 import { IS_ANDROID_WEB_VIEW } from '../../../util/is-android-web-view';
@@ -25,6 +25,8 @@ import { HydrationStateService } from '../../../op-log/apply/hydration-state.ser
 import { SnackService } from '../../../core/snack/snack.service';
 import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
 import { Task } from '../../tasks/task.model';
+import { CapacitorReminderService } from '../../../core/platform/capacitor-reminder.service';
+import { LOCAL_ACTIONS } from '../../../util/local-actions.token';
 
 type FocusNotificationTask = Pick<Task, 'id' | 'title'> | null | undefined;
 
@@ -190,6 +192,28 @@ export class AndroidFocusModeEffects {
   private _hydrationState = inject(HydrationStateService);
   private _snackService = inject(SnackService);
   private _globalTrackingInterval = inject(GlobalTrackingIntervalService);
+  private _reminderService = inject(CapacitorReminderService);
+  private _actions$ = inject(LOCAL_ACTIONS);
+
+  /**
+   * Ask for notification permission when the user STARTS a focus session.
+   *
+   * Action-based on purpose: `syncFocusModeToNotification$` also reaches its
+   * start branch via `restoreFocusSessionFromNative` on cold start (see
+   * `recoverFocusSession$`), and prompting there would put an OS dialog on the
+   * launch path — the unprompted launch-time prompt #8120 removed. Only
+   * `startFocusSession` is genuinely user-initiated. See #9648.
+   */
+  requestNotificationPermissionOnFocusStart$ =
+    IS_ANDROID_WEB_VIEW &&
+    createEffect(
+      () =>
+        this._actions$.pipe(
+          ofType(focusModeActions.startFocusSession),
+          tap(() => this._reminderService.requestPermissionsInBackground()),
+        ),
+      { dispatch: false },
+    );
 
   // Start/stop focus mode notification when timer state changes
   syncFocusModeToNotification$ =

--- a/src/app/features/android/store/android-foreground-tracking.effects.ts
+++ b/src/app/features/android/store/android-foreground-tracking.effects.ts
@@ -27,6 +27,7 @@ import { HydrationStateService } from '../../../op-log/apply/hydration-state.ser
 import { SnackService } from '../../../core/snack/snack.service';
 import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
 import { OperationWriteFlushService } from '../../../op-log/sync/operation-write-flush.service';
+import { CapacitorReminderService } from '../../../core/platform/capacitor-reminder.service';
 
 export type NativeTrackingData = {
   taskId: string;
@@ -174,6 +175,7 @@ export class AndroidForegroundTrackingEffects {
   private _taskService = inject(TaskService);
   private _hydrationState = inject(HydrationStateService);
   private _snackService = inject(SnackService);
+  private _reminderService = inject(CapacitorReminderService);
   private _globalTrackingIntervalService = inject(GlobalTrackingIntervalService);
   private _operationWriteFlush = inject(OperationWriteFlushService);
 
@@ -271,6 +273,20 @@ export class AndroidForegroundTrackingEffects {
                 taskId: currentTask.id,
                 timeSpent: currentTask.timeSpent,
               });
+              // The tracking notification is the user's first contact with
+              // notifications on many fresh installs; without this nothing ever
+              // requests POST_NOTIFICATIONS here and the notification is
+              // silently suppressed (#9648). Not awaited — this tap is
+              // synchronous and must not stall the service start — so the
+              // notification posted below is lost when the grant arrives late,
+              // and we re-post on grant.
+              void this._reminderService
+                .requestPermissionsInBackground()
+                .then((isNewlyGranted) => {
+                  if (isNewlyGranted) {
+                    void this._repostTrackingNotificationAfterGrant();
+                  }
+                });
               this._safeNativeCall(
                 () =>
                   androidInterface.startTrackingService?.(
@@ -496,6 +512,34 @@ export class AndroidForegroundTrackingEffects {
         ),
       { dispatch: false },
     );
+
+  /**
+   * Re-post the tracking notification after a late POST_NOTIFICATIONS grant.
+   *
+   * `startForeground()` already ran while the permission was denied, so Android
+   * dropped that notification and does not replay it. Only ACTION_UPDATE
+   * re-posts (TrackingForegroundService.updateNotification), and the regular
+   * update path suppresses deltas under 5s (isTimeSpentJumpForNotification), so
+   * a quick tap on Allow would otherwise leave the notification missing for the
+   * whole session. Verified on an API 34 emulator (#9648).
+   *
+   * Reads the CURRENT timeSpent rather than the value captured at start:
+   * updateTimeSpent() re-anchors startTimestamp/accumulatedMs, so pushing the
+   * stale start value would rewind the native counter by the dialog duration.
+   */
+  private async _repostTrackingNotificationAfterGrant(): Promise<void> {
+    const currentTask = await firstValueFrom(this._store.select(selectCurrentTask));
+    if (!currentTask) {
+      return;
+    }
+    DroidLog.log('Re-posting tracking notification after permission grant', {
+      taskId: currentTask.id,
+    });
+    this._safeNativeCall(
+      () => androidInterface.updateTrackingService?.(currentTask.timeSpent || 0),
+      'Failed to re-post tracking notification after permission grant',
+    );
+  }
 
   private _safeNativeCall(fn: () => void, errorMsg: string, showSnackbar = false): void {
     try {

--- a/src/app/features/mobile/store/mobile-notification.effects.spec.ts
+++ b/src/app/features/mobile/store/mobile-notification.effects.spec.ts
@@ -184,22 +184,25 @@ describe('MobileNotificationEffects', () => {
       expect(reminderServiceSpy.ensureExactAlarmPermission).not.toHaveBeenCalled();
     }));
 
-    it('checks exact alarm permission when notifications are granted', fakeAsync(() => {
+    it('never checks exact alarms at startup, even when notifications are granted', fakeAsync(() => {
+      // ensureExactAlarmPermission() opens Android's "Alarms & reminders"
+      // settings page. At startup there is nothing scheduled, so sending the
+      // user there is pure noise — the scheduling effects own that check (#9648).
       setup('android');
       reminderServiceSpy.getPermissionState.and.resolveTo('granted');
       runStartup();
 
-      expect(reminderServiceSpy.ensureExactAlarmPermission).toHaveBeenCalledTimes(1);
+      expect(reminderServiceSpy.ensureExactAlarmPermission).not.toHaveBeenCalled();
       expect(snackServiceSpy.open).not.toHaveBeenCalled();
     }));
 
-    it('warns when granted but exact alarm permission is denied', fakeAsync(() => {
+    it('stays silent at startup when exact alarms would be denied', fakeAsync(() => {
       setup('android');
       reminderServiceSpy.getPermissionState.and.resolveTo('granted');
       reminderServiceSpy.ensureExactAlarmPermission.and.resolveTo(false);
       runStartup();
 
-      expect(snackServiceSpy.open).toHaveBeenCalledTimes(1);
+      expect(snackServiceSpy.open).not.toHaveBeenCalled();
     }));
   });
 

--- a/src/app/features/mobile/store/mobile-notification.effects.ts
+++ b/src/app/features/mobile/store/mobile-notification.effects.ts
@@ -110,12 +110,12 @@ export class MobileNotificationEffects {
                 this._notifyPermissionIssue();
                 return;
               }
-              if (permissionState !== 'granted') {
-                // Not asked yet — defer the prompt and the exact-alarm check
-                // until a notification actually needs scheduling.
-                return;
-              }
-              await this._warnIfExactAlarmPermissionDeniedOnce();
+              // Deliberately no exact-alarm check here. `ensureExactAlarmPermission()`
+              // opens Android's "Alarms & reminders" settings PAGE, and running it at
+              // startup sent users there with nothing scheduled — reachable for anyone
+              // once notifications are granted, which now happens on the first timer
+              // start (#9648). The scheduling effects below run it when a reminder
+              // actually needs an alarm, which is the only moment it can matter.
             } catch (error) {
               Log.err(error);
               this._notifyPermissionIssue(error?.toString());


### PR DESCRIPTION
Fixes the Android permission flow reported in #9648: fresh installs never requested `POST_NOTIFICATIONS`, so the tracking and focus-mode foreground-service notifications were silently suppressed on Android 13+ — and the app opened the "Alarms & reminders" settings page at startup with nothing scheduled.

## Changes

**1. Request `POST_NOTIFICATIONS` on timer starts** (`c839af1`)
- New `CapacitorReminderService.requestPermissionsInBackground()`: asks at most once per session, without blocking the caller (the service starts run inside synchronous effect taps). A denial is not re-prompted for the rest of the session.
- Wired to the two genuinely user-initiated start paths: tracking-service start (`AndroidForegroundTrackingEffects`) and `startFocusSession` (`AndroidFocusModeEffects`, action-based via `LOCAL_ACTIONS` so the cold-start recovery path `restoreFocusSessionFromNative` never prompts — consistent with the lazy-prompt design from #8120).
- Because `startForeground()` runs while the permission is still denied, Android drops that first notification and both services render steady-state time via a native chronometer with no per-tick pushes (#8243) — so nothing re-posts it organically. On a prompt→granted transition the current notification is therefore re-posted explicitly, reading *current* state to avoid rewinding the native counters (tracking: `updateTrackingService`; focus: `updateFocusModeService`, `a22e2d1`). Both native services ignore `ACTION_UPDATE` when not running, so a session that ended while the dialog was open is safe.
- Legacy WebView shell short-circuits via the existing #7408 guards (no broken Web Notifications fallback).

**2. Stop opening exact-alarm settings at startup** (`4714050`)
- `MobileNotificationEffects` no longer runs `ensureExactAlarmPermission()` (which opens the Android settings page) during the startup permission check. The check still runs once per session from the scheduling effects — i.e. only when a reminder actually needs an alarm.

## Testing
- New unit tests for `requestPermissionsInBackground` (memoization, grant/deny/already-granted semantics, legacy-WebView short-circuit); updated startup-check specs. All touched suites pass, lint clean.
- Re-post behavior verified on an API 34 emulator.
- Reviewed for sync-rule compliance: effects use `LOCAL_ACTIONS`, `dispatch: false`, no synced-state writes, no per-tick notification pushes.

Fixes #9648