### PR TITLE
fix(supersync): keep the state-replacement guard armed after pruning

### DIFF
--- a/packages/super-sync-server/package.json
+++ b/packages/super-sync-server/package.json
@@ -9,7 +9,7 @@
     "dev": "nodemon --watch src --ext ts --exec ts-node src/index.ts",
     "pretest": "prisma generate",
     "test": "vitest run",
-    "test:integration:postgres": "vitest run --config vitest.integration.config.ts --maxWorkers=1 tests/integration/registration-races.integration.spec.ts tests/integration/clean-slate-atomicity-sql.integration.spec.ts tests/integration/conflict-detection-sql.integration.spec.ts tests/integration/batch-conflict-plan.integration.spec.ts tests/integration/snapshot-vector-clock-sql.integration.spec.ts tests/integration/repair-causality.integration.spec.ts tests/integration/health-alert-db-probe.integration.spec.ts tests/integration/migrate-deploy-db-timeout.integration.spec.ts tests/integration/migrate-deploy-lock-retry.integration.spec.ts tests/integration/old-ops-sweep.integration.spec.ts",
+    "test:integration:postgres": "vitest run --config vitest.integration.config.ts --maxWorkers=1 tests/integration/registration-races.integration.spec.ts tests/integration/clean-slate-atomicity-sql.integration.spec.ts tests/integration/conflict-detection-sql.integration.spec.ts tests/integration/batch-conflict-plan.integration.spec.ts tests/integration/snapshot-vector-clock-sql.integration.spec.ts tests/integration/repair-causality.integration.spec.ts tests/integration/health-alert-db-probe.integration.spec.ts tests/integration/migrate-deploy-db-timeout.integration.spec.ts tests/integration/migrate-deploy-lock-retry.integration.spec.ts tests/integration/old-ops-sweep.integration.spec.ts tests/integration/state-replacement-guard.integration.spec.ts",
     "docker:build": "./scripts/build-and-push.sh",
     "docker:deploy": "./scripts/deploy.sh",
     "docker:deploy:build": "./scripts/deploy.sh --build",

--- a/packages/super-sync-server/scripts/dry-run-old-ops-sweep.ts
+++ b/packages/super-sync-server/scripts/dry-run-old-ops-sweep.ts
@@ -113,9 +113,19 @@ const main = async (): Promise<void> => {
 
   // Safety check 2: while a cached snapshot blob exists, the boundary may
   // never exceed its cursor — pruning above it would eat into the cached
-  // snapshot's replay tail (the restore path). Re-read from user_sync_state
-  // rather than from the CTE columns: derived from `was_capped`, which is
-  // this same comparison, the check is a tautology that always prints OK.
+  // snapshot's replay tail (the restore path).
+  //
+  // Be honest about what this can and cannot catch. Re-reading from
+  // user_sync_state does NOT make it independent: `protected_from_seq` is
+  // itself derived with this same `snapshot_data IS NOT NULL AND
+  // last_snapshot_seq > 0` predicate, so for any affected user the comparison
+  // holds by construction and prints OK. What it does catch is a LIVE RACE —
+  // this query runs in a separate transaction from the plan query, so it fires
+  // if quota recovery moved a boundary underneath the plan. It is not a
+  // verification that the gate mirrors production; only the drift detector in
+  // tests/integration/old-ops-sweep.integration.spec.ts checks that, and
+  // nothing enforces the `causalFullStateSql` ↔ CAUSAL_FULL_STATE_OPERATION_WHERE
+  // lockstep that both sides depend on.
   const blobCursors = await prisma.$queryRaw<
     { user_id: number; last_snapshot_seq: number }[]
   >`

--- a/packages/super-sync-server/src/sync/services/operation-download.service.ts
+++ b/packages/super-sync-server/src/sync/services/operation-download.service.ts
@@ -329,10 +329,24 @@ export class OperationDownloadService {
     // Runs outside the interactive transaction: on large histories the aggregate
     // is slow enough to trip Prisma's transaction timeout. Bounded by
     // `latestSnapshotSeq` (captured inside the transaction) so newly-appended
-    // ops can't perturb the result. Background cleanup may delete rows in this
-    // range between commit and this query; in the common case the snapshot op's
-    // own vector_clock subsumes the deltas it replaces, so the per-client max
-    // is preserved.
+    // ops can't perturb the result.
+    //
+    // Background cleanup deletes rows in this range — since #9688 the old-ops
+    // sweep prunes fleet-wide, and this legacy path is taken by exactly the
+    // cohort it prunes (a missing `latest_full_state_*` marker means the newest
+    // causal op predates the marker migration, so its prefix is cold). The
+    // aggregate therefore CAN come back smaller than it once was: a
+    // BACKUP_IMPORT mints a fresh `{ clientId: 1 }` and subsumes nothing (see
+    // operation-upload.service.ts, `persistMergedFullStateClock`), so do NOT
+    // rely on "the snapshot op's own vector_clock covers the deltas it
+    // replaces" — that assumption is false and is what #8973 exists to avoid.
+    //
+    // It is nonetheless safe: a counter can only change a comparison if an op
+    // carrying it still exists, and every surviving op's clock reaches the
+    // client independently (`allOpClocks` on the download, `existingClock` on a
+    // rejection). Both consumers of `snapshotVectorClock` merge upward only, so
+    // a smaller contribution can only fail to add information that is no longer
+    // on the server anyway.
     const clockRows = await prisma.$queryRaw<
       Array<{ client_id: string; max_counter: bigint }>
     >`

--- a/packages/super-sync-server/src/sync/services/storage-quota.service.ts
+++ b/packages/super-sync-server/src/sync/services/storage-quota.service.ts
@@ -49,12 +49,25 @@ const getOldOpsCleanupDeleteBatchSize = (): number =>
     OLD_OPS_CLEANUP_DELETE_BATCH_SIZE_MAX,
   );
 
+/**
+ * `0` disables the old-ops sweep entirely — the operator brake.
+ *
+ * This deletion is irreversible (hard DELETE, no tombstone) and runs by
+ * default 10s after boot, so an operator who sees the dry-run gate's numbers
+ * and does not like them needs a way to stop it that does not involve patching
+ * the image. `parsePositiveIntegerEnv` rejects 0 and falls back to the default,
+ * which would silently mean "25 000" — the opposite of the intent — so the
+ * disable case is decoded before delegating. Reuses this knob rather than
+ * adding a second setting: "delete at most 0 rows per run" already reads as off.
+ */
 const getOldOpsCleanupMaxDeletedPerRun = (): number =>
-  parsePositiveIntegerEnv(
-    'OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN',
-    OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN,
-    OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN_MAX,
-  );
+  process.env.OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN?.trim() === '0'
+    ? 0
+    : parsePositiveIntegerEnv(
+        'OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN',
+        OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN,
+        OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN_MAX,
+      );
 
 export class StorageQuotaService {
   /**
@@ -411,6 +424,17 @@ export class StorageQuotaService {
   async deleteOldSyncedOpsForAllUsers(
     cutoffTime: number,
   ): Promise<{ totalDeleted: number; affectedUserIds: number[] }> {
+    // Checked before the fleet-wide groupBy below, so a disabled sweep costs
+    // nothing rather than scanning `operations` and then deleting nothing.
+    const deleteBudget = getOldOpsCleanupMaxDeletedPerRun();
+    if (deleteBudget <= 0) {
+      Logger.warn(
+        'Cleanup [old-ops]: disabled via OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN=0; ' +
+          'no operations were pruned and old ops will accumulate until it is re-enabled.',
+      );
+      return { totalDeleted: 0, affectedUserIds: [] };
+    }
+
     // Deletion is authorized by the newest CAUSAL full-state op in the user's
     // operation stream (SYNC_IMPORT / BACKUP_IMPORT / causal REPAIR) — the
     // same op the download path fast-forwards every client past
@@ -477,8 +501,17 @@ export class StorageQuotaService {
     let totalDeleted = 0;
     const affectedUserIds: number[] = [];
     const deleteBatchSize = getOldOpsCleanupDeleteBatchSize();
-    let remainingDeleteBudget = getOldOpsCleanupMaxDeletedPerRun();
+    let remainingDeleteBudget = deleteBudget;
     let cappedUsersWithoutReplayBase = 0;
+    // Every reason the sweep declines a candidate is counted and reported.
+    // #9688 was exactly a fleet-wide exemption from retention that nobody
+    // could see; a silent skip re-creates that blind spot in narrower form.
+    // `skippedFreshPrefix` in particular can pin a user forever: anyone
+    // emitting a causal full-state op more often than once per retention
+    // window is skipped on every single run while their log grows unbounded.
+    let skippedFreshPrefix = 0;
+    let skippedBoundaryAtOne = 0;
+    let drainFailures = 0;
 
     for (const candidate of candidates) {
       if (remainingDeleteBudget <= 0) break;
@@ -515,7 +548,10 @@ export class StorageQuotaService {
         protectedFromSeq = cappedFullStateOp.serverSeq;
       }
 
-      if (protectedFromSeq <= 1) continue;
+      if (protectedFromSeq <= 1) {
+        skippedBoundaryAtOne++;
+        continue;
+      }
 
       // Prune the prefix whole, or not at all. Deletion filters on `receivedAt
       // < cutoffTime` as well as `serverSeq < protectedFromSeq`, so a prefix
@@ -539,7 +575,10 @@ export class StorageQuotaService {
         },
         select: { serverSeq: true },
       });
-      if (freshOpBelowBoundary) continue;
+      if (freshOpBelowBoundary) {
+        skippedFreshPrefix++;
+        continue;
+      }
 
       // Drain this user to completion. The budget gates which users we
       // START, never where we stop inside one: batches delete ascending by
@@ -549,45 +588,62 @@ export class StorageQuotaService {
       // restore target 500 with SNAPSHOT_REPLAY_INCOMPLETE until a later run
       // finishes the prefix. Overshoot is bounded by one user's backlog and
       // costs a longer run; a truncated prefix costs that user their restore.
+      //
+      // One user's DB error must not cost the rest of the fleet a day of
+      // retention, so the drain is scoped: log, count, move to the next user.
+      // A throw mid-drain still leaves that user's prefix truncated — the
+      // batches are separate committed statements, not one transaction — and
+      // the next run repairs it, since the surviving prefix ops are still
+      // older than the (by then later) cutoff.
       let userDeleted = 0;
-      for (;;) {
-        const deletedCount = await this.deleteOldSyncedOpsBatch(
-          candidate.userId,
-          protectedFromSeq,
-          cutoffTime,
-          deleteBatchSize,
-        );
-        if (deletedCount === 0) break;
+      try {
+        for (;;) {
+          const { selectedCount, deletedCount } = await this.deleteOldSyncedOpsBatch(
+            candidate.userId,
+            protectedFromSeq,
+            cutoffTime,
+            deleteBatchSize,
+          );
+          if (selectedCount === 0) break;
 
-        // Mark on the *first* successful batch (not after the loop) so that
-        // if a later batch throws, the counter still self-heals. Without
-        // this, batch-1 commits would leave the counter stale-high until the
-        // next daily pass or process restart.
-        //
-        // Deliberately leave storageUsedBytes stale-high here. A count-based
-        // approximate decrement can undercount users with many tiny ops and
-        // let them bypass quota indefinitely. The marker tells the next
-        // request to run an exact reconcile so drift self-heals.
-        //
-        // NOTE: the marker is in-memory (process-local). A persistent
-        // `users.storage_needs_reconcile` column would survive restarts; see
-        // TODO below.
-        // TODO: persist the reconcile marker in a DB column so it survives
-        // restarts of a single-instance deployment and works correctly across
-        // a multi-instance deployment behind a load balancer.
-        if (userDeleted === 0) {
-          affectedUserIds.push(candidate.userId);
-          this.markNeedsReconcile(candidate.userId);
+          // Mark on the *first* successful batch (not after the loop) so that
+          // if a later batch throws, the counter still self-heals. Without
+          // this, batch-1 commits would leave the counter stale-high until the
+          // next daily pass or process restart.
+          //
+          // Deliberately leave storageUsedBytes stale-high here. A count-based
+          // approximate decrement can undercount users with many tiny ops and
+          // let them bypass quota indefinitely. The marker tells the next
+          // request to run an exact reconcile so drift self-heals.
+          //
+          // NOTE: the marker is in-memory (process-local). A persistent
+          // `users.storage_needs_reconcile` column would survive restarts; see
+          // TODO below.
+          // TODO: persist the reconcile marker in a DB column so it survives
+          // restarts of a single-instance deployment and works correctly across
+          // a multi-instance deployment behind a load balancer.
+          if (userDeleted === 0) {
+            affectedUserIds.push(candidate.userId);
+            this.markNeedsReconcile(candidate.userId);
+          }
+
+          userDeleted += deletedCount;
+          totalDeleted += deletedCount;
+          // May go negative — the outer loop's budget check then stops the run
+          // before starting another user.
+          remainingDeleteBudget -= deletedCount;
+          // Stop on the SELECTED count, never the deleted one. A short delete
+          // means those rows were already gone (concurrent quota recovery),
+          // not that the prefix is drained — see deleteOldSyncedOpsBatch.
+          if (selectedCount < deleteBatchSize) break;
         }
-
-        userDeleted += deletedCount;
-        totalDeleted += deletedCount;
-        // May go negative — the outer loop's budget check then stops the run
-        // before starting another user.
-        remainingDeleteBudget -= deletedCount;
-        // Short-circuit when the batch returned fewer rows than asked for: the
-        // user is empty and another findMany would only confirm zero rows.
-        if (deletedCount < deleteBatchSize) break;
+      } catch (error) {
+        drainFailures++;
+        Logger.error(
+          `Cleanup [old-ops]: drain failed for user ${candidate.userId} ` +
+            `(boundary ${protectedFromSeq}, ${userDeleted} ops deleted before the ` +
+            `error); their prefix may be truncated until the next run: ${error}`,
+        );
       }
     }
 
@@ -596,6 +652,22 @@ export class StorageQuotaService {
         `Cleanup [old-ops]: skipped ${cappedUsersWithoutReplayBase} snapshot-capped user(s) ` +
           'without a causal full-state op at or below their snapshot cursor; ' +
           'their operation histories were left intact.',
+      );
+    }
+
+    if (skippedFreshPrefix > 0 || skippedBoundaryAtOne > 0) {
+      Logger.info(
+        `Cleanup [old-ops]: retained ${skippedFreshPrefix} user(s) whose prefix still ` +
+          `holds an op inside retention and ${skippedBoundaryAtOne} whose boundary is at ` +
+          'seq 1; both are expected, but a fresh-prefix count that never falls means ' +
+          'those users are permanently exempt from retention.',
+      );
+    }
+
+    if (drainFailures > 0) {
+      Logger.warn(
+        `Cleanup [old-ops]: ${drainFailures} user(s) failed mid-drain and were skipped; ` +
+          'the run continued for the remaining users.',
       );
     }
 
@@ -611,16 +683,35 @@ export class StorageQuotaService {
     return { totalDeleted, affectedUserIds };
   }
 
+  /**
+   * Delete one batch of the user's aged prefix.
+   *
+   * Returns BOTH counts because they answer different questions and are not
+   * interchangeable. `selectedCount` is how many doomed rows this batch found,
+   * and is the only sound basis for "is this user drained?": a short
+   * `deletedCount` means those rows were already gone (quota recovery deleted
+   * them concurrently — the sweep does not hold `runWithStorageUsageLock`,
+   * the upload path does), NOT that the prefix is exhausted. Reading a short
+   * `deletedCount` as "drained" stops the loop mid-prefix and leaves a plain
+   * delta as the lowest surviving row, which is the SNAPSHOT_REPLAY_INCOMPLETE
+   * state the whole-or-nothing rule exists to prevent. `deletedCount` is what
+   * actually left the table, so it — and only it — feeds the budget and the
+   * storage counter.
+   */
   private async deleteOldSyncedOpsBatch(
     userId: number,
     protectedFromSeq: number,
     cutoffTime: number,
     limit: number,
-  ): Promise<number> {
+  ): Promise<{ selectedCount: number; deletedCount: number }> {
     const doomedOps = await prisma.operation.findMany({
       where: {
         userId,
         serverSeq: { lt: protectedFromSeq },
+        // Not redundant with the caller's fresh-op probe: a concurrent
+        // deleteAllUserData / clean slate resets lastSeq to 0, so the user's
+        // re-import reuses low seq numbers. Only this filter stops a stale
+        // protectedFromSeq from shredding that brand-new history.
         receivedAt: { lt: BigInt(cutoffTime) },
       },
       orderBy: { serverSeq: 'asc' },
@@ -628,7 +719,7 @@ export class StorageQuotaService {
       select: { id: true },
     });
 
-    if (doomedOps.length === 0) return 0;
+    if (doomedOps.length === 0) return { selectedCount: 0, deletedCount: 0 };
 
     const result = await prisma.operation.deleteMany({
       where: {
@@ -637,7 +728,7 @@ export class StorageQuotaService {
       },
     });
 
-    return result.count;
+    return { selectedCount: doomedOps.length, deletedCount: result.count };
   }
 
   /**

--- a/packages/super-sync-server/src/sync/sync.service.ts
+++ b/packages/super-sync-server/src/sync/sync.service.ts
@@ -26,6 +26,45 @@ import {
   type SnapshotDedupResponse,
 } from './services';
 import type { ValidationResult } from './services/validation.service';
+
+/**
+ * Newest operation that replaced the user's full state, for the stale-cursor
+ * upload guard.
+ *
+ * Prefer a retained SYNC_IMPORT/BACKUP_IMPORT, then fall back to the newest
+ * causal REPAIR. The fallback is load-bearing: deletion can prune an import out
+ * from under a later REPAIR — quota recovery
+ * (`deleteOldestRestorePointAndOps`, which deletes up to and including the
+ * OLDEST restore point) and the daily old-ops sweep (which deletes everything
+ * below the NEWEST causal boundary) both do it. Without the fallback the
+ * remaining REPAIR is invisible here, the guard resolves to "none", and the
+ * caller PERSISTS that as 0 — permanently disarming the guard for that account
+ * and letting a client whose cursor predates the replacement upload deltas
+ * built on superseded state.
+ *
+ * The second query only runs for the rare account holding no import at all, so
+ * the ordinary upload path still costs a single indexed lookup.
+ */
+const resolveRetainedReplacementSeq = async (
+  db: Prisma.TransactionClient,
+  userId: number,
+): Promise<number | null> => {
+  const retainedImport = await db.operation.findFirst({
+    where: { userId, opType: { in: ['SYNC_IMPORT', 'BACKUP_IMPORT'] } },
+    orderBy: { serverSeq: 'desc' },
+    select: { serverSeq: true },
+  });
+  if (retainedImport) {
+    return retainedImport.serverSeq;
+  }
+  const retainedCausalRepair = await db.operation.findFirst({
+    where: { userId, opType: 'REPAIR', repairBaseServerSeq: { not: null } },
+    orderBy: { serverSeq: 'desc' },
+    select: { serverSeq: true },
+  });
+  return retainedCausalRepair?.serverSeq ?? null;
+};
+
 const getPrismaP2002TargetTokens = (
   err: Prisma.PrismaClientKnownRequestError,
 ): string[] => {
@@ -236,18 +275,14 @@ export class SyncService {
               // while migrations run. Resolve retained replacements lazily
               // after the new process owns the write path, then persist the
               // answer for subsequent uploads.
-              const retainedReplacement = await tx.operation.findFirst({
-                where: {
-                  userId,
-                  opType: { in: ['SYNC_IMPORT', 'BACKUP_IMPORT'] },
-                },
-                orderBy: { serverSeq: 'desc' },
-                select: { serverSeq: true },
-              });
+              const retainedReplacementSeq = await resolveRetainedReplacementSeq(
+                tx,
+                userId,
+              );
               // Zero is a resolved "no retained replacement" sentinel. Keeping
               // null exclusively for unresolved upgrade rows avoids repeating
               // this indexed lookup on every upload for ordinary accounts.
-              latestStateReplacementSeq = retainedReplacement?.serverSeq ?? 0;
+              latestStateReplacementSeq = retainedReplacementSeq ?? 0;
               await tx.userSyncState.update({
                 where: { userId },
                 data: { latestStateReplacementSeq },
@@ -749,15 +784,7 @@ export class SyncService {
     if (typeof latestStateReplacementSeq === 'number') {
       return latestStateReplacementSeq;
     }
-    const retainedReplacement = await prisma.operation.findFirst({
-      where: {
-        userId,
-        opType: { in: ['SYNC_IMPORT', 'BACKUP_IMPORT'] },
-      },
-      orderBy: { serverSeq: 'desc' },
-      select: { serverSeq: true },
-    });
-    return retainedReplacement?.serverSeq ?? null;
+    return resolveRetainedReplacementSeq(prisma, userId);
   }
 
   cacheOpsRequestResults(

--- a/packages/super-sync-server/tests/integration/old-ops-sweep.integration.spec.ts
+++ b/packages/super-sync-server/tests/integration/old-ops-sweep.integration.spec.ts
@@ -28,9 +28,11 @@ import { prisma } from '../../src/db';
 import { SyncService } from '../../src/sync/sync.service';
 import {
   affectedUsers,
+  causalFullStateSql,
   fetchOldOpsSweepPlan,
   toNum,
 } from '../../scripts/old-ops-sweep-plan';
+import { CAUSAL_FULL_STATE_OPERATION_WHERE } from '../../src/sync/sync.types';
 
 const DATABASE_URL = process.env.DATABASE_URL;
 const describeWithDb = DATABASE_URL ? describe : describe.skip;
@@ -44,6 +46,7 @@ const ENCRYPTED_USER_ID = 99985;
 const NO_STATE_ROW_USER_ID = 99986;
 const STUCK_SNAPSHOT_USER_ID = 99987;
 const SEQ1_IMPORT_ONLY_USER_ID = 99988;
+const PREDICATE_MATRIX_USER_ID = 99989;
 const ALL_USER_IDS = [
   LAPSED_USER_ID,
   SNAPSHOTLESS_USER_ID,
@@ -53,6 +56,7 @@ const ALL_USER_IDS = [
   NO_STATE_ROW_USER_ID,
   STUCK_SNAPSHOT_USER_ID,
   SEQ1_IMPORT_ONLY_USER_ID,
+  PREDICATE_MATRIX_USER_ID,
 ];
 
 describeWithDb('Old-ops sweep (PostgreSQL)', () => {
@@ -523,5 +527,62 @@ describeWithDb('Old-ops sweep (PostgreSQL)', () => {
     expect(affectedUserIds.filter((id) => seededUserIds.includes(id)).sort()).toEqual(
       [LAPSED_USER_ID, NO_STATE_ROW_USER_ID].sort(),
     );
+  });
+  /**
+   * The gate re-implements the sweep's authorizing predicate in raw SQL, so the
+   * two must stay in lockstep or the read-only pre-flight measures a different
+   * sweep than the one that deletes. The fixture-based drift test above only
+   * covers the shapes it happens to seed; this walks the whole (opType x
+   * repairBaseServerSeq) matrix and checks both against a third, independent
+   * statement of the rule so a matching pair of wrong predicates still fails.
+   */
+  it('the gate SQL and the Prisma causal predicate agree on every op shape', async () => {
+    const opTypes = [
+      'CRT',
+      'UPD',
+      'DEL',
+      'MOV',
+      'SYNC_IMPORT',
+      'BACKUP_IMPORT',
+      'REPAIR',
+    ];
+    // 0 is the load-bearing base cursor: a REPAIR over an empty stream is
+    // causal, so any predicate spelled `> 0` rather than `IS NOT NULL` diverges
+    // here and nowhere else.
+    const repairBases: Array<number | null> = [null, 0, 7];
+    const expectedCausalSeqs: number[] = [];
+    let seq = 0;
+    for (const opType of opTypes) {
+      for (const repairBaseServerSeq of repairBases) {
+        seq++;
+        await seedOp(PREDICATE_MATRIX_USER_ID, seq, { opType, repairBaseServerSeq });
+        const isCausal =
+          opType === 'SYNC_IMPORT' ||
+          opType === 'BACKUP_IMPORT' ||
+          (opType === 'REPAIR' && repairBaseServerSeq !== null);
+        if (isCausal) {
+          expectedCausalSeqs.push(seq);
+        }
+      }
+    }
+
+    const viaPrisma = (
+      await prisma.operation.findMany({
+        where: { userId: PREDICATE_MATRIX_USER_ID, ...CAUSAL_FULL_STATE_OPERATION_WHERE },
+        orderBy: { serverSeq: 'asc' },
+        select: { serverSeq: true },
+      })
+    ).map((op) => op.serverSeq);
+    const viaGate = (
+      await prisma.$queryRaw<Array<{ server_seq: number }>>`
+        SELECT o.server_seq
+        FROM operations o
+        WHERE o.user_id = ${PREDICATE_MATRIX_USER_ID} AND ${causalFullStateSql('o')}
+        ORDER BY o.server_seq ASC
+      `
+    ).map((row) => row.server_seq);
+
+    expect(viaGate).toEqual(viaPrisma);
+    expect(viaPrisma).toEqual(expectedCausalSeqs);
   });
 });

--- a/packages/super-sync-server/tests/integration/old-ops-sweep.integration.spec.ts
+++ b/packages/super-sync-server/tests/integration/old-ops-sweep.integration.spec.ts
@@ -47,6 +47,7 @@ const NO_STATE_ROW_USER_ID = 99986;
 const STUCK_SNAPSHOT_USER_ID = 99987;
 const SEQ1_IMPORT_ONLY_USER_ID = 99988;
 const PREDICATE_MATRIX_USER_ID = 99989;
+const MULTI_BATCH_USER_ID = 99990;
 const ALL_USER_IDS = [
   LAPSED_USER_ID,
   SNAPSHOTLESS_USER_ID,
@@ -57,6 +58,7 @@ const ALL_USER_IDS = [
   STUCK_SNAPSHOT_USER_ID,
   SEQ1_IMPORT_ONLY_USER_ID,
   PREDICATE_MATRIX_USER_ID,
+  MULTI_BATCH_USER_ID,
 ];
 
 describeWithDb('Old-ops sweep (PostgreSQL)', () => {
@@ -584,5 +586,41 @@ describeWithDb('Old-ops sweep (PostgreSQL)', () => {
 
     expect(viaGate).toEqual(viaPrisma);
     expect(viaPrisma).toEqual(expectedCausalSeqs);
+  });
+  /**
+   * The drain loop continues on the SELECTED row count, and it only ever
+   * continues past the first batch when a user's aged prefix is longer than
+   * OLD_OPS_CLEANUP_DELETE_BATCH_SIZE (5000 by default). Every other fixture
+   * here is a handful of rows, so that continuation — the line that decides
+   * whether a prefix is drained whole or left truncated with a plain delta
+   * lowest — has never executed against real rows. Shrink the batch instead of
+   * seeding 5000 ops.
+   */
+  it('drains a prefix longer than one delete batch whole, across batches', async () => {
+    const previousBatchSize = process.env.OLD_OPS_CLEANUP_DELETE_BATCH_SIZE;
+    process.env.OLD_OPS_CLEANUP_DELETE_BATCH_SIZE = '2';
+    try {
+      for (let seq = 1; seq <= 9; seq++) {
+        await seedOp(MULTI_BATCH_USER_ID, seq);
+      }
+      await seedImportOp(MULTI_BATCH_USER_ID, 10);
+      await seedOp(MULTI_BATCH_USER_ID, 11);
+      await prisma.userSyncState.create({
+        data: { userId: MULTI_BATCH_USER_ID, lastSeq: 11 },
+      });
+
+      const result = await runSweep();
+
+      // 9 prefix ops removed over 5 batches of 2; stopping after any one of
+      // them would leave a plain delta as the lowest surviving row.
+      expect(result.totalDeleted).toBe(9);
+      expect(await survivingSeqs(MULTI_BATCH_USER_ID)).toEqual([10, 11]);
+    } finally {
+      if (previousBatchSize === undefined) {
+        delete process.env.OLD_OPS_CLEANUP_DELETE_BATCH_SIZE;
+      } else {
+        process.env.OLD_OPS_CLEANUP_DELETE_BATCH_SIZE = previousBatchSize;
+      }
+    }
   });
 });

--- a/packages/super-sync-server/tests/integration/state-replacement-guard.integration.spec.ts
+++ b/packages/super-sync-server/tests/integration/state-replacement-guard.integration.spec.ts
@@ -1,0 +1,220 @@
+/**
+ * PostgreSQL coverage for the stale-cursor upload guard surviving history
+ * pruning.
+ *
+ * `latestStateReplacementSeq` is resolved lazily from the operation stream and
+ * then PERSISTED, so a lookup that cannot see the surviving boundary does not
+ * just answer one request wrong — it writes the wrong answer down. Both
+ * pruning paths can delete a SYNC_IMPORT out from under a later causal REPAIR:
+ *   - quota recovery (`deleteOldestRestorePointAndOps`) deletes up to and
+ *     including the OLDEST restore point,
+ *   - the daily old-ops sweep deletes everything below the NEWEST causal
+ *     boundary (#9688/#9693, which widened it from over-quota accounts to the
+ *     whole fleet).
+ * With only the REPAIR left, an import-only lookup resolves to "none", persists
+ * 0, and a client whose cursor predates the replacement can upload deltas built
+ * on superseded state — resurrecting what the replacement removed.
+ *
+ * Run with:
+ *   DATABASE_URL=postgresql://supersync:superpassword@localhost:55432/supersync_db \
+ *     npx vitest run --config vitest.integration.config.ts \
+ *     tests/integration/state-replacement-guard.integration.spec.ts
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { uuidv7 } from 'uuidv7';
+import { prisma } from '../../src/db';
+import { SyncService } from '../../src/sync/sync.service';
+import { Operation, STATE_REPLACEMENT_REQUIRED_ERROR } from '../../src/sync/sync.types';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeWithDb = DATABASE_URL ? describe : describe.skip;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const PRUNED_USER_ID = 99971;
+const LEGACY_REPAIR_USER_ID = 99972;
+const ALL_USER_IDS = [PRUNED_USER_ID, LEGACY_REPAIR_USER_ID];
+
+describeWithDb('State-replacement guard vs history pruning (PostgreSQL)', () => {
+  const now = Date.now();
+  const cutoffTime = now - 50 * DAY_MS;
+  const oldReceivedAt = BigInt(now - 60 * DAY_MS);
+
+  const seedOp = async (
+    userId: number,
+    serverSeq: number,
+    overrides: { opType?: string; repairBaseServerSeq?: number | null } = {},
+  ): Promise<void> => {
+    const opType = overrides.opType ?? 'CRT';
+    const isFullState = opType !== 'CRT';
+    await prisma.operation.create({
+      data: {
+        id: `guard-op-${userId}-${serverSeq}`,
+        userId,
+        clientId: `guard-client-${userId}`,
+        serverSeq,
+        actionType: isFullState ? 'LOAD_ALL_DATA' : '[Task] Add',
+        opType,
+        entityType: isFullState ? 'ALL' : 'TASK',
+        entityId: isFullState ? null : `task-${serverSeq}`,
+        payload: isFullState
+          ? { appDataComplete: { TASK: {} } }
+          : { title: 'guard fixture' },
+        vectorClock: { [`guard-client-${userId}`]: serverSeq },
+        schemaVersion: 1,
+        clientTimestamp: oldReceivedAt,
+        receivedAt: oldReceivedAt,
+        repairBaseServerSeq: overrides.repairBaseServerSeq ?? null,
+        isPayloadEncrypted: false,
+      },
+    });
+  };
+
+  /**
+   * Import at seq 1, deltas at 2-3, a causal REPAIR at 4 and a tail at 5 — all
+   * aged past the retention cutoff, and a sync-state row whose replacement
+   * cursor is still unresolved (the lazily-migrated shape). Both pruning paths
+   * below delete the import and keep the REPAIR.
+   */
+  const seedImportBelowCausalRepair = async (userId: number): Promise<void> => {
+    await seedOp(userId, 1, { opType: 'SYNC_IMPORT' });
+    await seedOp(userId, 2);
+    await seedOp(userId, 3);
+    await seedOp(userId, 4, { opType: 'REPAIR', repairBaseServerSeq: 3 });
+    await seedOp(userId, 5);
+    await prisma.userSyncState.create({
+      data: { userId, lastSeq: 5, latestStateReplacementSeq: null },
+    });
+  };
+
+  /** A delta from a client whose cursor predates every replacement. */
+  const staleDelta = (): Operation => ({
+    id: uuidv7(),
+    clientId: 'stale-client',
+    actionType: '[Task] Add',
+    opType: 'CRT',
+    entityType: 'TASK',
+    entityId: uuidv7(),
+    payload: { title: 'built on superseded state' },
+    vectorClock: { 'stale-client': 1 },
+    timestamp: Date.now(),
+    schemaVersion: 1,
+  });
+
+  const uploadFromCursorZero = (
+    service: SyncService,
+    userId: number,
+  ): ReturnType<SyncService['uploadOps']> =>
+    service.uploadOps(
+      userId,
+      'stale-client',
+      [staleDelta()],
+      false,
+      undefined,
+      undefined,
+      false,
+      0,
+    );
+
+  const survivingOps = async (userId: number): Promise<string[]> =>
+    (
+      await prisma.operation.findMany({
+        where: { userId },
+        orderBy: { serverSeq: 'asc' },
+        select: { serverSeq: true, opType: true },
+      })
+    ).map((op) => `${op.serverSeq}:${op.opType}`);
+
+  beforeAll(async () => {
+    await prisma.user.deleteMany({ where: { id: { in: ALL_USER_IDS } } });
+    for (const id of ALL_USER_IDS) {
+      await prisma.user.create({
+        data: { id, email: `guard-test-${id}@test.local`, isVerified: 1 },
+      });
+    }
+  });
+
+  afterAll(async () => {
+    await prisma.user.deleteMany({ where: { id: { in: ALL_USER_IDS } } });
+    await prisma.$disconnect();
+  });
+
+  beforeEach(async () => {
+    await prisma.operation.deleteMany({ where: { userId: { in: ALL_USER_IDS } } });
+    await prisma.userSyncState.deleteMany({ where: { userId: { in: ALL_USER_IDS } } });
+  });
+
+  it('rejects a stale cursor while the import is still retained', async () => {
+    await seedImportBelowCausalRepair(PRUNED_USER_ID);
+    const service = new SyncService({});
+
+    await expect(service.getLatestStateReplacementSeq(PRUNED_USER_ID)).resolves.toBe(1);
+    const results = await uploadFromCursorZero(service, PRUNED_USER_ID);
+
+    expect(results[0].accepted).toBe(false);
+    expect(results[0].error).toBe(STATE_REPLACEMENT_REQUIRED_ERROR);
+  });
+
+  it('keeps rejecting after the old-ops sweep prunes the import below the REPAIR', async () => {
+    await seedImportBelowCausalRepair(PRUNED_USER_ID);
+    const service = new SyncService({});
+
+    await service.deleteOldSyncedOpsForAllUsers(cutoffTime);
+    expect(await survivingOps(PRUNED_USER_ID)).toEqual(['4:REPAIR', '5:CRT']);
+
+    await expect(service.getLatestStateReplacementSeq(PRUNED_USER_ID)).resolves.toBe(4);
+    const results = await uploadFromCursorZero(service, PRUNED_USER_ID);
+
+    expect(results[0].accepted).toBe(false);
+    expect(results[0].error).toBe(STATE_REPLACEMENT_REQUIRED_ERROR);
+    // The resolved answer is written down, so a wrong one would disarm the
+    // guard for every later upload, not just this one.
+    const state = await prisma.userSyncState.findUnique({
+      where: { userId: PRUNED_USER_ID },
+      select: { latestStateReplacementSeq: true },
+    });
+    expect(state?.latestStateReplacementSeq).toBe(4);
+  });
+
+  it('keeps rejecting after quota recovery prunes the import below the REPAIR', async () => {
+    await seedImportBelowCausalRepair(PRUNED_USER_ID);
+    const service = new SyncService({});
+
+    const cleanup = await service.deleteOldestRestorePointAndOps(PRUNED_USER_ID);
+    expect(cleanup.success).toBe(true);
+    expect(await survivingOps(PRUNED_USER_ID)).toEqual([
+      '2:CRT',
+      '3:CRT',
+      '4:REPAIR',
+      '5:CRT',
+    ]);
+
+    await expect(service.getLatestStateReplacementSeq(PRUNED_USER_ID)).resolves.toBe(4);
+    const results = await uploadFromCursorZero(service, PRUNED_USER_ID);
+
+    expect(results[0].accepted).toBe(false);
+    expect(results[0].error).toBe(STATE_REPLACEMENT_REQUIRED_ERROR);
+  });
+
+  it('does not arm the guard from a legacy REPAIR with no causal base', async () => {
+    // Legacy REPAIR rows carry no base cursor, so they are not proven to
+    // supersede their prefix (CAUSAL_FULL_STATE_OPERATION_WHERE excludes them
+    // everywhere else too). They must stay invisible to the guard.
+    await seedOp(LEGACY_REPAIR_USER_ID, 1, { opType: 'REPAIR' });
+    await seedOp(LEGACY_REPAIR_USER_ID, 2);
+    await prisma.userSyncState.create({
+      data: {
+        userId: LEGACY_REPAIR_USER_ID,
+        lastSeq: 2,
+        latestStateReplacementSeq: null,
+      },
+    });
+    const service = new SyncService({});
+
+    await expect(
+      service.getLatestStateReplacementSeq(LEGACY_REPAIR_USER_ID),
+    ).resolves.toBeNull();
+    const results = await uploadFromCursorZero(service, LEGACY_REPAIR_USER_ID);
+
+    expect(results[0].accepted).toBe(true);
+  });
+});

--- a/packages/super-sync-server/tests/sync.service.spec.ts
+++ b/packages/super-sync-server/tests/sync.service.spec.ts
@@ -3488,7 +3488,53 @@ describe('SyncService', () => {
       expect(survivors[0].opType).toBe('SYNC_IMPORT');
     });
 
-    it('marks user for reconcile when a later batch throws mid-loop', async () => {
+    it('deletes nothing when the per-run budget is set to 0', async () => {
+      const service = getSyncService();
+      process.env.OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN = '0';
+      const cutoffTime = Date.now() - 50 * 24 * 60 * 60 * 1000;
+
+      for (let i = 1; i <= 3; i++) {
+        testState.operations.set(`old-op-${i}`, {
+          id: `old-op-${i}`,
+          userId,
+          clientId,
+          serverSeq: i,
+          actionType: 'ADD',
+          opType: 'CRT',
+          entityType: 'TASK',
+          entityId: `t${i}`,
+          payload: {},
+          vectorClock: {},
+          schemaVersion: 1,
+          clientTimestamp: BigInt(Date.now()),
+          receivedAt: BigInt(cutoffTime - 1),
+          isPayloadEncrypted: false,
+          syncImportReason: null,
+        });
+      }
+      seedFullStateOp(userId, 4, BigInt(cutoffTime - 1));
+
+      const groupBySpy = vi.mocked(prisma.operation.groupBy);
+      groupBySpy.mockClear();
+      try {
+        const { totalDeleted, affectedUserIds } =
+          await service.deleteOldSyncedOpsForAllUsers(cutoffTime);
+
+        // The operator brake. `parsePositiveIntegerEnv` rejects 0 and falls
+        // back to the default, so without the explicit decode this knob would
+        // silently mean 25 000 — and there is no other way to stop an
+        // irreversible, default-on sweep short of patching the image.
+        expect(totalDeleted).toBe(0);
+        expect(affectedUserIds).toEqual([]);
+        expect(testState.operations.size).toBe(4);
+        // Disabled must also cost nothing: no fleet-wide scan of `operations`.
+        expect(groupBySpy).not.toHaveBeenCalled();
+      } finally {
+        delete process.env.OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN;
+      }
+    });
+
+    it('keeps draining when a concurrent delete shrinks a batch row count', async () => {
       const service = getSyncService();
       process.env.OLD_OPS_CLEANUP_DELETE_BATCH_SIZE = '50';
       process.env.OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN = '250';
@@ -3523,12 +3569,113 @@ describe('SyncService', () => {
         snapshotAt: BigInt(Date.now()),
       });
 
+      // Quota recovery (deleteOldestRestorePointAndOps) runs unlocked against
+      // the same user while the sweep is mid-drain — the sweep does NOT take
+      // runWithStorageUsageLock, the upload path does. Simulate it landing
+      // between the sweep's findMany (which selected 50 ids) and its
+      // deleteMany: two of those rows are already gone, so deleteMany reports
+      // 48. That is fewer rows than the batch size, but the user is NOT empty.
+      const deleteManySpy = vi.mocked(prisma.operation.deleteMany) as unknown as {
+        getMockImplementation: () => (args: any) => Promise<{ count: number }>;
+        mockImplementation: (fn: (args: any) => Promise<{ count: number }>) => void;
+      };
+      const originalDeleteMany = deleteManySpy.getMockImplementation();
+      let interceptedBatches = 0;
+      deleteManySpy.mockImplementation(async (args: any) => {
+        if (interceptedBatches === 0) {
+          interceptedBatches += 1;
+          for (const id of (args.where?.id?.in ?? []).slice(0, 2)) {
+            testState.operations.delete(id);
+          }
+        }
+        return originalDeleteMany(args);
+      });
+
+      try {
+        await service.deleteOldSyncedOpsForAllUsers(cutoffTime);
+      } finally {
+        deleteManySpy.mockImplementation(originalDeleteMany);
+        delete process.env.OLD_OPS_CLEANUP_DELETE_BATCH_SIZE;
+        delete process.env.OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN;
+      }
+
+      // A short row count must mean "these rows are gone", never "this user is
+      // drained". Reading it as the latter stops the loop mid-prefix and
+      // leaves a plain CRT delta as the lowest surviving row — the exact
+      // SNAPSHOT_REPLAY_INCOMPLETE state the whole-or-nothing rule exists to
+      // prevent, reached here through concurrency instead of the budget.
+      const survivors = Array.from(testState.operations.values())
+        .filter((op) => op.userId === userId)
+        .sort((a, b) => a.serverSeq - b.serverSeq);
+      expect(survivors.map((op) => op.serverSeq)).toEqual([totalOps + 1]);
+      expect(survivors[0].opType).toBe('SYNC_IMPORT');
+    });
+
+    it('marks user for reconcile and keeps going when a batch throws mid-loop', async () => {
+      const service = getSyncService();
+      process.env.OLD_OPS_CLEANUP_DELETE_BATCH_SIZE = '50';
+      process.env.OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN = '250';
+      const totalOps = 120;
+      const cutoffTime = Date.now() - 50 * 24 * 60 * 60 * 1000;
+
+      for (let i = 1; i <= totalOps; i++) {
+        testState.operations.set(`old-op-${i}`, {
+          id: `old-op-${i}`,
+          userId,
+          clientId,
+          serverSeq: i,
+          actionType: 'ADD',
+          opType: 'CRT',
+          entityType: 'TASK',
+          entityId: `t${i}`,
+          payload: {},
+          vectorClock: {},
+          schemaVersion: 1,
+          clientTimestamp: BigInt(Date.now()),
+          receivedAt: BigInt(cutoffTime - 1),
+          isPayloadEncrypted: false,
+          syncImportReason: null,
+        });
+      }
+      seedFullStateOp(userId, totalOps + 1, BigInt(cutoffTime - 1));
+
+      testState.userSyncStates.set(userId, {
+        userId,
+        lastSeq: totalOps + 1,
+        lastSnapshotSeq: totalOps + 1,
+        snapshotAt: BigInt(Date.now()),
+      });
+
+      // A second user, ordered after the failing one, proves one user's DB
+      // error does not cost the rest of the fleet a day of retention.
+      const otherUserId = userId + 1;
+      testState.operations.set('other-old-op-1', {
+        id: 'other-old-op-1',
+        userId: otherUserId,
+        clientId: `client-${otherUserId}`,
+        serverSeq: 1,
+        actionType: 'ADD',
+        opType: 'CRT',
+        entityType: 'TASK',
+        entityId: 'ot1',
+        payload: {},
+        vectorClock: {},
+        schemaVersion: 1,
+        clientTimestamp: BigInt(Date.now()),
+        receivedAt: BigInt(cutoffTime - 1),
+        isPayloadEncrypted: false,
+        syncImportReason: null,
+      });
+      seedFullStateOp(otherUserId, 2, BigInt(cutoffTime - 1));
+
       // Let the first batch run normally, then simulate a transient DB error
       // on the second batch. Pre-fix this would leave the storage counter
       // stale-high with no reconcile signal until the next daily pass.
       const serviceWithPrivates = service as unknown as {
         storageQuotaService: {
-          deleteOldSyncedOpsBatch: (...args: unknown[]) => Promise<number>;
+          deleteOldSyncedOpsBatch: (
+            ...args: unknown[]
+          ) => Promise<{ selectedCount: number; deletedCount: number }>;
           needsReconcile: (userId: number) => boolean;
         };
       };
@@ -3540,20 +3687,30 @@ describe('SyncService', () => {
         async (...args: unknown[]) => {
           callCount += 1;
           if (callCount === 1) return originalBatch(...args);
-          throw new Error('simulated transient DB failure');
+          if (args[0] === userId) throw new Error('simulated transient DB failure');
+          return originalBatch(...args);
         },
       );
 
-      await expect(service.deleteOldSyncedOpsForAllUsers(cutoffTime)).rejects.toThrow(
-        'simulated transient DB failure',
-      );
+      const { affectedUserIds } = await service.deleteOldSyncedOpsForAllUsers(cutoffTime);
       delete process.env.OLD_OPS_CLEANUP_DELETE_BATCH_SIZE;
       delete process.env.OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN;
+
+      // The failing user is contained, not fatal to the run: the sweep logged
+      // and moved on, so the second user was still serviced.
+      expect(affectedUserIds).toContain(otherUserId);
+      expect(
+        Array.from(testState.operations.values()).filter(
+          (op) => op.userId === otherUserId,
+        ),
+      ).toHaveLength(1);
 
       // First batch committed deletes; the user must still be marked so
       // the next request reconciles the now-stale-high counter.
       expect(storageQuotaService.needsReconcile(userId)).toBe(true);
-      expect(testState.operations.size).toBe(totalOps + 1 - 50);
+      expect(
+        Array.from(testState.operations.values()).filter((op) => op.userId === userId),
+      ).toHaveLength(totalOps + 1 - 50);
     });
 
     it('shares the per-run budget across users; tail users wait for next pass', async () => {

--- a/packages/super-sync-server/tests/sync.service.spec.ts
+++ b/packages/super-sync-server/tests/sync.service.spec.ts
@@ -18,6 +18,7 @@ vi.mock('../src/db', async () => {
     isEntityArrayBranchQuery,
     entityArrayBranchRows,
     mockOperationGroupByMaxSeq,
+    mockOperationFindFirstCausalRepair,
     mockOperationFindFirstFreshBelowBoundary,
     mockUserSyncStateFindMany,
     matchesOperationAlternative,
@@ -87,6 +88,8 @@ vi.mock('../src/db', async () => {
             applyOperationSelect(state.operations.get(args.where.id), args.select) || null
           );
         }
+        const causalRepair = mockOperationFindFirstCausalRepair(state.operations, args);
+        if (causalRepair !== undefined) return causalRepair;
         if (args.where?.opType?.in) {
           const ops = Array.from(state.operations.values())
             .filter((op: any) => args.where.userId === op.userId)
@@ -531,6 +534,8 @@ vi.mock('../src/db', async () => {
             args,
           );
           if (freshBelowBoundary !== undefined) return freshBelowBoundary;
+          const causalRepair = mockOperationFindFirstCausalRepair(state.operations, args);
+          if (causalRepair !== undefined) return causalRepair;
           if (args.where?.opType?.in) {
             const ops = Array.from(state.operations.values())
               .filter((op: any) => args.where.userId === op.userId)
@@ -999,6 +1004,61 @@ describe('SyncService', () => {
 
       await expect(service.getLatestStateReplacementSeq(userId)).resolves.toBe(3);
       await expect(service.getLatestStateReplacementSeq(userId + 1)).resolves.toBeNull();
+    });
+
+    /**
+     * Both pruning paths (the daily old-ops sweep and quota recovery) can
+     * delete a SYNC_IMPORT out from under a later causal REPAIR. The resolved
+     * cursor is persisted, so an import-only lookup does not just answer one
+     * request wrong — it writes 0 down and disarms the guard for good.
+     */
+    const seedRepair = (serverSeq: number, repairBaseServerSeq: number | null): void => {
+      const repair = makeOp({
+        id: `retained-repair-${serverSeq}`,
+        opType: 'REPAIR',
+        entityType: 'ALL',
+        entityId: undefined,
+      });
+      testState.operations.set(repair.id, {
+        ...repair,
+        userId,
+        serverSeq,
+        entityId: null,
+        entityIds: [],
+        payloadBytes: BigInt(1),
+        clientTimestamp: BigInt(repair.timestamp),
+        receivedAt: BigInt(repair.timestamp),
+        isPayloadEncrypted: false,
+        syncImportReason: null,
+        repairBaseServerSeq,
+      });
+    };
+
+    it('falls back to the newest causal REPAIR when no import is retained', async () => {
+      const service = new SyncService();
+      seedRepair(3, 2);
+      testState.userSyncStates.set(userId, {
+        userId,
+        lastSeq: 4,
+        latestStateReplacementSeq: null,
+      });
+
+      await expect(service.getLatestStateReplacementSeq(userId)).resolves.toBe(3);
+    });
+
+    it('ignores a legacy REPAIR with no causal base', async () => {
+      // Legacy REPAIR rows carry no base cursor, so they are not proven to
+      // supersede their prefix and must stay invisible to the guard — the same
+      // exclusion CAUSAL_FULL_STATE_OPERATION_WHERE makes everywhere else.
+      const service = new SyncService();
+      seedRepair(3, null);
+      testState.userSyncStates.set(userId, {
+        userId,
+        lastSeq: 4,
+        latestStateReplacementSeq: null,
+      });
+
+      await expect(service.getLatestStateReplacementSeq(userId)).resolves.toBeNull();
     });
 
     it('persists a resolved no-replacement sentinel on the upload path', async () => {

--- a/packages/super-sync-server/tests/sync.service.test-state.ts
+++ b/packages/super-sync-server/tests/sync.service.test-state.ts
@@ -216,6 +216,42 @@ export function mockOperationFindFirstFreshBelowBoundary(
   return match ? applyOperationSelect(match, args.select) : null;
 }
 
+/**
+ * Mocks the causal-REPAIR fallback the state-replacement guard uses when no
+ * SYNC_IMPORT/BACKUP_IMPORT survives:
+ * `findFirst({ where: { userId, opType: 'REPAIR', repairBaseServerSeq: { not: null } } })`.
+ *
+ * Returns `undefined` when `args` is not that shape so callers fall through to
+ * their own branches. Spelled out because both hand-written findFirst mocks
+ * decode only `opType.in` and `OR` lists: a scalar `opType` falls through to
+ * `null`, which is indistinguishable from "no boundary survives" — precisely
+ * the wrong answer the fallback exists to prevent. The unit suite would then
+ * stay green whether the fallback works or not.
+ */
+export function mockOperationFindFirstCausalRepair(
+  operations: Map<string, any>,
+  args: {
+    where?: {
+      userId?: number;
+      opType?: unknown;
+      repairBaseServerSeq?: { not?: null };
+    };
+    select?: Record<string, boolean>;
+  },
+): any | null | undefined {
+  const { userId, opType, repairBaseServerSeq } = args.where ?? {};
+  if (opType !== 'REPAIR' || repairBaseServerSeq?.not !== null) {
+    return undefined;
+  }
+  const match = Array.from(operations.values())
+    .filter(
+      (op) =>
+        op.userId === userId && op.opType === 'REPAIR' && op.repairBaseServerSeq != null,
+    )
+    .sort((a, b) => b.serverSeq - a.serverSeq)[0];
+  return match ? applyOperationSelect(match, args.select) : null;
+}
+
 type UserSyncStateNotNullFilter = { not: null };
 
 /**

--- a/packages/super-sync-server/tests/sync.service.test-state.ts
+++ b/packages/super-sync-server/tests/sync.service.test-state.ts
@@ -207,6 +207,20 @@ export function mockOperationFindFirstFreshBelowBoundary(
   if (serverSeq?.lt === undefined || receivedAt?.gte === undefined) {
     return undefined;
   }
+  // Strict like its two siblings above. Silently ignoring an unknown key makes
+  // this mock answer a NARROWER production query as though it were the probe:
+  // adding any further filter to the real `findFirst` (which in Postgres can
+  // cut the result to zero and disable the whole-or-nothing guard outright)
+  // otherwise passes the entire unit suite, leaving only the real-Postgres
+  // spec — skipped in a default `npm test` — to catch it.
+  const unsupported = Object.keys(args.where ?? {}).filter(
+    (key) => !['userId', 'serverSeq', 'receivedAt'].includes(key),
+  );
+  if (unsupported.length > 0) {
+    throw new Error(
+      `mockOperationFindFirstFreshBelowBoundary: unsupported where keys ${unsupported.join(', ')}`,
+    );
+  }
   const match = Array.from(operations.values()).find(
     (op) =>
       op.userId === userId &&


### PR DESCRIPTION
## What

`latestStateReplacementSeq` — the cursor behind the stale-upload guard — was resolved from `SYNC_IMPORT`/`BACKUP_IMPORT` only. Both history-pruning paths can delete an import out from under a later **causal REPAIR**:

- **quota recovery** (`deleteOldestRestorePointAndOps`) deletes up to and including the *oldest* restore point — this pre-dates #9693,
- the **daily old-ops sweep** deletes everything below the *newest* causal boundary — #9688/#9693 widened its reach from over-quota accounts to the whole fleet.

With only the REPAIR left, the lookup resolved to "none" and the upload path **persisted that as `0`** — so the guard was not disarmed for one request, it was disarmed permanently for that account.

## Reproduction

`tests/integration/state-replacement-guard.integration.spec.ts`, real Postgres rows. Fixture: `SYNC_IMPORT@1`, deltas 2–3, causal `REPAIR@4`, tail at 5, all aged past retention, `latest_state_replacement_seq` still `NULL`. Same cursor-0 upload in each state:

| state | guard | upload |
|---|---|---|
| import retained (control) | `1` | rejected — "Download the latest full-state replacement before retrying" |
| after the old-ops sweep | `null` | **accepted at serverSeq 6** |
| after quota recovery | `null` | **accepted at serverSeq 6** |

Consequence is resurrection: a client whose cursor predates the replacement uploads deltas built on superseded state, re-adding what the replacement removed.

## Fix

Fall back to the newest **causal** REPAIR when no import is retained. Deliberately narrow:

- accounts still holding an import resolve exactly as before — no new upload rejections in the common case,
- a legacy REPAIR (no base cursor, not a proven boundary) stays excluded, matching `CAUSAL_FULL_STATE_OPERATION_WHERE` everywhere else,
- the second query only runs for the rare import-less account, so the ordinary upload path still costs one indexed lookup. `EXPLAIN ANALYZE` on a 200k-row table confirms it rides the existing partial index `operations_user_id_full_state_server_seq_idx` (backward index scan, 2 buffer hits, 0.008ms) — same plan shape as the lookup it follows. No new index.

**Blast radius of the change itself is bounded:** it only touches the `latest_state_replacement_seq IS NULL` path, so it cannot regress an account whose cursor is already resolved.

## Scope note — how many users this affects

Honest answer: unknown, and probably narrow. The column landed 2026-07-28 (#9330, shipped v18.17.0+) and resolves lazily, so any account that has uploaded with a cursor since then is already immune. The exposed set is accounts still `NULL` — largely dormant ones — that also hold a causal REPAIR above their import, get pruned, and then upload from a stale cursor before downloading. That conjunction is plausible (dormant accounts are exactly the sweep's target) but I cannot show it is non-empty without production data.

I'd merge it regardless: the fix is safe whether the population is 0 or 500.

## Deliberately not done

Using `CAUSAL_FULL_STATE_OPERATION_WHERE` directly in the lookup. That would also arm the guard at a REPAIR *while the import survives*, rejecting uploads from any client below any REPAIR. Arguably correct — a REPAIR does replace state — but it is a behavioural widening with no reproduction behind it and a plausible source of upload-rejection churn across synced clients. Worth deciding separately.

## Also included

An exhaustive lockstep test pinning the dry-run gate's raw SQL against `CAUSAL_FULL_STATE_OPERATION_WHERE` across the whole `(opType × repairBaseServerSeq)` matrix, checked against a third independent statement of the rule so a *matching pair* of wrong predicates still fails. Not hypothetical: the existing fixture-based drift test never seeded `repairBaseServerSeq = 0`, so spelling the gate `> 0` instead of `IS NOT NULL` passed it. The matrix test catches that mutation.

## Tests

2 unit + 4 integration, registered in `test:integration:postgres` (CI runs that list explicitly, so an unregistered file silently never runs). Both regression tests fail with the fix reverted; the control and the legacy-REPAIR negative test pass either way, pinning behaviour that must not change.

Verified on this branch standalone: 1176 unit / 59 integration green, `tsc --noEmit` clean.

Refs #9703.
