### PR TITLE
test(e2e): re-click sync when a cycle already swallowed the click

### DIFF
--- a/e2e/pages/supersync.page.ts
+++ b/e2e/pages/supersync.page.ts
@@ -104,6 +104,14 @@ const remainingTimeout = (startedAt: number, total: number): number =>
   Math.max(1, total - (Date.now() - startedAt));
 
 /**
+ * How long to give one sync-button click to actually start a cycle before
+ * clicking again. Long enough to cover the op-flush + payload encryption that
+ * precede the first request, short enough to retry several times inside the
+ * caller's timeout.
+ */
+const SYNC_CLICK_RETRY_INTERVAL_MS = 3000;
+
+/**
  * Page object for SuperSync configuration and sync operations.
  * Used for E2E tests that verify multi-client sync via the super-sync-server.
  */
@@ -1916,8 +1924,12 @@ export class SuperSyncPage extends BasePage {
       request.method() !== 'OPTIONS' && isOpsUrl(request.url());
     const isArmedOpsRequest = (request: Request): boolean =>
       requestsStartedAfterArm.has(request) && isOpsRequest(request);
+    let cycleStarted = false;
     const requestHandler = (request: Request): void => {
       requestsStartedAfterArm.add(request);
+      if (isOpsRequest(request)) {
+        cycleStarted = true;
+      }
     };
     const responseHandler = (response: Response): void => {
       if (isArmedOpsRequest(response.request()) && !response.ok()) {
@@ -1935,20 +1947,52 @@ export class SuperSyncPage extends BasePage {
     this.page.on('requestfailed', requestFailedHandler);
 
     try {
-      const [response] = await Promise.all([
-        this.page.waitForResponse(
+      // Settle instead of reject so the waiter can be raced against the
+      // re-click timer below without producing an unhandled rejection.
+      const settled = this.page
+        .waitForResponse(
           (candidate) => isArmedOpsRequest(candidate.request()) && candidate.ok(),
           { timeout },
-        ),
-        this.syncBtn.click(),
-      ]);
+        )
+        .then(
+          (response) => ({ response, error: undefined }),
+          (error: unknown) => ({ response: undefined, error }),
+        );
+
+      // The app silently drops a sync-button click while another cycle is
+      // already running (`SyncWrapperService.sync()` returns HANDLED_ERROR
+      // without issuing a request) — e.g. the auto-sync that the daily-summary
+      // archive kicks off. Re-click until a cycle actually starts instead of
+      // waiting out the whole timeout on a swallowed click.
+      const deadline = Date.now() + timeout;
+      let outcome: Awaited<typeof settled> | null = null;
+      do {
+        await this.syncBtn.click();
+        outcome = await Promise.race([
+          settled,
+          this.page
+            .waitForTimeout(
+              Math.min(SYNC_CLICK_RETRY_INTERVAL_MS, Math.max(1, deadline - Date.now())),
+            )
+            .then(() => null),
+        ]);
+      } while (!outcome && !cycleStarted && Date.now() < deadline);
+
+      const { response, error: waitError } = outcome ?? (await settled);
+      if (!response) {
+        throw waitError;
+      }
       const responseFailure = await response.finished();
       if (responseFailure) {
         throw responseFailure;
       }
     } catch (error) {
       const attemptSummary =
-        failedAttempts.length > 0 ? failedAttempts.join(', ') : 'none observed';
+        failedAttempts.length > 0
+          ? failedAttempts.join(', ')
+          : cycleStarted
+            ? 'none observed'
+            : 'no cycle started — every sync click was swallowed';
       throw new Error(
         `SuperSync did not receive a completed successful /api/sync/ops response within ${timeout}ms. Failed attempts: ${attemptSummary}`,
         { cause: error },


### PR DESCRIPTION
## Problem

`E2E Tests (SuperSync 6/6)` has been intermittently red since 2026-08-15, always on the same test:

```
[chromium] › e2e/tests/sync/supersync-worklog.spec.ts:126:7 › @supersync Worklog Sync › Worklog shows correct time data after sync
Error: SuperSync did not receive a completed successful /api/sync/ops response within 30000ms. Failed attempts: none observed
```

Recent hits: [32484032831](https://github.com/super-productivity/super-productivity/actions/runs/32484032831) (master), [32505606034](https://github.com/super-productivity/super-productivity/actions/runs/32505606034) (a PR gate, failed on this pre-existing flake rather than on its own diff), and [31889313662](https://github.com/super-productivity/super-productivity/actions/runs/31889313662) — the first master run after #9171 introduced `_triggerSuperSyncCycle`. [31922071073](https://github.com/super-productivity/super-productivity/actions/runs/31922071073) hit the same message in `supersync-network-failure.spec.ts:379`.

## Root cause

The test's `syncAndWait()` at `supersync-worklog.spec.ts:175` runs right after the Finish-Day → daily-summary → archive flow, which already kicks off an automatic sync. The button click lands inside that cycle. From the Playwright traces of both recent failures, identically:

```
[ol] OperationLogUploadService: Uploading batch of 7 ops via API
[sync] Sync already in progress, skipping concurrent sync attempt   ← the test's click
[ol] OperationLogUploadService: Uploaded 7 ops via API.
```

`SyncWrapperService.sync()` (`src/app/imex/sync/sync-wrapper.service.ts:315`) returns `HANDLED_ERROR` with **zero HTTP requests**. But `_triggerSuperSyncCycle` only accepts an `/api/sync/ops` response whose request started *after* arming, so it waited out the full 30s. The network trace confirms the last request was the auto-sync's `POST /api/sync/ops`, then nothing for 30s; the failure screenshot shows a healthy app, tooltip "In sync — click to sync now", no dialog.

Harness bug, not a product bug — the 7 ops did reach the server, so the test's own precondition was satisfied.

## Fix

The response waiter no longer rides on a single click. It re-clicks the sync button every 3s until an ops request actually starts, within the caller's existing timeout. Once a cycle is observed, clicking stops and the original wait-for-completed-successful-response semantics take over unchanged, including tolerating intermediate provider retries. Extra clicks are no-ops by design (`sync()` returns `HANDLED_ERROR` synchronously while a cycle is in flight).

The failure message now names the swallowed-click case ("no cycle started — every sync click was swallowed") so a future occurrence is diagnosable from the log alone.

## Verification

- `npm run checkFile e2e/pages/supersync.page.ts` passes; `tsc --noEmit -p e2e/tsconfig.json` reports no errors in the file.
- Not reproduced locally — the failure is a load-dependent race, and the sandbox this was written in cannot reach Docker-published ports. **The SuperSync E2E suite on this branch is the real check.**

## Caveat

This only covers the swallowed-click path. The one `supersync-network-failure.spec.ts:379` occurrence shares the error message but that test deliberately drops responses, so its cause may differ; its trace was not inspected.