### PR TITLE
fix(supersync): keep live websocket clients out of the stale-device sweep

### DIFF
--- a/packages/super-sync-server/prisma/schema.prisma
+++ b/packages/super-sync-server/prisma/schema.prisma
@@ -147,6 +147,7 @@ model SyncDevice {
   deviceName   String? @map("device_name")
   userAgent    String? @map("user_agent")
   lastSeenAt   BigInt  @map("last_seen_at")
+  /// Reserved: written once at device registration, never read or updated.
   lastAckedSeq Int     @default(0) @map("last_acked_seq")
   createdAt    BigInt  @map("created_at")
 

--- a/packages/super-sync-server/src/api.ts
+++ b/packages/super-sync-server/src/api.ts
@@ -242,6 +242,14 @@ export const apiRoutes = async (
         // AUTH_CACHE_INVALIDATION: account deletion must not leave a ghost-token window.
         authCache.invalidate(userId);
 
+        // The cascade removed this user's sync_devices rows, but an open socket
+        // keeps answering pings, so the dead-connection branch never reaps it.
+        // Its heartbeat touch would then re-INSERT a device row for a user that
+        // no longer exists and trip the FK every throttle window. Closed after
+        // the delete, not before: with the user row already gone no reconnect
+        // can re-authenticate and re-orphan a socket.
+        getWsConnectionService().closeForUser(userId);
+
         Logger.audit({ event: 'USER_ACCOUNT_DELETED', userId });
 
         return reply.send({ success: true });

--- a/packages/super-sync-server/src/server.ts
+++ b/packages/super-sync-server/src/server.ts
@@ -491,8 +491,11 @@ export const createServer = (
       // Start cleanup jobs
       startCleanupJobs();
 
-      // Start WebSocket heartbeat
-      getWsConnectionService().startHeartbeat();
+      // Start WebSocket heartbeat. It also refreshes the device row of every live
+      // socket, so a long-lived read-only connection is not pruned as stale.
+      getWsConnectionService().startHeartbeat((userId, clientId) =>
+        getSyncService().touchDevice(userId, clientId),
+      );
 
       try {
         const address = await fastifyServer.listen(createListenOptions(fullConfig));

--- a/packages/super-sync-server/src/sync/services/websocket-connection.service.ts
+++ b/packages/super-sync-server/src/sync/services/websocket-connection.service.ts
@@ -1,5 +1,6 @@
 import { WebSocket } from 'ws';
 import { Logger } from '../../logger';
+import { DEVICE_TOUCH_THROTTLE_MS } from '../sync.types';
 
 interface ConnectedClient {
   ws: WebSocket;
@@ -8,6 +9,13 @@ interface ConnectedClient {
   lastPong: number;
   /** Wall-clock ms when this socket was accepted (used for the storm summary). */
   connectedAt: number;
+  /**
+   * Wall-clock ms of the last device touch issued for this socket. Purely an
+   * in-memory throttle so a long-lived connection costs ~one write per
+   * DEVICE_TOUCH_THROTTLE_MS rather than one per heartbeat tick; the statement
+   * itself is throttled again in SQL, so a stale value here is harmless.
+   */
+  lastTouchedAt: number;
   /**
    * Wall-clock ms at which the reconnect cooldown expires. Set on accept and
    * extended forward on each refused challenger so a sustained storm cannot
@@ -37,6 +45,12 @@ interface ConnectedClient {
 export class WebSocketConnectionService {
   private connections = new Map<number, Set<ConnectedClient>>();
   private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Injected rather than imported so this service stays free of persistence:
+   * it knows when a client is demonstrably alive, not how a device row is
+   * written. Fire-and-forget by contract — the callee must not reject.
+   */
+  private touchDevice: ((userId: number, clientId: string) => void) | null = null;
 
   /** 30s ping interval - keeps connection alive through proxies (most: 60-120s timeout) */
   private static readonly PING_INTERVAL_MS = 30_000;
@@ -161,6 +175,7 @@ export class WebSocketConnectionService {
       userId,
       lastPong: nowMs,
       connectedAt: nowMs,
+      lastTouchedAt: nowMs,
       cooldownUntil: nowMs + WebSocketConnectionService.RECONNECT_COOLDOWN_MS,
       refusedChallengers: 0,
       summaryLogged: false,
@@ -310,8 +325,9 @@ export class WebSocketConnectionService {
     }
   }
 
-  startHeartbeat(): void {
+  startHeartbeat(touchDevice?: (userId: number, clientId: string) => void): void {
     if (this.heartbeatInterval) return;
+    this.touchDevice = touchDevice ?? null;
 
     this.heartbeatInterval = setInterval(() => {
       const now = Date.now();
@@ -330,6 +346,18 @@ export class WebSocketConnectionService {
             );
             toRemove.push({ userId, client });
             continue;
+          }
+
+          // A socket that still answers pings is in active use, so keep its device
+          // row fresh: a connection held open past the retention window without
+          // uploading would otherwise be pruned mid-use. Touching only on accept
+          // would not cover that case.
+          if (
+            this.touchDevice &&
+            now - client.lastTouchedAt >= DEVICE_TOUCH_THROTTLE_MS
+          ) {
+            client.lastTouchedAt = now;
+            this.touchDevice(userId, client.clientId);
           }
 
           // Send app-level ping

--- a/packages/super-sync-server/tests/delete-account.routes.spec.ts
+++ b/packages/super-sync-server/tests/delete-account.routes.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+
+const mocks = vi.hoisted(() => ({
+  closeForUser: vi.fn(),
+  userDelete: vi.fn(),
+}));
+
+vi.mock('../src/sync/services/websocket-connection.service', () => ({
+  getWsConnectionService: () => ({ closeForUser: mocks.closeForUser }),
+}));
+
+// The global setup.ts prisma mock exposes only user.findUnique/update — this
+// route's cascade call (user.delete) is not on it, so redeclare the surface.
+vi.mock('../src/db', () => ({
+  prisma: {
+    user: { delete: (...args: unknown[]) => mocks.userDelete(...args) },
+  },
+}));
+
+import { apiRoutes } from '../src/api';
+
+/**
+ * `DELETE /api/account` cascades away the user's sync_devices rows, but an open
+ * websocket keeps answering pings, so the dead-connection branch never reaps
+ * it. Since #9598 that socket's heartbeat touch re-INSERTs a device row every
+ * throttle window, tripping sync_devices_user_id_fkey against a user that no
+ * longer exists. The route must close the user's sockets, and must do it after
+ * the delete so no reconnect can re-authenticate and re-orphan one.
+ */
+describe('DELETE /api/account (socket teardown)', () => {
+  let app: FastifyInstance;
+
+  const inject = () =>
+    app.inject({
+      method: 'DELETE',
+      url: '/api/account',
+      headers: { authorization: 'Bearer some-token' },
+    });
+
+  beforeEach(async () => {
+    mocks.closeForUser.mockClear();
+    mocks.userDelete.mockClear().mockResolvedValue({ id: 1 });
+    app = Fastify();
+    await app.register(apiRoutes, { prefix: '/api', requireTermsConsent: false });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('closes the deleted user’s websockets', async () => {
+    const res = await inject();
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.closeForUser).toHaveBeenCalledWith(1);
+  });
+
+  it('closes them after the cascade, not before', async () => {
+    await inject();
+
+    expect(mocks.userDelete).toHaveBeenCalled();
+    expect(mocks.closeForUser).toHaveBeenCalled();
+    expect(mocks.closeForUser.mock.invocationCallOrder[0]).toBeGreaterThan(
+      mocks.userDelete.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('leaves sockets open when the delete fails', async () => {
+    mocks.userDelete.mockRejectedValue(new Error('db down'));
+
+    const res = await inject();
+
+    expect(res.statusCode).toBe(500);
+    expect(mocks.closeForUser).not.toHaveBeenCalled();
+  });
+});

--- a/packages/super-sync-server/tests/websocket-connection.service.spec.ts
+++ b/packages/super-sync-server/tests/websocket-connection.service.spec.ts
@@ -520,6 +520,49 @@ describe('WebSocketConnectionService', () => {
   });
 
   describe('startHeartbeat', () => {
+    it('touches the device row of a live socket, throttled to the shared interval', () => {
+      const touch = vi.fn();
+      const ws = createMockWs();
+      service.addConnection(1, 'client-a', ws as any);
+
+      service.startHeartbeat(touch);
+
+      // First tick is inside the throttle window measured from accept.
+      vi.advanceTimersByTime(30_000);
+      ws._emitPong();
+      expect(touch).not.toHaveBeenCalled();
+
+      // Crossing DEVICE_TOUCH_THROTTLE_MS (2 min) yields exactly one write...
+      vi.advanceTimersByTime(30_000);
+      ws._emitPong();
+      vi.advanceTimersByTime(30_000);
+      ws._emitPong();
+      vi.advanceTimersByTime(30_000);
+      ws._emitPong();
+      expect(touch).toHaveBeenCalledTimes(1);
+      expect(touch).toHaveBeenCalledWith(1, 'client-a');
+
+      // ...and the next ticks are throttled again rather than one per heartbeat.
+      vi.advanceTimersByTime(30_000);
+      ws._emitPong();
+      vi.advanceTimersByTime(30_000);
+      ws._emitPong();
+      expect(touch).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps pinging when no touch fn is injected', () => {
+      const ws = createMockWs();
+      service.addConnection(1, 'client-a', ws as any);
+      ws.send.mockClear();
+
+      service.startHeartbeat();
+      vi.advanceTimersByTime(30_000);
+
+      expect(parseSendCalls(ws)).toContainEqual(
+        expect.objectContaining({ type: 'ping' }),
+      );
+    });
+
     it('should send ping at interval', () => {
       const ws = createMockWs();
       service.addConnection(1, 'client-a', ws as any);


### PR DESCRIPTION
Closes #9598.

## Scope

The download path already landed in master (`sync.routes.ts` → `SyncService.touchDevice`, throttled in SQL, fire-and-forget), so this PR is the remaining half: **the websocket path**, touched periodically while connected rather than only on accept.

Framed as you asked — this keeps the device registry accurate and stops the retention sweep deleting devices that are in active use. It is not about a revocation screen; there is no device-list or per-device revoke endpoint today, and `devicesOnline` is only exposed through the diagnostic `/api/sync/status`.

## Why the websocket path still needs it

The download touch only fires when a device actually pulls ops, and it pulls when *some other* device uploaded something. A device that holds an open socket, uploads nothing and receives nobody else's ops is never touched at all — and after `RETENTION_DAYS` it is deleted while demonstrably alive. Touching on accept alone would not cover it either, which is why this hooks the heartbeat.

## Implementation

- periodic touch from the existing 30s heartbeat, gated by an in-memory `lastTouchedAt` per connection against the shared `DEVICE_TOUCH_THROTTLE_MS` — about one statement per interval per live socket rather than one per tick, and the SQL throttles again on top
- the touch fn is **injected** at `startHeartbeat(...)` rather than imported, so `WebSocketConnectionService` stays persistence-agnostic: it knows when a client is alive, not how a device row is written
- `last_acked_seq` documented as reserved (written at registration, never read or updated) instead of dropped — removing a `NOT NULL` column is a destructive migration for self-hosters with nothing gained

## Test

Two cases in `websocket-connection.service.spec.ts`: one pinning the throttle (no write inside the first window, exactly one after crossing it, none on the ticks that follow) and one asserting the heartbeat still pings when no touch fn is injected. I checked the first fails in the intended direction — removing the touch block turns it red, 1 failed / 28 passed, and green again once restored.

Locally: `tsc --noEmit` clean for `src`, `websocket-connection.service.spec.ts` 29/29, prettier clean.

## Your question about read-only traffic

Real, and more common than the polling case would suggest. For SuperSync the client has **no periodic upload and no polling**: `sync-trigger.service.ts` merges event triggers (idle, wake, online, visibility, resume) with `_onUpdateLocalDataTrigger$`, and the interval timer is explicitly file-provider-only — the comment there says SuperSync relies on websocket push instead. So a client that changes nothing uploads nothing, indefinitely.

That is exactly the shape this PR covers: such a device typically sits on an open socket, and its only chance of being touched before this change was another device happening to upload.
