### PR TITLE
fix(tasks): apply the same Shift+T guards on both host paths #9577

### DIFF
--- a/src/app/features/tasks/task.service.spec.ts
+++ b/src/app/features/tasks/task.service.spec.ts
@@ -311,6 +311,76 @@ describe('TaskService', () => {
     });
   });
 
+  // The Shift+T fallback for rows that are not rendered by a live <task>
+  // (e.g. <planner-task> in the Planner overdue list). It has to apply the same
+  // two guards TaskComponent.scheduleForToday() applies, or the same keypress
+  // behaves differently based on the DOM host. (#9577)
+  describe('scheduleForTodayById', () => {
+    it('should dispatch planTasksForToday for a task that is not on today', () => {
+      const task = createMockTask('task-1', { dueDay: '2026-01-04' });
+      store.overrideSelector(selectTaskEntities, { ['task-1']: task });
+      store.refreshState();
+
+      service.scheduleForTodayById('task-1');
+
+      expect(store.dispatch).toHaveBeenCalledWith(
+        TaskSharedActions.planTasksForToday({
+          taskIds: ['task-1'],
+          today: '2026-01-05',
+          startOfNextDayDiffMs: 0,
+          // computed key: a quoted 'task-1' trips the naming-convention rule
+          parentTaskMap: { ['task-1']: undefined },
+        }),
+      );
+    });
+
+    it('should not re-plan a task whose dueDay is already today', () => {
+      const task = createMockTask('task-1', { dueDay: '2026-01-05' });
+      store.overrideSelector(selectTaskEntities, { ['task-1']: task });
+      store.refreshState();
+
+      service.scheduleForTodayById('task-1');
+
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('should not drop the reminder of a task due at a time today', () => {
+      // planTasksForToday applies `remindAt: undefined` unconditionally, so
+      // re-planning this task would silently clear its reminder.
+      const task = createMockTask('task-1', {
+        dueWithTime: new Date(2026, 0, 5, 14, 30).getTime(),
+        remindAt: new Date(2026, 0, 5, 14, 0).getTime(),
+      });
+      store.overrideSelector(selectTaskEntities, { ['task-1']: task });
+      store.refreshState();
+
+      service.scheduleForTodayById('task-1');
+
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('should not date a done task', () => {
+      // Completion never synthesizes a dueDay; dating a done task instead
+      // inflates the daily summary's done count for today.
+      const task = createMockTask('task-1', { isDone: true });
+      store.overrideSelector(selectTaskEntities, { ['task-1']: task });
+      store.refreshState();
+
+      service.scheduleForTodayById('task-1');
+
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('should still dispatch for an unknown id, leaving the reducer to drop it', () => {
+      store.overrideSelector(selectTaskEntities, {});
+      store.refreshState();
+
+      service.scheduleForTodayById('missing');
+
+      expect(store.dispatch).toHaveBeenCalled();
+    });
+  });
+
   describe('remove', () => {
     it('should dispatch deleteTask', () => {
       const task = createMockTaskWithSubTasks(createMockTask('task-1'));

--- a/src/app/features/tasks/task.service.ts
+++ b/src/app/features/tasks/task.service.ts
@@ -105,6 +105,7 @@ import { TaskFocusService } from './task-focus.service';
 import { DeletedTaskIssueSidecarService } from '../issue/two-way-sync/deleted-task-issue-sidecar.service';
 import { TimeBlockDeleteSidecarService } from '../calendar-integration/time-block/time-block-delete-sidecar.service';
 import { getDeadlineAutoPlanFields } from './util/get-deadline-auto-plan-fields';
+import { isTaskOnToday } from './util/is-task-on-today';
 import { TaskTimeSyncService } from './task-time-sync.service';
 
 @Injectable({
@@ -465,11 +466,26 @@ export class TaskService {
    */
   scheduleForTodayById(taskId: string): void {
     const task = this._taskEntities()[taskId];
+    const today = this._dateService.todayStr();
+    const startOfNextDayDiffMs = this._dateService.getStartOfNextDayDiffMs();
+
+    // The same two guards TaskComponent.scheduleForToday() applies, so Shift+T
+    // does not depend on whether a <task> or a <planner-task> renders the row.
+    // (#9577)
+    // Already on Today: planTasksForToday clears remindAt unconditionally, so
+    // re-planning a task due at a time today silently drops its reminder and
+    // writes both dueDay and dueWithTime.
+    // Done: completion never synthesizes a dueDay, and dating a done task adds
+    // it to the daily summary's done count for today.
+    if (task && (task.isDone || isTaskOnToday(task, today, startOfNextDayDiffMs))) {
+      return;
+    }
+
     this._store.dispatch(
       TaskSharedActions.planTasksForToday({
         taskIds: [taskId],
-        today: this._dateService.todayStr(),
-        startOfNextDayDiffMs: this._dateService.getStartOfNextDayDiffMs(),
+        today,
+        startOfNextDayDiffMs,
         parentTaskMap: task ? { [taskId]: task.parentId } : undefined,
       }),
     );

--- a/src/app/features/tasks/task/task-shortcuts.spec.ts
+++ b/src/app/features/tasks/task/task-shortcuts.spec.ts
@@ -717,13 +717,14 @@ describe('TaskComponent shortcut handling', () => {
     it('keeps the reminder of a task due at a time today', () => {
       // planTasksForToday clears remindAt unconditionally, so re-planning a task
       // that is already on Today would silently drop its reminder.
-      // isToday is installed as a property on the DateService mock, so it has
-      // to be redefined rather than assigned.
-      Object.defineProperty(dateService, 'isToday', {
-        value: () => true,
-        configurable: true,
+      // The timestamp is a real TODAY-local one: isScheduledToday() now derives
+      // the day from todayDateStr + the start-of-next-day offset (isTaskOnToday),
+      // so it no longer needs DateService.isToday to be stubbed true over a
+      // fixture that fell on a different day.
+      setTask({
+        dueWithTime: new Date(2026, 4, 5, 16, 0).getTime(),
+        remindAt: new Date(2026, 4, 5, 15, 30).getTime(),
       });
-      setTask({ dueWithTime: 1746453600000, remindAt: 1746452000000 });
 
       component.scheduleForToday();
 

--- a/src/app/features/tasks/task/task-shortcuts.spec.ts
+++ b/src/app/features/tasks/task/task-shortcuts.spec.ts
@@ -169,9 +169,14 @@ describe('TaskComponent shortcut handling', () => {
           provide: DateService,
           useValue: jasmine.createSpyObj(
             'DateService',
-            ['isToday', 'getLogicalTodayDate'],
+            ['isToday', 'getLogicalTodayDate', 'getStartOfNextDayDiffMs'],
             {
               isToday: () => false,
+              // isScheduledToday() calls this and is template-bound
+              // (task.component.html:166, :192), so the first test in this file
+              // that calls detectChanges() renders those @if blocks against this
+              // mock. Stubbed here rather than only in the Shift+T beforeEach.
+              getStartOfNextDayDiffMs: () => 0,
             },
           ),
         },

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -122,6 +122,7 @@ import {
 } from '../add-subtask-input/add-subtask-input.component';
 import { AddSubtaskInputService } from '../add-subtask-input/add-subtask-input.service';
 import { getSubTaskTimeLeftForDisplay } from '../util/get-sub-task-time-left-for-display';
+import { isTaskOnToday } from '../util/is-task-on-today';
 
 @Component({
   selector: 'task',
@@ -263,14 +264,13 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
           t.dueDay < todayStr))
     );
   });
-  isScheduledToday = computed(() => {
-    const t = this.task();
-    const todayStr = this.globalTrackingIntervalService.todayDateStr();
-    return (
-      (t.dueWithTime && this._dateService.isToday(t.dueWithTime)) ||
-      (t.dueDay && t.dueDay === todayStr)
-    );
-  });
+  isScheduledToday = computed(() =>
+    isTaskOnToday(
+      this.task(),
+      this.globalTrackingIntervalService.todayDateStr(),
+      this._dateService.getStartOfNextDayDiffMs(),
+    ),
+  );
   hasTimeConflict = computed(() => {
     const task = this.task();
     return (

--- a/src/app/features/tasks/util/is-task-on-today.spec.ts
+++ b/src/app/features/tasks/util/is-task-on-today.spec.ts
@@ -1,0 +1,111 @@
+import { isTaskOnToday } from './is-task-on-today';
+import { Task } from '../task.model';
+
+const createTask = (overrides: Partial<Task> = {}): Task =>
+  ({
+    id: 'task1',
+    dueDay: undefined,
+    dueWithTime: undefined,
+    ...overrides,
+  }) as Task;
+
+/** Local-midnight ms for a YYYY-MM-DD, so the fixtures don't depend on the TZ. */
+const localMs = (dateStr: string, h = 0, m = 0): number => {
+  const [y, mo, d] = dateStr.split('-').map(Number);
+  return new Date(y, mo - 1, d, h, m).getTime();
+};
+
+describe('isTaskOnToday', () => {
+  const TODAY_STR = '2026-03-15';
+  const NO_OFFSET = 0;
+
+  describe('dueDay', () => {
+    it('is on today when dueDay equals todayStr', () => {
+      expect(
+        isTaskOnToday(createTask({ dueDay: '2026-03-15' }), TODAY_STR, NO_OFFSET),
+      ).toBe(true);
+    });
+
+    it('is not on today when dueDay is before todayStr', () => {
+      expect(
+        isTaskOnToday(createTask({ dueDay: '2026-03-14' }), TODAY_STR, NO_OFFSET),
+      ).toBe(false);
+    });
+
+    it('is not on today when dueDay is after todayStr', () => {
+      expect(
+        isTaskOnToday(createTask({ dueDay: '2026-03-16' }), TODAY_STR, NO_OFFSET),
+      ).toBe(false);
+    });
+  });
+
+  describe('dueWithTime', () => {
+    it('is on today when dueWithTime falls on todayStr', () => {
+      expect(
+        isTaskOnToday(
+          createTask({ dueWithTime: localMs('2026-03-15', 9) }),
+          TODAY_STR,
+          NO_OFFSET,
+        ),
+      ).toBe(true);
+    });
+
+    it('is not on today when dueWithTime falls on another day', () => {
+      expect(
+        isTaskOnToday(
+          createTask({ dueWithTime: localMs('2026-03-16', 9) }),
+          TODAY_STR,
+          NO_OFFSET,
+        ),
+      ).toBe(false);
+    });
+
+    it('wins over a dueDay that disagrees', () => {
+      expect(
+        isTaskOnToday(
+          createTask({ dueDay: '2026-03-10', dueWithTime: localMs('2026-03-15', 9) }),
+          TODAY_STR,
+          NO_OFFSET,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe('startOfNextDayDiffMs', () => {
+    const OFFSET_4H = 4 * 60 * 60 * 1000;
+
+    it('counts the small hours as still belonging to the previous logical day', () => {
+      // 02:00 on the 16th is before a 04:00 start-of-next-day, so it is still
+      // the 15th — matching DateService.isToday().
+      expect(
+        isTaskOnToday(
+          createTask({ dueWithTime: localMs('2026-03-16', 2) }),
+          TODAY_STR,
+          OFFSET_4H,
+        ),
+      ).toBe(true);
+    });
+
+    it('does not shift a task past the offset back onto today', () => {
+      expect(
+        isTaskOnToday(
+          createTask({ dueWithTime: localMs('2026-03-16', 6) }),
+          TODAY_STR,
+          OFFSET_4H,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('unscheduled', () => {
+    it('is not on today when neither field is set', () => {
+      expect(isTaskOnToday(createTask(), TODAY_STR, NO_OFFSET)).toBe(false);
+    });
+
+    it('is not on today for a zero dueWithTime', () => {
+      expect(isTaskOnToday(createTask({ dueWithTime: 0 }), TODAY_STR, NO_OFFSET)).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/src/app/features/tasks/util/is-task-on-today.spec.ts
+++ b/src/app/features/tasks/util/is-task-on-today.spec.ts
@@ -69,6 +69,27 @@ describe('isTaskOnToday', () => {
         ),
       ).toBe(true);
     });
+
+    it('is a deliberate superset: a today dueDay counts even when dueWithTime is not today', () => {
+      // The other direction of the shape above, and the one that distinguishes a
+      // disjunction from a precedence check. Canonical TODAY membership reads
+      // dueWithTime FIRST and only falls back to dueDay when it is unset
+      // (ARCHITECTURE-DECISIONS.md Decision #1), so for this legacy both-fields
+      // shape the canonical readers disagree with us:
+      //   work-context.selectors.ts:58-79  computeOrderedTaskIdsForToday -> false
+      //   planner.selectors.ts:66-74                                     -> false
+      //   task.selectors.ts:617-623        isInToday                     -> false
+      // isTaskOnToday is a strict superset on purpose — see the note on the
+      // predicate itself. Both call sites only ever use it to SUPPRESS a
+      // dispatch, and in this shape the dispatch was a no-op anyway.
+      expect(
+        isTaskOnToday(
+          createTask({ dueDay: '2026-03-15', dueWithTime: localMs('2026-03-16', 9) }),
+          TODAY_STR,
+          NO_OFFSET,
+        ),
+      ).toBe(true);
+    });
   });
 
   describe('startOfNextDayDiffMs', () => {

--- a/src/app/features/tasks/util/is-task-on-today.ts
+++ b/src/app/features/tasks/util/is-task-on-today.ts
@@ -1,0 +1,31 @@
+import { Task } from '../task.model';
+import { getDbDateStr } from '../../../util/get-db-date-str';
+
+/**
+ * Pure predicate for "is this task already on Today" — the read side of
+ * `planTasksForToday`.
+ *
+ * Extracted because the same question was being asked in two places that
+ * disagreed: `TaskComponent.isScheduledToday()` (a computed, which also drives
+ * the "Add to Today" button) and, by omission, `TaskService.scheduleForTodayById()`,
+ * which asked it nowhere and re-planned regardless. See #9577.
+ *
+ * Kept clock-free/deterministic in the same shape as `isTaskOverdue`: the caller
+ * threads in `todayStr` (a DB date string, e.g. from `DateService.todayStr()`)
+ * and the start-of-next-day offset, so custom start-of-day settings are
+ * respected and the predicate stays testable without mocking the clock.
+ *
+ * `dueWithTime` is checked first, following the dueWithTime/dueDay
+ * mutual-exclusivity pattern; because this is a disjunction the order is not
+ * load-bearing, but it matches the definition this replaces.
+ */
+export const isTaskOnToday = (
+  task: Pick<Task, 'dueDay' | 'dueWithTime'>,
+  todayStr: string,
+  startOfNextDayDiffMs: number,
+): boolean =>
+  !!(
+    (task.dueWithTime &&
+      getDbDateStr(new Date(task.dueWithTime - startOfNextDayDiffMs)) === todayStr) ||
+    (task.dueDay && task.dueDay === todayStr)
+  );

--- a/src/app/features/tasks/util/is-task-on-today.ts
+++ b/src/app/features/tasks/util/is-task-on-today.ts
@@ -18,6 +18,19 @@ import { getDbDateStr } from '../../../util/get-db-date-str';
  * `dueWithTime` is checked first, following the dueWithTime/dueDay
  * mutual-exclusivity pattern; because this is a disjunction the order is not
  * load-bearing, but it matches the definition this replaces.
+ *
+ * That disjunction makes this a DELIBERATE STRICT SUPERSET of canonical TODAY
+ * membership, and the difference is worth knowing before reusing it. The
+ * canonical readers — `computeOrderedTaskIdsForToday`
+ * (work-context.selectors.ts), `planner.selectors.ts` and `isInToday`
+ * (task.selectors.ts) — apply Decision #1 of ARCHITECTURE-DECISIONS.md: check
+ * `dueWithTime` first, and consult `dueDay` ONLY if `dueWithTime` is unset. So a
+ * legacy task carrying both, with `dueDay` today and `dueWithTime` tomorrow, is
+ * NOT on Today for them and IS on Today for this predicate. That is intended:
+ * both call sites use it only to suppress a `planTasksForToday` dispatch, so the
+ * superset can only ever suppress more, never plan something it should not — and
+ * in that one divergent shape the dispatch was a no-op anyway. Do not reuse this
+ * anywhere the answer decides what to SHOW; use the selectors for that.
  */
 export const isTaskOnToday = (
   task: Pick<Task, 'dueDay' | 'dueWithTime'>,


### PR DESCRIPTION
Fixes #9577.

`taskScheduleToday` (Shift+T) reaches "schedule for today" by two routes depending on which component renders the focused row (`task-shortcut.service.ts:95-109`): a live `<task>` host delegates to `TaskComponent.scheduleForTodayWithFocus()`, anything else — `<planner-task>` in the Planner overdue list — falls back to `TaskService.scheduleForTodayById()`. After #9563 the `<task>` path grew two guards that the fallback never had, so the same keypress does different things based on the DOM host.

### The change

Per the issue's suggestion, a small pure `isTaskOnToday(task, todayStr, startOfNextDayDiffMs)` next to `is-task-overdue.ts`, and both call sites now ask it:

- `TaskService.scheduleForTodayById()` gains the two guards.
- `TaskComponent.isScheduledToday()` is re-expressed in terms of it rather than keeping a second inline definition, so the two cannot drift again.

The shared logic lives in the util, not in `TaskService` — the issue notes the service is already 1525 lines against the grandfathered 1200-line `max-lines` cap, and this does not add to it.

**The two cases the fallback was performing:**

1. **Task already on Today.** `handlePlanTasksForToday` applies `remindAt: undefined` unconditionally (`task-shared-scheduling.reducer.ts:243-250`), while `shouldClearDueTimeForToday` returns `false` for a `dueWithTime` that is today — so re-planning a task due at a time today silently dropped its reminder and wrote both `dueDay` and `dueWithTime`.
2. **Done tasks.** Completion never synthesizes a `dueDay` (`task-related-model.effects.ts:77-81`); dating a done task admits it to `daily-summary.component.ts:556`, which has no `isDone` guard, inflating today's done count.

### On the sync model

`docs/sync-and-op-log/contributor-sync-model.md` — no effect or reducer is touched, and no new dispatch is introduced. The guards only *suppress* a dispatch, so the change strictly reduces the operations emitted for a keypress that produced no state change.

### Deliberately not included

The issue also mentions folding in the sub-task case (a sub-task whose parent is already on Today dispatches a `planTasksForToday` the reducer rejects at `:197-204`). That needs the TODAY tag's membership rather than the task entity alone, so it is a wider change than the host-parity fix and is left out to keep this diff reviewable. Happy to follow up.

### One existing test changed, and why

`task-shortcuts.spec.ts` — *"keeps the reminder of a task due at a time today"* stubbed `DateService.isToday` to return `true` over a fixture whose `dueWithTime` was `1746453600000` = **2025**-05-05, while the block's `TODAY` is **2026**-05-05. The assertion only held because of the stub. `isScheduledToday()` no longer calls `DateService.isToday`, so the fixture is now a real `TODAY`-local timestamp and the `Object.defineProperty` stub is gone — the test's own comment flagged that stub as awkward.

### Verification

Negative control, per the issue's "needs a test that fails without the fix": with only the two source files reverted and the specs kept, `task.service.spec.ts` is **3 FAILED / 75 SUCCESS** — the three guard tests, exactly. With the fix, the four relevant specs (`task.service`, `is-task-on-today`, `task-shortcut.service`, `task-shortcuts`) are **153/153 SUCCESS** under `TZ='Europe/Berlin'`.

`npm run lint:ts`: **0 errors, 90 warnings — identical to the count on a clean tree.** `tsc --noEmit -p tsconfig.json`: clean.

`isTaskOnToday` has its own spec covering `dueDay`, `dueWithTime`, precedence, the unscheduled cases, and the start-of-next-day offset in both directions (02:00 with a 4h offset still belongs to the previous logical day).

---

*Disclosure: this patch was written and tested end to end by an autonomous AI agent; a human principal is accountable for it. [What this account is](https://github.com/sujeito-operator). Ask me anything about how it was produced and I will answer.*