### PR TITLE
fix(supersync): stop the old-ops sweep truncating a prefix on a short batch

### DIFF
--- a/packages/super-sync-server/scripts/dry-run-old-ops-sweep.ts
+++ b/packages/super-sync-server/scripts/dry-run-old-ops-sweep.ts
@@ -113,9 +113,19 @@ const main = async (): Promise<void> => {
 
   // Safety check 2: while a cached snapshot blob exists, the boundary may
   // never exceed its cursor — pruning above it would eat into the cached
-  // snapshot's replay tail (the restore path). Re-read from user_sync_state
-  // rather than from the CTE columns: derived from `was_capped`, which is
-  // this same comparison, the check is a tautology that always prints OK.
+  // snapshot's replay tail (the restore path).
+  //
+  // Be honest about what this can and cannot catch. Re-reading from
+  // user_sync_state does NOT make it independent: `protected_from_seq` is
+  // itself derived with this same `snapshot_data IS NOT NULL AND
+  // last_snapshot_seq > 0` predicate, so for any affected user the comparison
+  // holds by construction and prints OK. What it does catch is a LIVE RACE —
+  // this query runs in a separate transaction from the plan query, so it fires
+  // if quota recovery moved a boundary underneath the plan. It is not a
+  // verification that the gate mirrors production; only the drift detector in
+  // tests/integration/old-ops-sweep.integration.spec.ts checks that, and
+  // nothing enforces the `causalFullStateSql` ↔ CAUSAL_FULL_STATE_OPERATION_WHERE
+  // lockstep that both sides depend on.
   const blobCursors = await prisma.$queryRaw<
     { user_id: number; last_snapshot_seq: number }[]
   >`

--- a/packages/super-sync-server/src/sync/services/operation-download.service.ts
+++ b/packages/super-sync-server/src/sync/services/operation-download.service.ts
@@ -329,10 +329,24 @@ export class OperationDownloadService {
     // Runs outside the interactive transaction: on large histories the aggregate
     // is slow enough to trip Prisma's transaction timeout. Bounded by
     // `latestSnapshotSeq` (captured inside the transaction) so newly-appended
-    // ops can't perturb the result. Background cleanup may delete rows in this
-    // range between commit and this query; in the common case the snapshot op's
-    // own vector_clock subsumes the deltas it replaces, so the per-client max
-    // is preserved.
+    // ops can't perturb the result.
+    //
+    // Background cleanup deletes rows in this range — since #9688 the old-ops
+    // sweep prunes fleet-wide, and this legacy path is taken by exactly the
+    // cohort it prunes (a missing `latest_full_state_*` marker means the newest
+    // causal op predates the marker migration, so its prefix is cold). The
+    // aggregate therefore CAN come back smaller than it once was: a
+    // BACKUP_IMPORT mints a fresh `{ clientId: 1 }` and subsumes nothing (see
+    // operation-upload.service.ts, `persistMergedFullStateClock`), so do NOT
+    // rely on "the snapshot op's own vector_clock covers the deltas it
+    // replaces" — that assumption is false and is what #8973 exists to avoid.
+    //
+    // It is nonetheless safe: a counter can only change a comparison if an op
+    // carrying it still exists, and every surviving op's clock reaches the
+    // client independently (`allOpClocks` on the download, `existingClock` on a
+    // rejection). Both consumers of `snapshotVectorClock` merge upward only, so
+    // a smaller contribution can only fail to add information that is no longer
+    // on the server anyway.
     const clockRows = await prisma.$queryRaw<
       Array<{ client_id: string; max_counter: bigint }>
     >`

--- a/packages/super-sync-server/src/sync/services/storage-quota.service.ts
+++ b/packages/super-sync-server/src/sync/services/storage-quota.service.ts
@@ -49,12 +49,25 @@ const getOldOpsCleanupDeleteBatchSize = (): number =>
     OLD_OPS_CLEANUP_DELETE_BATCH_SIZE_MAX,
   );
 
+/**
+ * `0` disables the old-ops sweep entirely — the operator brake.
+ *
+ * This deletion is irreversible (hard DELETE, no tombstone) and runs by
+ * default 10s after boot, so an operator who sees the dry-run gate's numbers
+ * and does not like them needs a way to stop it that does not involve patching
+ * the image. `parsePositiveIntegerEnv` rejects 0 and falls back to the default,
+ * which would silently mean "25 000" — the opposite of the intent — so the
+ * disable case is decoded before delegating. Reuses this knob rather than
+ * adding a second setting: "delete at most 0 rows per run" already reads as off.
+ */
 const getOldOpsCleanupMaxDeletedPerRun = (): number =>
-  parsePositiveIntegerEnv(
-    'OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN',
-    OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN,
-    OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN_MAX,
-  );
+  process.env.OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN?.trim() === '0'
+    ? 0
+    : parsePositiveIntegerEnv(
+        'OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN',
+        OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN,
+        OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN_MAX,
+      );
 
 export class StorageQuotaService {
   /**
@@ -411,6 +424,17 @@ export class StorageQuotaService {
   async deleteOldSyncedOpsForAllUsers(
     cutoffTime: number,
   ): Promise<{ totalDeleted: number; affectedUserIds: number[] }> {
+    // Checked before the fleet-wide groupBy below, so a disabled sweep costs
+    // nothing rather than scanning `operations` and then deleting nothing.
+    const deleteBudget = getOldOpsCleanupMaxDeletedPerRun();
+    if (deleteBudget <= 0) {
+      Logger.warn(
+        'Cleanup [old-ops]: disabled via OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN=0; ' +
+          'no operations were pruned and old ops will accumulate until it is re-enabled.',
+      );
+      return { totalDeleted: 0, affectedUserIds: [] };
+    }
+
     // Deletion is authorized by the newest CAUSAL full-state op in the user's
     // operation stream (SYNC_IMPORT / BACKUP_IMPORT / causal REPAIR) — the
     // same op the download path fast-forwards every client past
@@ -477,8 +501,17 @@ export class StorageQuotaService {
     let totalDeleted = 0;
     const affectedUserIds: number[] = [];
     const deleteBatchSize = getOldOpsCleanupDeleteBatchSize();
-    let remainingDeleteBudget = getOldOpsCleanupMaxDeletedPerRun();
+    let remainingDeleteBudget = deleteBudget;
     let cappedUsersWithoutReplayBase = 0;
+    // Every reason the sweep declines a candidate is counted and reported.
+    // #9688 was exactly a fleet-wide exemption from retention that nobody
+    // could see; a silent skip re-creates that blind spot in narrower form.
+    // `skippedFreshPrefix` in particular can pin a user forever: anyone
+    // emitting a causal full-state op more often than once per retention
+    // window is skipped on every single run while their log grows unbounded.
+    let skippedFreshPrefix = 0;
+    let skippedBoundaryAtOne = 0;
+    let drainFailures = 0;
 
     for (const candidate of candidates) {
       if (remainingDeleteBudget <= 0) break;
@@ -515,7 +548,10 @@ export class StorageQuotaService {
         protectedFromSeq = cappedFullStateOp.serverSeq;
       }
 
-      if (protectedFromSeq <= 1) continue;
+      if (protectedFromSeq <= 1) {
+        skippedBoundaryAtOne++;
+        continue;
+      }
 
       // Prune the prefix whole, or not at all. Deletion filters on `receivedAt
       // < cutoffTime` as well as `serverSeq < protectedFromSeq`, so a prefix
@@ -539,7 +575,10 @@ export class StorageQuotaService {
         },
         select: { serverSeq: true },
       });
-      if (freshOpBelowBoundary) continue;
+      if (freshOpBelowBoundary) {
+        skippedFreshPrefix++;
+        continue;
+      }
 
       // Drain this user to completion. The budget gates which users we
       // START, never where we stop inside one: batches delete ascending by
@@ -549,45 +588,62 @@ export class StorageQuotaService {
       // restore target 500 with SNAPSHOT_REPLAY_INCOMPLETE until a later run
       // finishes the prefix. Overshoot is bounded by one user's backlog and
       // costs a longer run; a truncated prefix costs that user their restore.
+      //
+      // One user's DB error must not cost the rest of the fleet a day of
+      // retention, so the drain is scoped: log, count, move to the next user.
+      // A throw mid-drain still leaves that user's prefix truncated — the
+      // batches are separate committed statements, not one transaction — and
+      // the next run repairs it, since the surviving prefix ops are still
+      // older than the (by then later) cutoff.
       let userDeleted = 0;
-      for (;;) {
-        const deletedCount = await this.deleteOldSyncedOpsBatch(
-          candidate.userId,
-          protectedFromSeq,
-          cutoffTime,
-          deleteBatchSize,
-        );
-        if (deletedCount === 0) break;
+      try {
+        for (;;) {
+          const { selectedCount, deletedCount } = await this.deleteOldSyncedOpsBatch(
+            candidate.userId,
+            protectedFromSeq,
+            cutoffTime,
+            deleteBatchSize,
+          );
+          if (selectedCount === 0) break;
 
-        // Mark on the *first* successful batch (not after the loop) so that
-        // if a later batch throws, the counter still self-heals. Without
-        // this, batch-1 commits would leave the counter stale-high until the
-        // next daily pass or process restart.
-        //
-        // Deliberately leave storageUsedBytes stale-high here. A count-based
-        // approximate decrement can undercount users with many tiny ops and
-        // let them bypass quota indefinitely. The marker tells the next
-        // request to run an exact reconcile so drift self-heals.
-        //
-        // NOTE: the marker is in-memory (process-local). A persistent
-        // `users.storage_needs_reconcile` column would survive restarts; see
-        // TODO below.
-        // TODO: persist the reconcile marker in a DB column so it survives
-        // restarts of a single-instance deployment and works correctly across
-        // a multi-instance deployment behind a load balancer.
-        if (userDeleted === 0) {
-          affectedUserIds.push(candidate.userId);
-          this.markNeedsReconcile(candidate.userId);
+          // Mark on the *first* successful batch (not after the loop) so that
+          // if a later batch throws, the counter still self-heals. Without
+          // this, batch-1 commits would leave the counter stale-high until the
+          // next daily pass or process restart.
+          //
+          // Deliberately leave storageUsedBytes stale-high here. A count-based
+          // approximate decrement can undercount users with many tiny ops and
+          // let them bypass quota indefinitely. The marker tells the next
+          // request to run an exact reconcile so drift self-heals.
+          //
+          // NOTE: the marker is in-memory (process-local). A persistent
+          // `users.storage_needs_reconcile` column would survive restarts; see
+          // TODO below.
+          // TODO: persist the reconcile marker in a DB column so it survives
+          // restarts of a single-instance deployment and works correctly across
+          // a multi-instance deployment behind a load balancer.
+          if (userDeleted === 0) {
+            affectedUserIds.push(candidate.userId);
+            this.markNeedsReconcile(candidate.userId);
+          }
+
+          userDeleted += deletedCount;
+          totalDeleted += deletedCount;
+          // May go negative — the outer loop's budget check then stops the run
+          // before starting another user.
+          remainingDeleteBudget -= deletedCount;
+          // Stop on the SELECTED count, never the deleted one. A short delete
+          // means those rows were already gone (concurrent quota recovery),
+          // not that the prefix is drained — see deleteOldSyncedOpsBatch.
+          if (selectedCount < deleteBatchSize) break;
         }
-
-        userDeleted += deletedCount;
-        totalDeleted += deletedCount;
-        // May go negative — the outer loop's budget check then stops the run
-        // before starting another user.
-        remainingDeleteBudget -= deletedCount;
-        // Short-circuit when the batch returned fewer rows than asked for: the
-        // user is empty and another findMany would only confirm zero rows.
-        if (deletedCount < deleteBatchSize) break;
+      } catch (error) {
+        drainFailures++;
+        Logger.error(
+          `Cleanup [old-ops]: drain failed for user ${candidate.userId} ` +
+            `(boundary ${protectedFromSeq}, ${userDeleted} ops deleted before the ` +
+            `error); their prefix may be truncated until the next run: ${error}`,
+        );
       }
     }
 
@@ -596,6 +652,22 @@ export class StorageQuotaService {
         `Cleanup [old-ops]: skipped ${cappedUsersWithoutReplayBase} snapshot-capped user(s) ` +
           'without a causal full-state op at or below their snapshot cursor; ' +
           'their operation histories were left intact.',
+      );
+    }
+
+    if (skippedFreshPrefix > 0 || skippedBoundaryAtOne > 0) {
+      Logger.info(
+        `Cleanup [old-ops]: retained ${skippedFreshPrefix} user(s) whose prefix still ` +
+          `holds an op inside retention and ${skippedBoundaryAtOne} whose boundary is at ` +
+          'seq 1; both are expected, but a fresh-prefix count that never falls means ' +
+          'those users are permanently exempt from retention.',
+      );
+    }
+
+    if (drainFailures > 0) {
+      Logger.warn(
+        `Cleanup [old-ops]: ${drainFailures} user(s) failed mid-drain and were skipped; ` +
+          'the run continued for the remaining users.',
       );
     }
 
@@ -611,16 +683,35 @@ export class StorageQuotaService {
     return { totalDeleted, affectedUserIds };
   }
 
+  /**
+   * Delete one batch of the user's aged prefix.
+   *
+   * Returns BOTH counts because they answer different questions and are not
+   * interchangeable. `selectedCount` is how many doomed rows this batch found,
+   * and is the only sound basis for "is this user drained?": a short
+   * `deletedCount` means those rows were already gone (quota recovery deleted
+   * them concurrently — the sweep does not hold `runWithStorageUsageLock`,
+   * the upload path does), NOT that the prefix is exhausted. Reading a short
+   * `deletedCount` as "drained" stops the loop mid-prefix and leaves a plain
+   * delta as the lowest surviving row, which is the SNAPSHOT_REPLAY_INCOMPLETE
+   * state the whole-or-nothing rule exists to prevent. `deletedCount` is what
+   * actually left the table, so it — and only it — feeds the budget and the
+   * storage counter.
+   */
   private async deleteOldSyncedOpsBatch(
     userId: number,
     protectedFromSeq: number,
     cutoffTime: number,
     limit: number,
-  ): Promise<number> {
+  ): Promise<{ selectedCount: number; deletedCount: number }> {
     const doomedOps = await prisma.operation.findMany({
       where: {
         userId,
         serverSeq: { lt: protectedFromSeq },
+        // Not redundant with the caller's fresh-op probe: a concurrent
+        // deleteAllUserData / clean slate resets lastSeq to 0, so the user's
+        // re-import reuses low seq numbers. Only this filter stops a stale
+        // protectedFromSeq from shredding that brand-new history.
         receivedAt: { lt: BigInt(cutoffTime) },
       },
       orderBy: { serverSeq: 'asc' },
@@ -628,7 +719,7 @@ export class StorageQuotaService {
       select: { id: true },
     });
 
-    if (doomedOps.length === 0) return 0;
+    if (doomedOps.length === 0) return { selectedCount: 0, deletedCount: 0 };
 
     const result = await prisma.operation.deleteMany({
       where: {
@@ -637,7 +728,7 @@ export class StorageQuotaService {
       },
     });
 
-    return result.count;
+    return { selectedCount: doomedOps.length, deletedCount: result.count };
   }
 
   /**

--- a/packages/super-sync-server/tests/integration/old-ops-sweep.integration.spec.ts
+++ b/packages/super-sync-server/tests/integration/old-ops-sweep.integration.spec.ts
@@ -47,6 +47,7 @@ const NO_STATE_ROW_USER_ID = 99986;
 const STUCK_SNAPSHOT_USER_ID = 99987;
 const SEQ1_IMPORT_ONLY_USER_ID = 99988;
 const PREDICATE_MATRIX_USER_ID = 99989;
+const MULTI_BATCH_USER_ID = 99990;
 const ALL_USER_IDS = [
   LAPSED_USER_ID,
   SNAPSHOTLESS_USER_ID,
@@ -57,6 +58,7 @@ const ALL_USER_IDS = [
   STUCK_SNAPSHOT_USER_ID,
   SEQ1_IMPORT_ONLY_USER_ID,
   PREDICATE_MATRIX_USER_ID,
+  MULTI_BATCH_USER_ID,
 ];
 
 describeWithDb('Old-ops sweep (PostgreSQL)', () => {
@@ -584,5 +586,41 @@ describeWithDb('Old-ops sweep (PostgreSQL)', () => {
 
     expect(viaGate).toEqual(viaPrisma);
     expect(viaPrisma).toEqual(expectedCausalSeqs);
+  });
+  /**
+   * The drain loop continues on the SELECTED row count, and it only ever
+   * continues past the first batch when a user's aged prefix is longer than
+   * OLD_OPS_CLEANUP_DELETE_BATCH_SIZE (5000 by default). Every other fixture
+   * here is a handful of rows, so that continuation — the line that decides
+   * whether a prefix is drained whole or left truncated with a plain delta
+   * lowest — has never executed against real rows. Shrink the batch instead of
+   * seeding 5000 ops.
+   */
+  it('drains a prefix longer than one delete batch whole, across batches', async () => {
+    const previousBatchSize = process.env.OLD_OPS_CLEANUP_DELETE_BATCH_SIZE;
+    process.env.OLD_OPS_CLEANUP_DELETE_BATCH_SIZE = '2';
+    try {
+      for (let seq = 1; seq <= 9; seq++) {
+        await seedOp(MULTI_BATCH_USER_ID, seq);
+      }
+      await seedImportOp(MULTI_BATCH_USER_ID, 10);
+      await seedOp(MULTI_BATCH_USER_ID, 11);
+      await prisma.userSyncState.create({
+        data: { userId: MULTI_BATCH_USER_ID, lastSeq: 11 },
+      });
+
+      const result = await runSweep();
+
+      // 9 prefix ops removed over 5 batches of 2; stopping after any one of
+      // them would leave a plain delta as the lowest surviving row.
+      expect(result.totalDeleted).toBe(9);
+      expect(await survivingSeqs(MULTI_BATCH_USER_ID)).toEqual([10, 11]);
+    } finally {
+      if (previousBatchSize === undefined) {
+        delete process.env.OLD_OPS_CLEANUP_DELETE_BATCH_SIZE;
+      } else {
+        process.env.OLD_OPS_CLEANUP_DELETE_BATCH_SIZE = previousBatchSize;
+      }
+    }
   });
 });

--- a/packages/super-sync-server/tests/sync.service.spec.ts
+++ b/packages/super-sync-server/tests/sync.service.spec.ts
@@ -3488,7 +3488,53 @@ describe('SyncService', () => {
       expect(survivors[0].opType).toBe('SYNC_IMPORT');
     });
 
-    it('marks user for reconcile when a later batch throws mid-loop', async () => {
+    it('deletes nothing when the per-run budget is set to 0', async () => {
+      const service = getSyncService();
+      process.env.OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN = '0';
+      const cutoffTime = Date.now() - 50 * 24 * 60 * 60 * 1000;
+
+      for (let i = 1; i <= 3; i++) {
+        testState.operations.set(`old-op-${i}`, {
+          id: `old-op-${i}`,
+          userId,
+          clientId,
+          serverSeq: i,
+          actionType: 'ADD',
+          opType: 'CRT',
+          entityType: 'TASK',
+          entityId: `t${i}`,
+          payload: {},
+          vectorClock: {},
+          schemaVersion: 1,
+          clientTimestamp: BigInt(Date.now()),
+          receivedAt: BigInt(cutoffTime - 1),
+          isPayloadEncrypted: false,
+          syncImportReason: null,
+        });
+      }
+      seedFullStateOp(userId, 4, BigInt(cutoffTime - 1));
+
+      const groupBySpy = vi.mocked(prisma.operation.groupBy);
+      groupBySpy.mockClear();
+      try {
+        const { totalDeleted, affectedUserIds } =
+          await service.deleteOldSyncedOpsForAllUsers(cutoffTime);
+
+        // The operator brake. `parsePositiveIntegerEnv` rejects 0 and falls
+        // back to the default, so without the explicit decode this knob would
+        // silently mean 25 000 — and there is no other way to stop an
+        // irreversible, default-on sweep short of patching the image.
+        expect(totalDeleted).toBe(0);
+        expect(affectedUserIds).toEqual([]);
+        expect(testState.operations.size).toBe(4);
+        // Disabled must also cost nothing: no fleet-wide scan of `operations`.
+        expect(groupBySpy).not.toHaveBeenCalled();
+      } finally {
+        delete process.env.OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN;
+      }
+    });
+
+    it('keeps draining when a concurrent delete shrinks a batch row count', async () => {
       const service = getSyncService();
       process.env.OLD_OPS_CLEANUP_DELETE_BATCH_SIZE = '50';
       process.env.OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN = '250';
@@ -3523,12 +3569,113 @@ describe('SyncService', () => {
         snapshotAt: BigInt(Date.now()),
       });
 
+      // Quota recovery (deleteOldestRestorePointAndOps) runs unlocked against
+      // the same user while the sweep is mid-drain — the sweep does NOT take
+      // runWithStorageUsageLock, the upload path does. Simulate it landing
+      // between the sweep's findMany (which selected 50 ids) and its
+      // deleteMany: two of those rows are already gone, so deleteMany reports
+      // 48. That is fewer rows than the batch size, but the user is NOT empty.
+      const deleteManySpy = vi.mocked(prisma.operation.deleteMany) as unknown as {
+        getMockImplementation: () => (args: any) => Promise<{ count: number }>;
+        mockImplementation: (fn: (args: any) => Promise<{ count: number }>) => void;
+      };
+      const originalDeleteMany = deleteManySpy.getMockImplementation();
+      let interceptedBatches = 0;
+      deleteManySpy.mockImplementation(async (args: any) => {
+        if (interceptedBatches === 0) {
+          interceptedBatches += 1;
+          for (const id of (args.where?.id?.in ?? []).slice(0, 2)) {
+            testState.operations.delete(id);
+          }
+        }
+        return originalDeleteMany(args);
+      });
+
+      try {
+        await service.deleteOldSyncedOpsForAllUsers(cutoffTime);
+      } finally {
+        deleteManySpy.mockImplementation(originalDeleteMany);
+        delete process.env.OLD_OPS_CLEANUP_DELETE_BATCH_SIZE;
+        delete process.env.OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN;
+      }
+
+      // A short row count must mean "these rows are gone", never "this user is
+      // drained". Reading it as the latter stops the loop mid-prefix and
+      // leaves a plain CRT delta as the lowest surviving row — the exact
+      // SNAPSHOT_REPLAY_INCOMPLETE state the whole-or-nothing rule exists to
+      // prevent, reached here through concurrency instead of the budget.
+      const survivors = Array.from(testState.operations.values())
+        .filter((op) => op.userId === userId)
+        .sort((a, b) => a.serverSeq - b.serverSeq);
+      expect(survivors.map((op) => op.serverSeq)).toEqual([totalOps + 1]);
+      expect(survivors[0].opType).toBe('SYNC_IMPORT');
+    });
+
+    it('marks user for reconcile and keeps going when a batch throws mid-loop', async () => {
+      const service = getSyncService();
+      process.env.OLD_OPS_CLEANUP_DELETE_BATCH_SIZE = '50';
+      process.env.OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN = '250';
+      const totalOps = 120;
+      const cutoffTime = Date.now() - 50 * 24 * 60 * 60 * 1000;
+
+      for (let i = 1; i <= totalOps; i++) {
+        testState.operations.set(`old-op-${i}`, {
+          id: `old-op-${i}`,
+          userId,
+          clientId,
+          serverSeq: i,
+          actionType: 'ADD',
+          opType: 'CRT',
+          entityType: 'TASK',
+          entityId: `t${i}`,
+          payload: {},
+          vectorClock: {},
+          schemaVersion: 1,
+          clientTimestamp: BigInt(Date.now()),
+          receivedAt: BigInt(cutoffTime - 1),
+          isPayloadEncrypted: false,
+          syncImportReason: null,
+        });
+      }
+      seedFullStateOp(userId, totalOps + 1, BigInt(cutoffTime - 1));
+
+      testState.userSyncStates.set(userId, {
+        userId,
+        lastSeq: totalOps + 1,
+        lastSnapshotSeq: totalOps + 1,
+        snapshotAt: BigInt(Date.now()),
+      });
+
+      // A second user, ordered after the failing one, proves one user's DB
+      // error does not cost the rest of the fleet a day of retention.
+      const otherUserId = userId + 1;
+      testState.operations.set('other-old-op-1', {
+        id: 'other-old-op-1',
+        userId: otherUserId,
+        clientId: `client-${otherUserId}`,
+        serverSeq: 1,
+        actionType: 'ADD',
+        opType: 'CRT',
+        entityType: 'TASK',
+        entityId: 'ot1',
+        payload: {},
+        vectorClock: {},
+        schemaVersion: 1,
+        clientTimestamp: BigInt(Date.now()),
+        receivedAt: BigInt(cutoffTime - 1),
+        isPayloadEncrypted: false,
+        syncImportReason: null,
+      });
+      seedFullStateOp(otherUserId, 2, BigInt(cutoffTime - 1));
+
       // Let the first batch run normally, then simulate a transient DB error
       // on the second batch. Pre-fix this would leave the storage counter
       // stale-high with no reconcile signal until the next daily pass.
       const serviceWithPrivates = service as unknown as {
         storageQuotaService: {
-          deleteOldSyncedOpsBatch: (...args: unknown[]) => Promise<number>;
+          deleteOldSyncedOpsBatch: (
+            ...args: unknown[]
+          ) => Promise<{ selectedCount: number; deletedCount: number }>;
           needsReconcile: (userId: number) => boolean;
         };
       };
@@ -3540,20 +3687,30 @@ describe('SyncService', () => {
         async (...args: unknown[]) => {
           callCount += 1;
           if (callCount === 1) return originalBatch(...args);
-          throw new Error('simulated transient DB failure');
+          if (args[0] === userId) throw new Error('simulated transient DB failure');
+          return originalBatch(...args);
         },
       );
 
-      await expect(service.deleteOldSyncedOpsForAllUsers(cutoffTime)).rejects.toThrow(
-        'simulated transient DB failure',
-      );
+      const { affectedUserIds } = await service.deleteOldSyncedOpsForAllUsers(cutoffTime);
       delete process.env.OLD_OPS_CLEANUP_DELETE_BATCH_SIZE;
       delete process.env.OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN;
+
+      // The failing user is contained, not fatal to the run: the sweep logged
+      // and moved on, so the second user was still serviced.
+      expect(affectedUserIds).toContain(otherUserId);
+      expect(
+        Array.from(testState.operations.values()).filter(
+          (op) => op.userId === otherUserId,
+        ),
+      ).toHaveLength(1);
 
       // First batch committed deletes; the user must still be marked so
       // the next request reconciles the now-stale-high counter.
       expect(storageQuotaService.needsReconcile(userId)).toBe(true);
-      expect(testState.operations.size).toBe(totalOps + 1 - 50);
+      expect(
+        Array.from(testState.operations.values()).filter((op) => op.userId === userId),
+      ).toHaveLength(totalOps + 1 - 50);
     });
 
     it('shares the per-run budget across users; tail users wait for next pass', async () => {

--- a/packages/super-sync-server/tests/sync.service.test-state.ts
+++ b/packages/super-sync-server/tests/sync.service.test-state.ts
@@ -207,6 +207,20 @@ export function mockOperationFindFirstFreshBelowBoundary(
   if (serverSeq?.lt === undefined || receivedAt?.gte === undefined) {
     return undefined;
   }
+  // Strict like its two siblings above. Silently ignoring an unknown key makes
+  // this mock answer a NARROWER production query as though it were the probe:
+  // adding any further filter to the real `findFirst` (which in Postgres can
+  // cut the result to zero and disable the whole-or-nothing guard outright)
+  // otherwise passes the entire unit suite, leaving only the real-Postgres
+  // spec — skipped in a default `npm test` — to catch it.
+  const unsupported = Object.keys(args.where ?? {}).filter(
+    (key) => !['userId', 'serverSeq', 'receivedAt'].includes(key),
+  );
+  if (unsupported.length > 0) {
+    throw new Error(
+      `mockOperationFindFirstFreshBelowBoundary: unsupported where keys ${unsupported.join(', ')}`,
+    );
+  }
   const match = Array.from(operations.values()).find(
     (op) =>
       op.userId === userId &&


### PR DESCRIPTION
> Stacked on #9708 — review/merge that first; this branch's base retargets to master once it lands.

## The bug

The sweep's drain loop exited on `deletedCount < deleteBatchSize`. A short **delete** count does not mean the prefix is drained — it means those rows were already gone, deleted concurrently by quota recovery. The sweep does **not** hold `runWithStorageUsageLock`; the upload path does (`sync.routes.ops-handler.ts:232`), and `freeStorageForUpload` loops up to 50 prefix deletes per over-quota upload. So a recovery delete landing between the sweep's `findMany` and its `deleteMany` stopped the drain mid-prefix.

That leaves a plain `CRT` delta as the lowest surviving op — exactly the state `_resolveExpectedFirstSeq` (`op-replay.ts`) rejects. It throws `SNAPSHOT_REPLAY_INCOMPLETE` and the restore route surfaces it as a 500. The sweep's whole-or-nothing rule exists to prevent precisely this; reading the wrong counter defeated it.

Regression test written first and confirmed failing with the predicted symptom before the fix.

## Fix

`deleteOldSyncedOpsBatch` now returns `{ selectedCount, deletedCount }`. Selected answers "is this user drained"; deleted feeds the budget and the storage counter. They are not interchangeable.

## Scope — please push back if this is too much

**Only one of the four changes here is driven by an observed failure.** The repo's own rule says hardening without a reproduction is how this layer accumulates defensive complexity, so flagging it rather than burying it:

| change | evidence |
|---|---|
| short-batch truncation fix | **reproduced**, test fails without it |
| per-user error boundary — one user's DB error no longer costs the rest of the fleet a day of retention | none, defensive |
| skip observability (`skippedFreshPrefix` / `skippedBoundaryAtOne` / `drainFailures`) | none, diagnostic |
| `OLD_OPS_CLEANUP_MAX_DELETED_PER_RUN=0` now means *off* (it silently meant 25,000, since `parsePositiveIntegerEnv` rejects 0) | none, operator lever |

My argument for keeping them: the sweep is fleet-wide, default-on 10s after boot, and `ghcr.io/.../supersync:latest` **is** master, so self-hosters on `docker compose pull` run it. An operator with no off switch and no skip counters is how #9688 stayed invisible in the first place. But that is judgement, not evidence — happy to strip this to the truncation fix alone.

## Test-only changes

- **Multi-batch drain against real Postgres.** The drain loop only continues past the first batch when a prefix exceeds `OLD_OPS_CLEANUP_DELETE_BATCH_SIZE` (5000). Every integration fixture is ~12 rows, so the continuation — the exact line this PR changes — had only ever run against the in-memory mock. Shrinking the batch to 2 exercises it; replacing the continuation with an unconditional `break` leaves 2 of 9 prefix ops deleted and fails the test.
- **Strict `mockOperationFindFirstFreshBelowBoundary`**, matching its two siblings. Narrowing the production probe went from 0 → 10 failures after this.

## Two corrected comments

- `_computeSnapshotVectorClock` claimed a snapshot op's `vector_clock` "subsumes the deltas it replaces". It does not — a `BACKUP_IMPORT` mints a fresh `{clientId: 1}`. Replaced with the invariant that actually makes pruning safe.
- The dry-run gate's cap check is a tautology (`protected_from_seq` is derived with the same predicate it is compared against). It is a live-race detector; now documented as one.

## Still unmeasured

#9688 asked for the gate to be re-run to size any candidate fix; #9693 shipped without post-change numbers. Nobody knows how much of the snapshotless cohort has a causal op above seq 1. Worth running `MONITOR_STATEMENT_TIMEOUT_MS=1800000 npm run dry-run-old-ops-sweep:dev` on the server host before the next daily pass — it is read-only.

Verified on this branch: 1178 unit / 60 integration green, `tsc --noEmit` clean. Refs #9688, #9693.
