### PR TITLE
fix(settings): reopen repeated search result #9643

### DIFF
--- a/src/app/pages/config-page/config-page.component.spec.ts
+++ b/src/app/pages/config-page/config-page.component.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ConfigPageComponent } from './config-page.component';
 import { SyncConfigService } from '../../imex/sync/sync-config.service';
 import { SnackService } from '../../core/snack/snack.service';
@@ -16,6 +16,9 @@ import { TranslateService } from '@ngx-translate/core';
 import { LocalBackupService } from '../../imex/local-backup/local-backup.service';
 import { IS_ANDROID_WEB_VIEW_TOKEN } from '../../util/is-android-web-view';
 import { T } from '../../t.const';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { CollapsibleComponent } from '../../ui/collapsible/collapsible.component';
 
 describe('ConfigPageComponent', () => {
   let component: ConfigPageComponent;
@@ -23,10 +26,12 @@ describe('ConfigPageComponent', () => {
   let mockMatDialog: jasmine.SpyObj<MatDialog>;
   let mockProviderManager: jasmine.SpyObj<SyncProviderManager>;
   let mockLocalBackupService: jasmine.SpyObj<LocalBackupService>;
+  let fixture: ComponentFixture<ConfigPageComponent>;
 
   const setup = async (
     isAndroidWebView: boolean = false,
     lastBackupTime: number | null = null,
+    renderCollapsible: boolean = false,
   ): Promise<void> => {
     const mockSyncConfigService = jasmine.createSpyObj(
       'SyncConfigService',
@@ -58,6 +63,7 @@ describe('ConfigPageComponent', () => {
     mockTranslateService.instant.and.callFake((key: string) => key);
 
     await TestBed.configureTestingModule({
+      imports: renderCollapsible ? [NoopAnimationsModule] : [],
       providers: [
         { provide: SyncConfigService, useValue: mockSyncConfigService },
         { provide: IS_ANDROID_WEB_VIEW_TOKEN, useValue: isAndroidWebView },
@@ -87,11 +93,21 @@ describe('ConfigPageComponent', () => {
       ],
     })
       .overrideComponent(ConfigPageComponent, {
-        set: { imports: [], template: '' },
+        set: renderCollapsible
+          ? {
+              imports: [CollapsibleComponent],
+              template: `
+                <collapsible
+                  [isExpanded]="isSectionExpanded(generalFormCfg[0])"
+                ></collapsible>
+              `,
+            }
+          : { imports: [], template: '' },
       })
       .compileComponents();
 
-    component = TestBed.createComponent(ConfigPageComponent).componentInstance;
+    fixture = TestBed.createComponent(ConfigPageComponent);
+    component = fixture.componentInstance;
   };
 
   beforeEach(async () => {
@@ -157,5 +173,30 @@ describe('ConfigPageComponent', () => {
     await setup(true, null);
 
     expect(findLastBackupLine()).toBeUndefined();
+  });
+
+  it('reopens the same search result section after a manual collapse (#9643)', async () => {
+    TestBed.resetTestingModule();
+    await setup(false, null, true);
+    fixture.detectChanges();
+
+    const collapsible = fixture.debugElement.query(By.directive(CollapsibleComponent))
+      .componentInstance as CollapsibleComponent;
+    const target = {
+      labelKey: 'Language',
+      tabLabelKey: T.PS.TABS.GENERAL,
+      tabIndex: 0,
+      sectionKey: 'localization',
+      scrollSelector: '.localization',
+    };
+
+    component.goToSearchResult(target);
+    expect(collapsible.isExpanded).toBe(true);
+
+    collapsible.toggleExpand();
+    expect(collapsible.isExpanded).toBe(false);
+
+    component.goToSearchResult(target);
+    expect(collapsible.isExpanded).toBe(true);
   });
 });

--- a/src/app/pages/config-page/config-page.component.ts
+++ b/src/app/pages/config-page/config-page.component.ts
@@ -487,7 +487,14 @@ export class ConfigPageComponent implements OnInit {
   goToSearchResult(target: SettingsSearchTarget): void {
     this.onSearchChange('');
     this.selectedTabIndex = target.tabIndex;
-    this.expandedSection = target.sectionKey ?? null;
+    const sectionKey = target.sectionKey ?? null;
+    if (sectionKey !== null && sectionKey === this.expandedSection) {
+      // A collapsible can be closed locally while this key remains selected.
+      // Clear the binding for one change-detection pass so navigation reopens it.
+      this.expandedSection = null;
+      this._cd.detectChanges();
+    }
+    this.expandedSection = sectionKey;
     this._cd.detectChanges();
     // The tab body swaps in over `animationDuration`, so the element doesn't
     // exist yet; wait it out before scrolling.


### PR DESCRIPTION
## Problem

Settings search keeps the selected section key after the section is manually collapsed. Selecting the same result again assigns the same key, so Angular does not update the collapsible input and the section stays closed.

Fixes #9643

## Solution

When the same non-null section is selected again, clear the binding for one change-detection pass before restoring the key. A regression test renders the real collapsible, expands it from search, collapses it manually, and verifies that selecting the same result reopens it.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). (Not applicable: this restores existing settings navigation behavior and does not change a documented setting or workflow.)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
