### PR TITLE
fix(supersync-chart): decouple liveness from database connectivity

### DIFF
--- a/.github/workflows/supersync-server-tests.yml
+++ b/.github/workflows/supersync-server-tests.yml
@@ -75,6 +75,11 @@ jobs:
             echo 'connectionLimit=0 unexpectedly passed Helm validation' >&2
             exit 1
           fi
+          # Liveness must stay off the DB-gated endpoint; readiness and startup keep it.
+          rendered=$(helm template "${chart_args[@]}")
+          printf '%s\n' "$rendered" | grep -A3 'livenessProbe:' | grep -q 'path: /live'
+          printf '%s\n' "$rendered" | grep -A3 'readinessProbe:' | grep -q 'path: /health'
+          printf '%s\n' "$rendered" | grep -A3 'startupProbe:' | grep -q 'path: /health'
       - name: Run SuperSync Server Tests
         run: cd packages/super-sync-server && npm test
       - name: Apply PostgreSQL Test Schema

--- a/packages/super-sync-server/helm/supersync/templates/deployment.yaml
+++ b/packages/super-sync-server/helm/supersync/templates/deployment.yaml
@@ -148,9 +148,13 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 5
             failureThreshold: 30
+          # Liveness must not depend on the database: a restart cannot fix a downed
+          # DB, and it would drop every live-sync websocket on the way. Readiness
+          # and startup stay on /health so the pod still leaves the Service
+          # endpoints while the database is unreachable.
           livenessProbe:
             httpGet:
-              path: /health
+              path: /live
               port: http
             periodSeconds: 30
             timeoutSeconds: 5

--- a/packages/super-sync-server/src/server.ts
+++ b/packages/super-sync-server/src/server.ts
@@ -467,6 +467,17 @@ export const createServer = (
         }
       });
 
+      // Liveness - process health only, deliberately free of dependency checks.
+      // Restarting the process cannot fix a database that is down, and the restart
+      // lands a cold start exactly when the database comes back; on this chart it
+      // also drops every client's live-sync websocket, since replicaCount > 1 is
+      // rejected and there is no failover. Answering here still proves the event
+      // loop is responsive. Exempt from rate limiting like /health, as probes are
+      // frequent.
+      fastifyServer.get('/live', { config: { rateLimit: false } }, async () => ({
+        status: 'ok',
+      }));
+
       // API Routes
       await fastifyServer.register(apiRoutes, {
         prefix: '/api',


### PR DESCRIPTION
Closes #9599.

## What

`livenessProbe` now points at a new `/live` endpoint; readiness and startup stay on `/health`.

## Why

`/health` runs `SELECT 1` through Prisma. That is the right check for readiness and startup — a pod that cannot reach the database cannot serve — but as a liveness check it kills the pod after roughly 90s of database unavailability (`periodSeconds: 30`, default `failureThreshold: 3`). Restarting the application cannot fix a database that is down, and the restart lands a cold start exactly when the database comes back.

On this chart the cost is higher than a cold start: `replicaCount > 1` is rejected because websocket connection state is in-memory, so an unnecessary restart drops every connected client's live-sync socket with no failover.

Observed on a single-instance CloudNativePG restart: the database was unreachable for ~145s, `/health` correctly returned 503 throughout, and the pod survived only because Postgres started accepting connections before the operator finished reconciling. The Prisma pool reconnected with no process restart — liveness was never needed for recovery here.

## Scope

Minimal, as agreed in the issue: `/live` plus the probe repoint, nothing else. No probe knobs in `values.yaml`.

- `/live` returns `{ status: 'ok' }` and touches no dependency; answering it still proves the Node event loop is responsive, which a TCP socket check would not
- rate-limit exempt (`{ config: { rateLimit: false } }`) like `/health`, since probes are frequent
- readiness keeps `/health`, so a pod whose database is gone still leaves the Service endpoints — it just stops being restarted while it waits

## Test

Added to the existing `helm template` step in `supersync-server-tests.yml`, next to the connection-limit assertions: liveness must render `/live`, readiness and startup `/health`. I checked it fails in the intended direction by pointing liveness back at `/health` — the step goes red, and passes again once reverted.

Locally: `tsc --noEmit` clean for `src`, `server-security.spec.ts` 27/27, `config.spec.ts` 34/34, chart renders.
