### PR TITLE
fix(monitoring): make health-alert email delivery failure visible

### DIFF
--- a/docs/plans/2026-08-22-health-alert-email-delivery.md
+++ b/docs/plans/2026-08-22-health-alert-email-delivery.md
@@ -1,0 +1,255 @@
+# Implementation plan: make `health-alert.sh` email failure visible
+
+**Status:** Implemented and reviewed; committed on this branch · **Date:** 2026-08-22 ·
+**Baseline:** master `0ece8896d7`
+**Removal condition:** delete once merged.
+**Related:** #9191 (monitoring/alerting)
+
+## The defect
+
+Alerting can be completely unable to deliver mail while every surface an operator looks
+at reports green.
+
+`health-alert.sh` requires `ALERT_EMAIL` and exits 0 with a clear message when it is
+unset (`:34-38`). It never checked that a `mail` binary exists. A stock Debian or Ubuntu
+VPS has none — neither `mailutils` nor `bsd-mailx` is installed by default and no MTA is
+configured. `scripts/MONITORING-README.md:243-251` presented `ALERT_EMAIL` plus a crontab
+line as the complete setup, and `scripts/deploy.sh:503` prints that same line as the
+remediation. No MTA package is referenced anywhere in the repo. An operator who followed
+the documented setup exactly could end up with alerting that had never been capable of
+sending anything.
+
+The sibling script gets the guard right: `tools/backup-rotate.sh:122` checks
+`command -v mail`.
+
+What makes it silent is that the send path only runs once a problem already exists. On a
+healthy server it has never executed, so no `mail-failed` marker was ever written, and
+`deploy.sh:511` prints "no recorded failure (verified only when mail is attempted)".
+`MONITORING-README.md:253-256` stated the gap outright: _"It cannot prove delivery while
+the system is healthy because no email is sent then."_ It was known, documented, and
+unfixed.
+
+The existing tests could not catch it: `tests/health-alert-script.spec.ts:107` sets
+`PATH: ${binDir}:${process.env.PATH}`, so the fakes _shadow_ real binaries and "no `mail`
+binary" was a state the harness could not produce.
+
+## What is deliberately not built
+
+An earlier draft added a `--test` flag, a second `mail-unavailable` marker file, a
+three-state `deploy.sh` branch, and argument parsing. Review rejected all four:
+
+- **`--test`** cannot deliver what it promises. A queuing MTA exits 0 on accept, not on
+  delivery, so it never proves receipt — and one documentation line saying "check the
+  inbox" costs nothing and covers every past and future version of the script. It also
+  introduced two false-green paths of its own: `health-alert.sh:67` exits 0 when the
+  5-minute cron holds the `flock`, and `:34-38` exits 0 with no recipient set.
+- **Argument parsing** contradicts `:21-22` — _"Do NOT use `set -e` — a monitoring script
+  must never silently abort."_ Rejecting an unknown argument before the checks run is
+  exactly that abort, and the crontab-detection awk in `deploy.sh:465-474` would keep
+  reporting "cron installed" while every run exited early.
+- **A second marker file** duplicates a field `mail-failed` is already gaining. Both can
+  be present with no defined precedence, and `deploy.sh:507` tests `mail-failed` first —
+  so a stale relay error would mask the actual current cause.
+- **A `deploy.sh` "delivery has succeeded" branch** is not implementable. `state` is
+  deleted on the recovery send (`:360`), so a server that alerted and recovered is
+  indistinguishable from one that never sent anything.
+
+Also out of scope: a `curl`-over-SMTP transport reusing the server's existing `SMTP_*`
+credentials (a real option — `health-alert.sh` already reads `.env` and already depends on
+`curl` — but a larger change than this defect warrants), and #9695's separate finding that
+the restart check at `:132` reads `{{.RestartCount}}` and is therefore blind to PostgreSQL
+crash-restarts.
+
+## Step 1: preflight the transport — and gate the sends on it
+
+Placed after the `flock` gate, not beside the config validation at `:42-51`:
+`ALERT_STATE_DIR` does not exist until `:59`, and under `set -u` an earlier reference
+aborts the script. After the lock, so two overlapping cron runs cannot interleave a
+truncate-and-write on the marker, and so a lock-contended run stays as silent as it is
+today.
+
+```bash
+MAIL_CMD="${MAIL_CMD:-mail}"
+MAIL_AVAILABLE=true
+if ! command -v "$MAIL_CMD" >/dev/null 2>&1; then
+  MAIL_AVAILABLE=false
+  echo "health-alert: no '$MAIL_CMD' binary on PATH — install mailutils or bsd-mailx." >&2
+  record_mail_failure "no $MAIL_CMD binary on PATH — install mailutils or bsd-mailx"
+fi
+```
+
+**Writing the marker is not sufficient on its own, and a draft that only did that was
+actively wrong.** Creating `mail-failed` makes the recovery condition at `:356` true, so
+the healthy branch fires a send, `timeout 30 mail` exits 127, and `:364` overwrites the
+marker with a bare timestamp — the reason string never survived a single complete run.
+Reproduced end to end before the fix. Both send conditions therefore also require
+`$MAIL_AVAILABLE`, which additionally stops a doomed send being retried, and two extra
+stderr lines being printed, every five minutes forever.
+
+`MAIL_CMD` exists so the spec can express "no transport at all". Filtering `mail` out of
+`PATH` means dropping the directory that provides it, which takes `date`, `sed`, `flock`
+and `sha256sum` with it — the script then dies before it does anything assertable. It
+matches the script's existing env-var config style and is not the rejected flag surface.
+
+This writes the _existing_ marker, so `deploy.sh:507-509` already surfaces it with wording
+that is already correct for this case: _"Checks are running but nobody is being told.
+Verify `mail` works."_ No new file, no precedence rule.
+
+Deliberately **not** appended to `CONFIG_PROBLEMS`/`PROBLEMS`: that string is both the
+alert body (`:343-344`) and the dedupe hash input (`:330-337`), so putting "I cannot reach
+you" in it would report the broken channel _through_ the broken channel, and would keep
+`PROBLEMS` permanently non-empty — disabling the recovery branch at `:356`, which with
+`:347` is one of the two things that clear the marker.
+
+One caveat accepted knowingly: `deploy.sh:508` says "delivery FAILED" when nothing was
+attempted. That is the correct operational conclusion (nobody is being told) even if the
+verb is imprecise.
+
+**Verify:** a spec case running with `MAIL_CMD` set to a nonexistent binary asserts the
+marker exists and names it, that the run still performed its checks, and that no send was
+attempted (`mailLog` empty, no "Failed to send" on stderr).
+
+## Step 2: capture why a real send failed
+
+`:345` and `:359` ended in `2>/dev/null`, so "not installed", "relay refused" and "auth
+failed" were indistinguishable afterwards. Both sites now route through one
+`send_alert_mail` helper — one send path, so stderr capture and the failure record cannot
+drift apart — which captures stderr to a temp file and records it. (The gate on
+`$MAIL_AVAILABLE` lives at the two call sites, not in the helper: a copy inside it was
+unreachable and was removed in `bef0c160`.)
+
+Three constraints:
+
+- **Keep `timeout 30`, but do not rely on it alone.** Under a 5-minute cron, an MTA
+  hanging on an unreachable relay is a process-pileup vector. `timeout` bounds the `mail`
+  process only — it does **not** bound a `$(...)` reading its output, which waits for pipe
+  EOF and so outlives it whenever the MTA forks a delivery child. That is why stderr goes
+  to a temp file rather than a command substitution; see "What review caught" below.
+- **Bound and sanitize at write time _and_ at read time.** SMTP response text is written
+  by the remote relay and `deploy.sh` echoes the file straight to a terminal. Write-time is
+  `LC_ALL=C tr -d '\000-\010\013-\037\177'` plus `sed 's/\xc2[\x80-\x9f]//g'`, capped at 4096. Three separate mistakes were made here before it was right, so read the whole list
+  before touching the filter:
+  1. An early draft used `'\000-\010\013\014\016-\037'`, leaving **CR (13) and DEL (127)**
+     intact. CR is precisely the byte that lets relay text overwrite the line it prints on.
+  2. Extending the range to `\200-\237` to catch C1 **corrupts UTF-8** — those are also
+     continuation bytes, and it mangled this script's own em-dash message. Committed as
+     `096c93ca`, reverted in `bef0c160`. Do not re-attempt it.
+  3. The residual was then wrongly written off as "a lone C1 byte is invalid UTF-8, so it
+     is only a CSI in a legacy 8-bit locale". False: `\xC2\x9B` is the _well-formed_ UTF-8
+     encoding of CSI, both bytes are >= 0x80, and a UTF-8 terminal decodes a real control.
+     Removing the two-byte sequence is exact — `\xc2` + `\x80-\x9f` encodes U+0080-U+009F
+     and nothing else — so CSI/OSC go while em-dash, NBSP and CJK survive.
+
+  Write-time is not sufficient on its own. The marker is operator data that survives
+  `git pull` and may predate the filter, so `deploy.sh` sanitizes again at the point of
+  printing, via `printf` (not `echo`, which re-expands a printable `\033` under `xpg_echo`).
+  The same applies to `last-run`, read from the same directory by the same function.
+  Tab and LF are kept at write time; the reader flattens them.
+
+- **`deploy.sh:508` must not stay `$(cat …)`.** That strips only _trailing_ newlines, so a
+  multi-line marker interpolates mid-sentence. It now takes `head -1` for the timestamp
+  and prints the reason on its own indented line — `head -1` alone would have meant the
+  captured reason reached nobody, since `deploy.sh:507-512` is the only reader of
+  `mail-failed` in the repo. The reason extraction is `|| true`-guarded: `deploy.sh` runs
+  `set -euo pipefail` and `report_monitoring_status` is called immediately before
+  `exit 0`, so a SIGPIPE'd pipeline there would turn a successful deploy into a failing
+  one. Steps 1 and 2 are one atomic change with `deploy.sh`, not two: the marker is
+  operator data that survives `git pull`, so old-reader/new-marker is reachable.
+
+Keep the file owner-only, and enforce rather than infer it. `umask 077` at `:23` applies
+only at _creation_; a `.health-alert/` created earlier by anything else keeps its old mode.
+`chmod 700` on the directory and `chmod 600` on the marker, both `2>/dev/null || true` —
+if the directory belongs to another user the chmod fails, and a monitoring script must not
+start emitting errors every five minutes over it. This matters more after this step than
+before: the file gains the recipient address and possibly the relay hostname or username.
+
+**Verify:** spec cases with a failing fake `mail` that writes a recognisable stderr string;
+assert the first line still parses as a timestamp and the string appears, at **both** send
+sites. A separate case asserts CR, DEL, BEL and ESC are all stripped and the length is
+capped.
+
+## Step 3: document the MTA
+
+`scripts/MONITORING-README.md`, after the crontab fence (which ends at `:251` — inserting
+after `:250` lands _inside_ the code block):
+
+> Alerting needs a working MTA. `mailutils` or `bsd-mailx` provides the `mail` command;
+> bare `msmtp` does **not** — it is a transport, so pair it with `msmtp-mta`. Stock Debian
+> and Ubuntu ship neither. Before trusting the cron entry, confirm delivery end to end:
+>
+> ```bash
+> echo test | mail -s 'SuperSync test' you@example.com
+> ```
+>
+> A queuing MTA exits 0 on accept, not on delivery — check that the message actually
+> arrived. If it did not, `mailx` writes the undelivered body to `~/dead.letter` for the
+> cron user.
+
+The `:253-256` "cannot prove delivery while healthy" paragraph is now **false**, and step 1
+is what made it false: the missing-binary marker makes the first healthy run after the MTA
+is installed send one `SuperSync OK: Health Check Recovered` message and clear the marker.
+That single mail is a genuine end-to-end delivery proof — better evidence than `--test`
+could have produced, arriving without any new surface. It is only confusing if
+undocumented ("recovered" from a failure that never happened), so the paragraph now says
+so explicitly. The same one-line MTA pointer goes next to `deploy.sh:503`, which is the
+screen operators actually read.
+
+Do **not** add this to `DOCKER-MONITORING.md`: it contains no `ALERT_EMAIL` or `mail`
+content at all (`health-alert.sh` appears once, at `:260`, only to explain the
+`supersync-monitor` application name).
+
+Preserve the no-default-recipient reasoning at `:27-29` exactly as it stands: the script
+ships in the repo and the image, so a default address would mail a self-hoster's hostname,
+disk usage and container state to a stranger.
+
+**Verify:** docs review, per `docs/documentation-guide.md`.
+
+## Step 4: fix `backup-rotate.sh`
+
+`tools/backup-rotate.sh:121-125` guarded on `command -v mail` correctly and then sent to a
+hardcoded `admin@example.com` — IANA-reserved, so the "all backups deleted during rotation"
+alert reached nobody by construction. Now `"${ALERT_EMAIL:-}"`, skipped when unset, matching
+`health-alert.sh:34-38`.
+
+An earlier draft argued this had to land _first_ because step 3 arms it fleet-wide. That
+reasoning does not survive checking and has been dropped: the send sits inside
+`if [ "$TOTAL_BACKUPS" -eq 0 ]` (`:118`), a far bigger gate than the `mail` check; nothing
+in the repo references `backup-rotate.sh` (no doc, cron installer, test or compose file);
+and the runtime image does not ship it — `Dockerfile:60` copies `scripts/`, while `tools/`
+exists only in the builder stage. Ordering is free. The fix is still right: a hardcoded
+recipient in a shipped script is a defect on its own terms.
+
+**Verify:** the guard skips cleanly with `ALERT_EMAIL` unset.
+
+## What review caught after implementation
+
+Recorded because each was a defect the implementation introduced, not a pre-existing one.
+
+- **`err=$(timeout 30 ...)` hung the script forever on a forking MTA.** Command
+  substitution waits for pipe EOF, not for the process, so a delivery child that outlives
+  `mail` keeps it open and `timeout` does nothing — measured 45s against a stub sleeping
+  45s. A queuing MTA daemonizes exactly like that: the run never returns, the `flock` is
+  held, and every later cron run exits silently at the lock. This was a _regression_ — the
+  original code piped straight into `mail` with no substitution. Fixed by capturing stderr
+  to a temp file, which also bounds a verbose MTA's output instead of buffering it whole.
+- **`chmod 700` on the state dir was removed.** It re-locked a directory an operator may
+  have widened so a non-root `deploy.sh` could read it; after that `deploy.sh` cannot stat
+  the marker and prints "no recorded failure" — the change manufacturing the exact
+  false-green it exists to expose. It also chmod'd through a symlink. The marker write uses
+  `mktemp` + `mv` instead, which cannot follow a planted symlink and makes `chmod 600`
+  redundant.
+- **The MTA advice was wrong.** `msmtp-mta` supplies the `sendmail` interface, not the
+  `mail` command, so an operator following the first draft still failed the preflight.
+- **"Delivery is provable while healthy" was over-claimed.** The free proof exists only if
+  the cron ran _before_ the MTA was installed — the opposite of the order the same section
+  recommends. Now stated conditionally.
+
+## Risk
+
+The captured reason narrows the silent-failure window; it does not close it. A local
+`sendmail` that queues returns success and the message can still be dropped later as
+unauthenticated. The documentation says so; nothing here should imply otherwise.
+
+The reason line `deploy.sh` prints can name the recipient address and the relay host. It is
+a 0600 file, but the printed excerpt lands in CI logs and support pastes; `MONITORING-README`
+says so.

--- a/packages/super-sync-server/scripts/MONITORING-README.md
+++ b/packages/super-sync-server/scripts/MONITORING-README.md
@@ -250,10 +250,35 @@ is not started by `deploy.sh` and nothing else runs it:
 (crontab -l 2>/dev/null; echo "*/5 * * * * ALERT_EMAIL=you@example.com /path/to/super-sync-server/scripts/health-alert.sh") | crontab -
 ```
 
+### The cron entry is not enough — you also need an MTA
+
+`ALERT_EMAIL` plus the crontab line above gets the _checks_ running. Delivering
+their result needs a working `mail` command, and stock Debian and Ubuntu have
+none. `mailutils` or `bsd-mailx` provides it; bare `msmtp` does **not** — msmtp is
+a transport, so pair it with `msmtp-mta`.
+
+`health-alert.sh` now checks for the binary on every run and records its absence
+in `.health-alert/mail-failed`, which `deploy.sh` surfaces. Confirm delivery end
+to end before trusting the setup:
+
+```bash
+echo test | mail -s 'SuperSync test' you@example.com
+```
+
+A queuing MTA exits 0 on accept, not on delivery, so check the message actually
+arrived. If it did not, `mailx` writes the undelivered body to `~/dead.letter`
+for the cron user.
+
 `deploy.sh` reports at the end of every deploy whether this exact cron exists,
-whether it is still completing, and whether the last attempted email failed. It
-cannot prove delivery while the system is healthy because no email is sent then.
-If it says the cron is missing, nothing is watching the server.
+whether it is still completing, and why the last attempted email failed. If it
+says the cron is missing, nothing is watching the server.
+
+Delivery is now provable while the system is healthy: the missing-binary marker
+makes the next healthy run send one `SuperSync OK: Health Check Recovered`
+message and then clear the marker. So after installing an MTA on a healthy
+server, that single mail arriving within 5 minutes is the end-to-end proof —
+and `deploy.sh` dropping its warning is the confirmation. Nothing repeats: the
+marker is gone once a send succeeds.
 
 ### What it checks
 

--- a/packages/super-sync-server/scripts/MONITORING-README.md
+++ b/packages/super-sync-server/scripts/MONITORING-README.md
@@ -257,7 +257,7 @@ their result needs a working `mail` command, and stock Debian and Ubuntu have
 none. `mailutils` or `bsd-mailx` provides it; bare `msmtp` does **not** — msmtp is
 a transport, so pair it with `msmtp-mta`.
 
-`health-alert.sh` now checks for the binary on every run and records its absence
+`health-alert.sh` checks for the binary on every run and records its absence
 in `.health-alert/mail-failed`, which `deploy.sh` surfaces. Confirm delivery end
 to end before trusting the setup:
 
@@ -273,7 +273,7 @@ for the cron user.
 whether it is still completing, and why the last attempted email failed. If it
 says the cron is missing, nothing is watching the server.
 
-Delivery is now provable while the system is healthy: the missing-binary marker
+Delivery is provable while the system is healthy: the missing-binary marker
 makes the next healthy run send one `SuperSync OK: Health Check Recovered`
 message and then clear the marker. So after installing an MTA on a healthy
 server, that single mail arriving within 5 minutes is the end-to-end proof —

--- a/packages/super-sync-server/scripts/MONITORING-README.md
+++ b/packages/super-sync-server/scripts/MONITORING-README.md
@@ -254,8 +254,10 @@ is not started by `deploy.sh` and nothing else runs it:
 
 `ALERT_EMAIL` plus the crontab line above gets the _checks_ running. Delivering
 their result needs a working `mail` command, and stock Debian and Ubuntu have
-none. `mailutils` or `bsd-mailx` provides it; bare `msmtp` does **not** — msmtp is
-a transport, so pair it with `msmtp-mta`.
+none. Install `mailutils` or `bsd-mailx` — those provide `mail` itself. Neither
+`msmtp` nor `msmtp-mta` does: msmtp is a transport and `msmtp-mta` only supplies
+the `sendmail` interface underneath, so installing it alone leaves the check
+still failing. Use it _in addition to_ `bsd-mailx` if msmtp is your relay.
 
 `health-alert.sh` checks for the binary on every run and records its absence
 in `.health-alert/mail-failed`, which `deploy.sh` surfaces. Confirm delivery end
@@ -269,16 +271,21 @@ A queuing MTA exits 0 on accept, not on delivery, so check the message actually
 arrived. If it did not, `mailx` writes the undelivered body to `~/dead.letter`
 for the cron user.
 
-`deploy.sh` reports at the end of every deploy whether this exact cron exists,
+`deploy.sh` reports at the end of every successful deploy whether this exact cron exists,
 whether it is still completing, and why the last attempted email failed. If it
 says the cron is missing, nothing is watching the server.
 
-Delivery is provable while the system is healthy: the missing-binary marker
-makes the next healthy run send one `SuperSync OK: Health Check Recovered`
-message and then clear the marker. So after installing an MTA on a healthy
-server, that single mail arriving within 5 minutes is the end-to-end proof —
-and `deploy.sh` dropping its warning is the confirmation. Nothing repeats: the
-marker is gone once a send succeeds.
+If the cron was already running _before_ you installed an MTA, you get a proof
+for free: the missing-binary marker makes the next healthy run send one
+`SuperSync OK: Health Check Recovered` message and then clear the marker. That
+single mail arriving within 5 minutes is end-to-end proof, and `deploy.sh`
+dropping its warning is the confirmation. Nothing repeats — the marker is gone
+once a send succeeds. Set up in the other order (MTA first, then cron) and no
+mail is ever sent on a healthy server, so use the manual `mail` test above.
+
+Note that the `Reason:` line `deploy.sh` prints comes from your MTA and can name
+the recipient address and the relay host, so treat it like any other log excerpt
+before pasting it into an issue.
 
 ### What it checks
 

--- a/packages/super-sync-server/scripts/MONITORING-README.md
+++ b/packages/super-sync-server/scripts/MONITORING-README.md
@@ -275,17 +275,13 @@ for the cron user.
 whether it is still completing, and why the last attempted email failed. If it
 says the cron is missing, nothing is watching the server.
 
-If the cron was already running _before_ you installed an MTA, you get a proof
-for free: the missing-binary marker makes the next healthy run send one
-`SuperSync OK: Health Check Recovered` message and then clear the marker. That
-single mail arriving within 5 minutes is end-to-end proof, and `deploy.sh`
-dropping its warning is the confirmation. Nothing repeats — the marker is gone
-once a send succeeds. Set up in the other order (MTA first, then cron) and no
-mail is ever sent on a healthy server, so use the manual `mail` test above.
+If the cron was already running _before_ you installed the MTA, the missing-binary
+marker gets you that proof for free: the next healthy run sends one
+`SuperSync OK: Health Check Recovered` message and clears the marker. In the other
+order nothing is sent on a healthy server, so use the manual test above.
 
-Note that the `Reason:` line `deploy.sh` prints comes from your MTA and can name
-the recipient address and the relay host, so treat it like any other log excerpt
-before pasting it into an issue.
+The `Reason:` line `deploy.sh` prints comes from your MTA and can name the recipient
+address and the relay host — redact it before pasting into an issue.
 
 ### What it checks
 

--- a/packages/super-sync-server/scripts/deploy.sh
+++ b/packages/super-sync-server/scripts/deploy.sh
@@ -453,6 +453,16 @@ echo "    All containers healthy"
 echo ""
 # Report whether the separately-installed alert cron is active and completing.
 # Advisory only: deploys never edit the operator's crontab. (#9191)
+# Flatten stdin to one printable line of at most $1 bytes. Used for the mail-failed
+# marker, whose reason text can originate from a remote SMTP relay.
+sanitize_untrusted() {
+    LC_ALL=C tr -d '\000-\010\013-\037\177' |
+        LC_ALL=C sed 's/\xc2[\x80-\x9f]//g' |
+        tr '\n\t' '  ' |
+        head -c "$1" |
+        sed 's/[[:space:]]*$//'
+}
+
 report_monitoring_status() {
     local state_dir="$SERVER_DIR/.health-alert"
     local script_path="$SERVER_DIR/scripts/health-alert.sh"
@@ -501,19 +511,25 @@ report_monitoring_status() {
         else
             echo "             Monitoring is not confirmed active. Install with:"
             echo "               (crontab -l 2>/dev/null; echo \"*/5 * * * * ALERT_EMAIL=you@example.com $script_path\") | crontab -"
-            echo "             Alerting also needs a working \`mail\` command (mailutils or bsd-mailx;"
-            echo "             bare msmtp needs msmtp-mta). Stock Debian/Ubuntu ship none."
+            echo "             Alerting also needs a \`mail\` command: install mailutils or"
+            echo "             bsd-mailx. Stock Debian/Ubuntu ship neither (msmtp-mta does not"
+            echo "             provide \`mail\` — it is a sendmail transport underneath them)."
         fi
     fi
 
     if [ -f "$state_dir/mail-failed" ]; then
-        # head -1: the marker gained a reason after the timestamp, and $(cat ...) strips
-        # only *trailing* newlines, so a multi-line marker would interpolate mid-sentence.
-        echo "    WARNING: alert email delivery FAILED at $(head -1 "$state_dir/mail-failed" 2>/dev/null)."
-        local mail_reason
-        mail_reason=$(tail -n +2 "$state_dir/mail-failed" 2>/dev/null | tr '\n\r\t' '   ' | head -c 200) || true
+        # This marker is operator data that survives `git pull` and may have been written
+        # by an older health-alert.sh, so sanitize on READ as well — the reason line can
+        # carry SMTP text authored by a remote relay. printf, not echo: under xpg_echo a
+        # printable \033 would be re-expanded into a real ESC after this filter ran.
+        # head -1 for the timestamp: $(cat ...) strips only *trailing* newlines, so a
+        # multi-line marker would interpolate mid-sentence.
+        local mail_ts mail_reason
+        mail_ts=$(head -1 "$state_dir/mail-failed" 2>/dev/null | sanitize_untrusted 60) || true
+        printf '    WARNING: alert email delivery FAILED at %s.\n' "$mail_ts"
+        mail_reason=$(tail -n +2 "$state_dir/mail-failed" 2>/dev/null | sanitize_untrusted 200) || true
         if [ -n "$mail_reason" ]; then
-            echo "             Reason: $mail_reason"
+            printf '             Reason: %s\n' "$mail_reason"
         fi
         echo "             Checks are running but nobody is being told. Verify \`mail\` works."
     else

--- a/packages/super-sync-server/scripts/deploy.sh
+++ b/packages/super-sync-server/scripts/deploy.sh
@@ -510,7 +510,7 @@ report_monitoring_status() {
         # head -1: the marker gained a reason after the timestamp, and $(cat ...) strips
         # only *trailing* newlines, so a multi-line marker would interpolate mid-sentence.
         echo "    WARNING: alert email delivery FAILED at $(head -1 "$state_dir/mail-failed" 2>/dev/null)."
-        local mail_reason=""
+        local mail_reason
         mail_reason=$(tail -n +2 "$state_dir/mail-failed" 2>/dev/null | tr '\n\r\t' '   ' | head -c 200) || true
         if [ -n "$mail_reason" ]; then
             echo "             Reason: $mail_reason"

--- a/packages/super-sync-server/scripts/deploy.sh
+++ b/packages/super-sync-server/scripts/deploy.sh
@@ -501,11 +501,20 @@ report_monitoring_status() {
         else
             echo "             Monitoring is not confirmed active. Install with:"
             echo "               (crontab -l 2>/dev/null; echo \"*/5 * * * * ALERT_EMAIL=you@example.com $script_path\") | crontab -"
+            echo "             Alerting also needs a working \`mail\` command (mailutils or bsd-mailx;"
+            echo "             bare msmtp needs msmtp-mta). Stock Debian/Ubuntu ship none."
         fi
     fi
 
     if [ -f "$state_dir/mail-failed" ]; then
-        echo "    WARNING: alert email delivery FAILED at $(cat "$state_dir/mail-failed" 2>/dev/null)."
+        # head -1: the marker gained a reason after the timestamp, and $(cat ...) strips
+        # only *trailing* newlines, so a multi-line marker would interpolate mid-sentence.
+        echo "    WARNING: alert email delivery FAILED at $(head -1 "$state_dir/mail-failed" 2>/dev/null)."
+        local mail_reason=""
+        mail_reason=$(tail -n +2 "$state_dir/mail-failed" 2>/dev/null | tr '\n\r\t' '   ' | head -c 200) || true
+        if [ -n "$mail_reason" ]; then
+            echo "             Reason: $mail_reason"
+        fi
         echo "             Checks are running but nobody is being told. Verify \`mail\` works."
     else
         echo "    alert email: no recorded failure (verified only when mail is attempted)"

--- a/packages/super-sync-server/scripts/deploy.sh
+++ b/packages/super-sync-server/scripts/deploy.sh
@@ -493,13 +493,15 @@ report_monitoring_status() {
     # runs the script and the current user's crontab has no matching entry.
     if [ -f "$state_dir/last-run" ]; then
         local last_run age
-        last_run=$(cat "$state_dir/last-run" 2>/dev/null || true)
+        # Same directory, same trust boundary as mail-failed below: sanitize before
+        # printing. A bad value just fails the date parse, which the >30m branch reports.
+        last_run=$(sanitize_untrusted 40 < "$state_dir/last-run" 2>/dev/null) || true
         age=$(( $(date -u +%s) - $(date -u -d "$last_run" +%s 2>/dev/null || echo 0) ))
         if [ "$age" -gt 1800 ]; then
-            echo "    WARNING: last completed run was $last_run (>30m ago) — health-alert.sh is not completing."
+            printf '    WARNING: last completed run was %s (>30m ago) — health-alert.sh is not completing.\n' "$last_run"
         else
             recent_run=true
-            echo "    last run: $last_run"
+            printf '    last run: %s\n' "$last_run"
         fi
     else
         echo "    WARNING: health-alert.sh has no completed run recorded yet (expected within 5 minutes)."

--- a/packages/super-sync-server/scripts/deploy.sh
+++ b/packages/super-sync-server/scripts/deploy.sh
@@ -451,10 +451,8 @@ echo "    All containers healthy"
 
 # Verify HTTPS health check
 echo ""
-# Report whether the separately-installed alert cron is active and completing.
-# Advisory only: deploys never edit the operator's crontab. (#9191)
-# Flatten stdin to one printable line of at most $1 bytes. Used for the mail-failed
-# marker, whose reason text can originate from a remote SMTP relay.
+# Flatten stdin to one printable line of at most $1 bytes. Used for the .health-alert
+# markers, whose text can originate from a remote SMTP relay.
 sanitize_untrusted() {
     LC_ALL=C tr -d '\000-\010\013-\037\177' |
         LC_ALL=C sed 's/\xc2[\x80-\x9f]//g' |
@@ -463,6 +461,8 @@ sanitize_untrusted() {
         sed 's/[[:space:]]*$//'
 }
 
+# Report whether the separately-installed alert cron is active and completing.
+# Advisory only: deploys never edit the operator's crontab. (#9191)
 report_monitoring_status() {
     local state_dir="$SERVER_DIR/.health-alert"
     local script_path="$SERVER_DIR/scripts/health-alert.sh"
@@ -513,21 +513,20 @@ report_monitoring_status() {
         else
             echo "             Monitoring is not confirmed active. Install with:"
             echo "               (crontab -l 2>/dev/null; echo \"*/5 * * * * ALERT_EMAIL=you@example.com $script_path\") | crontab -"
-            echo "             Alerting also needs a \`mail\` command: install mailutils or"
-            echo "             bsd-mailx. Stock Debian/Ubuntu ship neither (msmtp-mta does not"
-            echo "             provide \`mail\` — it is a sendmail transport underneath them)."
+            echo "             Alerting also needs a \`mail\` command (mailutils or bsd-mailx;"
+            echo "             msmtp-mta does not provide one) — see scripts/MONITORING-README.md."
         fi
     fi
 
     if [ -f "$state_dir/mail-failed" ]; then
-        # This marker is operator data that survives `git pull` and may have been written
-        # by an older health-alert.sh, so sanitize on READ as well — the reason line can
-        # carry SMTP text authored by a remote relay. printf, not echo: under xpg_echo a
-        # printable \033 would be re-expanded into a real ESC after this filter ran.
-        # head -1 for the timestamp: $(cat ...) strips only *trailing* newlines, so a
-        # multi-line marker would interpolate mid-sentence.
+        # sanitize_untrusted both flattens and filters here, and both jobs are load-bearing.
+        # Flattening: record_mail_failure keeps the newline that separates timestamp from
+        # reason, and this printf is one line. Filtering: .health-alert is 0700 only until an
+        # operator widens it so a non-root deploy.sh can read it, and the reason is SMTP text
+        # from a remote relay either way. Keep the C1 filter in sync with health-alert.sh's
+        # record_mail_failure. printf, not echo — xpg_echo re-expands a printable \033.
         local mail_ts mail_reason
-        mail_ts=$(head -1 "$state_dir/mail-failed" 2>/dev/null | sanitize_untrusted 60) || true
+        mail_ts=$(head -1 "$state_dir/mail-failed" 2>/dev/null | sanitize_untrusted 40) || true
         printf '    WARNING: alert email delivery FAILED at %s.\n' "$mail_ts"
         mail_reason=$(tail -n +2 "$state_dir/mail-failed" 2>/dev/null | sanitize_untrusted 200) || true
         if [ -n "$mail_reason" ]; then

--- a/packages/super-sync-server/scripts/health-alert.sh
+++ b/packages/super-sync-server/scripts/health-alert.sh
@@ -68,11 +68,13 @@ MAIL_FAILED_FILE="$ALERT_STATE_DIR/mail-failed"
 # Record why mail could not be delivered. Line 1 is always the timestamp, so readers that
 # want only that (deploy.sh) can take the first line; the reason follows. Reason text can
 # originate from a remote SMTP relay and deploy.sh echoes it to a terminal, so strip
-# control characters and cap the length at write time.
+# control characters and cap the length at write time. The range covers C1 (\200-\237)
+# as well as C0: 0x9B is a single-byte CSI in an 8-bit locale, the same line-overwrite
+# trick as CR. Tab and LF are kept deliberately.
 record_mail_failure() {
   {
     date -u +%Y-%m-%dT%H:%M:%SZ
-    printf '%s\n' "$1" | LC_ALL=C tr -d '\000-\010\013-\037\177' | head -c 4096
+    printf '%s\n' "$1" | LC_ALL=C tr -d '\000-\010\013-\037\177\200-\237' | head -c 4096
   } > "$MAIL_FAILED_FILE"
   chmod 600 "$MAIL_FAILED_FILE" 2>/dev/null || true
 }

--- a/packages/super-sync-server/scripts/health-alert.sh
+++ b/packages/super-sync-server/scripts/health-alert.sh
@@ -73,17 +73,15 @@ MAIL_FAILED_FILE="$ALERT_STATE_DIR/mail-failed"
 # every non-ASCII message, this script's own em-dash included (tried in 096c93ca, reverted
 # in bef0c160). The sed removes UTF-8-*encoded* C1 instead — \xc2 followed by \x80-\x9f
 # encodes U+0080-U+009F and nothing else, so CSI/OSC are removed exactly while em-dash,
-# NBSP and CJK survive. Written via mktemp+mv: `>` would follow a symlink planted at the
-# marker path, and mv also replaces the file atomically at the umask's 0600.
+# NBSP and CJK survive. Like `state`, `last-run` and the lock file, this write follows a
+# symlink planted at its path; hardening one of the four sites would close nothing, so the
+# residual is accepted here on the same terms as its siblings rather than papered over.
 record_mail_failure() {
-  local tmp
-  tmp=$(mktemp "$ALERT_STATE_DIR/.mail-failed.XXXXXX" 2>/dev/null) || return 0
   {
     date -u +%Y-%m-%dT%H:%M:%SZ
     printf '%s\n' "$1" | LC_ALL=C tr -d '\000-\010\013-\037\177' |
       LC_ALL=C sed 's/\xc2[\x80-\x9f]//g' | head -c 4096
-  } > "$tmp"
-  mv -f "$tmp" "$MAIL_FAILED_FILE" 2>/dev/null || rm -f "$tmp"
+  } > "$MAIL_FAILED_FILE"
 }
 
 # One send path for both call sites, so stderr capture and the failure record cannot
@@ -95,15 +93,16 @@ send_alert_mail() {
   # MTA that forks a delivery child survives `timeout 30` and hangs the run indefinitely
   # while holding the flock — silently killing every later cron run. stdout is discarded
   # because that is where msmtp --debug prints the SMTP dialogue, AUTH included.
-  errfile=$(mktemp "$ALERT_STATE_DIR/.mail-err.XXXXXX" 2>/dev/null) || errfile=/dev/null
+  # Fixed name, not mktemp: the flock means one run at a time, so there is no collision
+  # to avoid, and a fixed path cannot accumulate orphans when a run is killed mid-send.
+  errfile="$ALERT_STATE_DIR/.mail-err"
   timeout 30 "$MAIL_CMD" -s "$1" -- "$ALERT_EMAIL" >/dev/null 2>"$errfile"
   rc=$?
+  err=$(head -c 4096 "$errfile" 2>/dev/null || true)
+  rm -f "$errfile"
   if [ "$rc" -eq 0 ]; then
-    [ "$errfile" = /dev/null ] || rm -f "$errfile"
     return 0
   fi
-  err=$(head -c 4096 "$errfile" 2>/dev/null || true)
-  [ "$errfile" = /dev/null ] || rm -f "$errfile"
   if [ "$rc" -eq 124 ]; then
     err="timed out after 30s${err:+: $err}"
   fi

--- a/packages/super-sync-server/scripts/health-alert.sh
+++ b/packages/super-sync-server/scripts/health-alert.sh
@@ -11,6 +11,8 @@
 #
 # Configuration (set these or pass via environment):
 #   ALERT_EMAIL    - Email address to receive alerts (required)
+#   MAIL_CMD       - mail binary to use (default: mail); mainly a test seam, but also
+#                    useful for an absolute path under a thin cron PATH
 #   COMPOSE_DIR    - Path to docker-compose.yml directory (default: script directory's parent)
 #   HEALTH_URL     - Health endpoint URL (default: read from .env DOMAIN)
 #   MAX_QUERY_SECONDS  - Alert if any query has been active longer (default: 120)
@@ -68,25 +70,24 @@ MAIL_FAILED_FILE="$ALERT_STATE_DIR/mail-failed"
 # Record why mail could not be delivered. Line 1 is always the timestamp, so readers that
 # want only that (deploy.sh) can take the first line; the reason follows. Reason text can
 # originate from a remote SMTP relay and deploy.sh echoes it to a terminal, so strip
-# control characters and cap the length at write time. The range covers C1 (\200-\237)
-# as well as C0: 0x9B is a single-byte CSI in an 8-bit locale, the same line-overwrite
-# trick as CR. Tab and LF are kept deliberately.
+# control characters and cap the length at write time. C1 (0x80-0x9F) is deliberately
+# NOT stripped: those bytes are also UTF-8 continuation bytes, so deleting them mangles
+# every non-ASCII message — including this script's own em-dash at the record_mail_failure
+# call below. A lone C1 byte is invalid UTF-8 and renders as a replacement character;
+# it is only a CSI in a legacy 8-bit locale, which is not worth corrupting output for.
 record_mail_failure() {
   {
     date -u +%Y-%m-%dT%H:%M:%SZ
-    printf '%s\n' "$1" | LC_ALL=C tr -d '\000-\010\013-\037\177\200-\237' | head -c 4096
+    printf '%s\n' "$1" | LC_ALL=C tr -d '\000-\010\013-\037\177' | head -c 4096
   } > "$MAIL_FAILED_FILE"
   chmod 600 "$MAIL_FAILED_FILE" 2>/dev/null || true
 }
 
-# One send path, so the no-transport short-circuit cannot be forgotten at one of the two
-# call sites. Body on stdin; returns non-zero and records why on failure.
+# One send path for both call sites, so stderr capture and the failure record cannot
+# drift apart. Body on stdin; returns non-zero and records why on failure. Callers are
+# responsible for the $MAIL_AVAILABLE gate — see the two send conditions below.
 send_alert_mail() {
   local err
-  if ! $MAIL_AVAILABLE; then
-    cat > /dev/null
-    return 1
-  fi
   # `2>&1 >/dev/null` captures only stderr: "not installed", "relay refused" and "auth
   # failed" are indistinguishable once discarded. timeout 30 stays — under a 5-minute cron
   # an MTA hanging on an unreachable relay is a process-pileup vector.
@@ -397,7 +398,6 @@ if [ -n "$PROBLEMS" ]; then
       echo "$CURRENT_HASH" > "$ALERT_STATE_FILE"
       rm -f "$MAIL_FAILED_FILE"
     else
-      # send_alert_mail already recorded the reason in the marker deploy.sh surfaces.
       echo "ERROR: Failed to send alert email" >&2
     fi
   fi

--- a/packages/super-sync-server/scripts/health-alert.sh
+++ b/packages/super-sync-server/scripts/health-alert.sh
@@ -11,8 +11,7 @@
 #
 # Configuration (set these or pass via environment):
 #   ALERT_EMAIL    - Email address to receive alerts (required)
-#   MAIL_CMD       - mail binary to use (default: mail); mainly a test seam, but also
-#                    useful for an absolute path under a thin cron PATH
+#   MAIL_CMD       - mail binary to use (default: mail); a test seam
 #   COMPOSE_DIR    - Path to docker-compose.yml directory (default: script directory's parent)
 #   HEALTH_URL     - Health endpoint URL (default: read from .env DOMAIN)
 #   MAX_QUERY_SECONDS  - Alert if any query has been active longer (default: 120)
@@ -30,6 +29,7 @@ COMPOSE_DIR="${COMPOSE_DIR:-$(dirname "$SCRIPT_DIR")}"
 # default address would silently mail a self-hoster's hostname, disk usage and container
 # state to whoever that address belongs to. Alerting is off until the operator opts in.
 ALERT_EMAIL="${ALERT_EMAIL:-}"
+MAIL_CMD="${MAIL_CMD:-mail}"
 MAX_QUERY_SECONDS="${MAX_QUERY_SECONDS:-120}"
 POOL_WARN_PCT="${POOL_WARN_PCT:-75}"
 
@@ -59,42 +59,55 @@ fi
 
 # State file in project-local directory (not /tmp — avoids symlink attacks and tmp cleanup)
 ALERT_STATE_DIR="${COMPOSE_DIR}/.health-alert"
+# umask 077 makes this 0700; deliberately not chmod'd on later runs, so an operator who
+# widens it (to let a non-root deploy.sh read the markers) is not silently overridden.
 mkdir -p "$ALERT_STATE_DIR"
-# umask 077 above only applies at creation; a .health-alert/ created earlier by anything
-# else keeps its old mode, and mail-failed can carry the recipient address and the relay
-# hostname. Enforce owner-only rather than inferring it.
-chmod 700 "$ALERT_STATE_DIR" 2>/dev/null || true
 ALERT_STATE_FILE="$ALERT_STATE_DIR/state"
 MAIL_FAILED_FILE="$ALERT_STATE_DIR/mail-failed"
 
 # Record why mail could not be delivered. Line 1 is always the timestamp, so readers that
 # want only that (deploy.sh) can take the first line; the reason follows. Reason text can
 # originate from a remote SMTP relay and deploy.sh echoes it to a terminal, so strip
-# control characters and cap the length at write time. C1 (0x80-0x9F) is deliberately
-# NOT stripped: those bytes are also UTF-8 continuation bytes, so deleting them mangles
-# every non-ASCII message — including this script's own em-dash at the record_mail_failure
-# call below. A lone C1 byte is invalid UTF-8 and renders as a replacement character;
-# it is only a CSI in a legacy 8-bit locale, which is not worth corrupting output for.
+# control characters and cap the length at write time. Do NOT switch the tr to a byte
+# range covering 0x80-0x9F: those are UTF-8 continuation bytes and deleting them corrupts
+# every non-ASCII message, this script's own em-dash included (tried in 096c93ca, reverted
+# in bef0c160). The sed removes UTF-8-*encoded* C1 instead — \xc2 followed by \x80-\x9f
+# encodes U+0080-U+009F and nothing else, so CSI/OSC are removed exactly while em-dash,
+# NBSP and CJK survive. Written via mktemp+mv: `>` would follow a symlink planted at the
+# marker path, and mv also replaces the file atomically at the umask's 0600.
 record_mail_failure() {
+  local tmp
+  tmp=$(mktemp "$ALERT_STATE_DIR/.mail-failed.XXXXXX" 2>/dev/null) || return 0
   {
     date -u +%Y-%m-%dT%H:%M:%SZ
-    printf '%s\n' "$1" | LC_ALL=C tr -d '\000-\010\013-\037\177' | head -c 4096
-  } > "$MAIL_FAILED_FILE"
-  chmod 600 "$MAIL_FAILED_FILE" 2>/dev/null || true
+    printf '%s\n' "$1" | LC_ALL=C tr -d '\000-\010\013-\037\177' |
+      LC_ALL=C sed 's/\xc2[\x80-\x9f]//g' | head -c 4096
+  } > "$tmp"
+  mv -f "$tmp" "$MAIL_FAILED_FILE" 2>/dev/null || rm -f "$tmp"
 }
 
 # One send path for both call sites, so stderr capture and the failure record cannot
 # drift apart. Body on stdin; returns non-zero and records why on failure. Callers are
 # responsible for the $MAIL_AVAILABLE gate — see the two send conditions below.
 send_alert_mail() {
-  local err
-  # `2>&1 >/dev/null` captures only stderr: "not installed", "relay refused" and "auth
-  # failed" are indistinguishable once discarded. timeout 30 stays — under a 5-minute cron
-  # an MTA hanging on an unreachable relay is a process-pileup vector.
-  if err=$(timeout 30 "$MAIL_CMD" -s "$1" "$ALERT_EMAIL" 2>&1 >/dev/null); then
+  local err errfile rc
+  # stderr to a FILE, never `err=$(...)`: command substitution waits for pipe EOF, so an
+  # MTA that forks a delivery child survives `timeout 30` and hangs the run indefinitely
+  # while holding the flock — silently killing every later cron run. stdout is discarded
+  # because that is where msmtp --debug prints the SMTP dialogue, AUTH included.
+  errfile=$(mktemp "$ALERT_STATE_DIR/.mail-err.XXXXXX" 2>/dev/null) || errfile=/dev/null
+  timeout 30 "$MAIL_CMD" -s "$1" -- "$ALERT_EMAIL" >/dev/null 2>"$errfile"
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    [ "$errfile" = /dev/null ] || rm -f "$errfile"
     return 0
   fi
-  record_mail_failure "${err:-mail exited non-zero with no error output}"
+  err=$(head -c 4096 "$errfile" 2>/dev/null || true)
+  [ "$errfile" = /dev/null ] || rm -f "$errfile"
+  if [ "$rc" -eq 124 ]; then
+    err="timed out after 30s${err:+: $err}"
+  fi
+  record_mail_failure "${err:-mail exited $rc with no error output}"
   return 1
 }
 
@@ -111,7 +124,6 @@ fi
 # not added to CONFIG_PROBLEMS: that string is the alert body and the dedupe hash input, so
 # it would report the broken channel through the broken channel and keep PROBLEMS
 # permanently non-empty, disabling the recovery branch that clears this marker.
-MAIL_CMD="${MAIL_CMD:-mail}"
 MAIL_AVAILABLE=true
 if ! command -v "$MAIL_CMD" >/dev/null 2>&1; then
   MAIL_AVAILABLE=false

--- a/packages/super-sync-server/scripts/health-alert.sh
+++ b/packages/super-sync-server/scripts/health-alert.sh
@@ -59,50 +59,46 @@ fi
 
 # State file in project-local directory (not /tmp — avoids symlink attacks and tmp cleanup)
 ALERT_STATE_DIR="${COMPOSE_DIR}/.health-alert"
-# umask 077 makes this 0700; deliberately not chmod'd on later runs, so an operator who
-# widens it (to let a non-root deploy.sh read the markers) is not silently overridden.
+# umask 077 makes this 0700. Later runs do not re-chmod it, so an operator can widen it to
+# let a non-root deploy.sh read the markers — which is why deploy.sh sanitizes on read too.
 mkdir -p "$ALERT_STATE_DIR"
 ALERT_STATE_FILE="$ALERT_STATE_DIR/state"
 MAIL_FAILED_FILE="$ALERT_STATE_DIR/mail-failed"
+MAIL_ERR_MAX_BYTES=4096
 
 # Record why mail could not be delivered. Line 1 is always the timestamp, so readers that
 # want only that (deploy.sh) can take the first line; the reason follows. Reason text can
 # originate from a remote SMTP relay and deploy.sh echoes it to a terminal, so strip
-# control characters and cap the length at write time. Do NOT switch the tr to a byte
-# range covering 0x80-0x9F: those are UTF-8 continuation bytes and deleting them corrupts
-# every non-ASCII message, this script's own em-dash included (tried in 096c93ca, reverted
-# in bef0c160). The sed removes UTF-8-*encoded* C1 instead — \xc2 followed by \x80-\x9f
-# encodes U+0080-U+009F and nothing else, so CSI/OSC are removed exactly while em-dash,
-# NBSP and CJK survive. Like `state`, `last-run` and the lock file, this write follows a
-# symlink planted at its path; hardening one of the four sites would close nothing, so the
-# residual is accepted here on the same terms as its siblings rather than papered over.
+# control characters and cap the length at write time. The sed matches UTF-8-*encoded* C1
+# (\xc2 followed by \x80-\x9f, which encodes U+0080-U+009F and nothing else) so CSI/OSC go
+# but em-dash, NBSP and CJK survive; a plain 0x80-0x9F byte range would instead eat UTF-8
+# continuation bytes and corrupt every non-ASCII message. Both halves are pinned by the
+# "strips UTF-8-encoded C1 controls" spec case.
 record_mail_failure() {
   {
     date -u +%Y-%m-%dT%H:%M:%SZ
     printf '%s\n' "$1" | LC_ALL=C tr -d '\000-\010\013-\037\177' |
-      LC_ALL=C sed 's/\xc2[\x80-\x9f]//g' | head -c 4096
+      LC_ALL=C sed 's/\xc2[\x80-\x9f]//g' | head -c "$MAIL_ERR_MAX_BYTES"
   } > "$MAIL_FAILED_FILE"
 }
 
-# One send path for both call sites, so stderr capture and the failure record cannot
-# drift apart. Body on stdin; returns non-zero and records why on failure. Callers are
-# responsible for the $MAIL_AVAILABLE gate — see the two send conditions below.
+# One send path for both call sites. Body on stdin; returns non-zero and records why on
+# failure. Callers gate on $MAIL_AVAILABLE — see the two send conditions below.
 send_alert_mail() {
   local err errfile rc
   # stderr to a FILE, never `err=$(...)`: command substitution waits for pipe EOF, so an
   # MTA that forks a delivery child survives `timeout 30` and hangs the run indefinitely
   # while holding the flock — silently killing every later cron run. stdout is discarded
   # because that is where msmtp --debug prints the SMTP dialogue, AUTH included.
-  # Fixed name, not mktemp: the flock means one run at a time, so there is no collision
-  # to avoid, and a fixed path cannot accumulate orphans when a run is killed mid-send.
   errfile="$ALERT_STATE_DIR/.mail-err"
   timeout 30 "$MAIL_CMD" -s "$1" -- "$ALERT_EMAIL" >/dev/null 2>"$errfile"
   rc=$?
-  err=$(head -c 4096 "$errfile" 2>/dev/null || true)
-  rm -f "$errfile"
   if [ "$rc" -eq 0 ]; then
+    rm -f "$errfile"
     return 0
   fi
+  err=$(head -c "$MAIL_ERR_MAX_BYTES" "$errfile" 2>/dev/null)
+  rm -f "$errfile"
   if [ "$rc" -eq 124 ]; then
     err="timed out after 30s${err:+: $err}"
   fi
@@ -117,12 +113,11 @@ if ! flock -n 9; then
   exit 0
 fi
 
-# Alerting is only as good as its transport, and a stock Debian/Ubuntu host has no `mail`
-# binary. Without this check the first discovery of that is the first real incident, months
-# after setup. Record it now instead, in the marker deploy.sh already surfaces. Deliberately
-# not added to CONFIG_PROBLEMS: that string is the alert body and the dedupe hash input, so
-# it would report the broken channel through the broken channel and keep PROBLEMS
-# permanently non-empty, disabling the recovery branch that clears this marker.
+# A stock Debian/Ubuntu host has no `mail` binary, and without this check the first
+# discovery of that is the first real incident, months after setup. Record it in the marker
+# deploy.sh already surfaces — never in CONFIG_PROBLEMS, which is the alert body and the
+# dedupe hash input: routing it there would report the broken channel through the broken
+# channel and keep PROBLEMS permanently non-empty, disabling the recovery branch.
 MAIL_AVAILABLE=true
 if ! command -v "$MAIL_CMD" >/dev/null 2>&1; then
   MAIL_AVAILABLE=false

--- a/packages/super-sync-server/scripts/health-alert.sh
+++ b/packages/super-sync-server/scripts/health-alert.sh
@@ -58,13 +58,62 @@ fi
 # State file in project-local directory (not /tmp — avoids symlink attacks and tmp cleanup)
 ALERT_STATE_DIR="${COMPOSE_DIR}/.health-alert"
 mkdir -p "$ALERT_STATE_DIR"
+# umask 077 above only applies at creation; a .health-alert/ created earlier by anything
+# else keeps its old mode, and mail-failed can carry the recipient address and the relay
+# hostname. Enforce owner-only rather than inferring it.
+chmod 700 "$ALERT_STATE_DIR" 2>/dev/null || true
 ALERT_STATE_FILE="$ALERT_STATE_DIR/state"
+MAIL_FAILED_FILE="$ALERT_STATE_DIR/mail-failed"
+
+# Record why mail could not be delivered. Line 1 is always the timestamp, so readers that
+# want only that (deploy.sh) can take the first line; the reason follows. Reason text can
+# originate from a remote SMTP relay and deploy.sh echoes it to a terminal, so strip
+# control characters and cap the length at write time.
+record_mail_failure() {
+  {
+    date -u +%Y-%m-%dT%H:%M:%SZ
+    printf '%s\n' "$1" | LC_ALL=C tr -d '\000-\010\013-\037\177' | head -c 4096
+  } > "$MAIL_FAILED_FILE"
+  chmod 600 "$MAIL_FAILED_FILE" 2>/dev/null || true
+}
+
+# One send path, so the no-transport short-circuit cannot be forgotten at one of the two
+# call sites. Body on stdin; returns non-zero and records why on failure.
+send_alert_mail() {
+  local err
+  if ! $MAIL_AVAILABLE; then
+    cat > /dev/null
+    return 1
+  fi
+  # `2>&1 >/dev/null` captures only stderr: "not installed", "relay refused" and "auth
+  # failed" are indistinguishable once discarded. timeout 30 stays — under a 5-minute cron
+  # an MTA hanging on an unreachable relay is a process-pileup vector.
+  if err=$(timeout 30 "$MAIL_CMD" -s "$1" "$ALERT_EMAIL" 2>&1 >/dev/null); then
+    return 0
+  fi
+  record_mail_failure "${err:-mail exited non-zero with no error output}"
+  return 1
+}
 
 # Prevent concurrent runs (cron overlap if a previous run hangs)
 LOCK_FILE="$ALERT_STATE_DIR/health-alert.lock"
 exec 9>"$LOCK_FILE"
 if ! flock -n 9; then
   exit 0
+fi
+
+# Alerting is only as good as its transport, and a stock Debian/Ubuntu host has no `mail`
+# binary. Without this check the first discovery of that is the first real incident, months
+# after setup. Record it now instead, in the marker deploy.sh already surfaces. Deliberately
+# not added to CONFIG_PROBLEMS: that string is the alert body and the dedupe hash input, so
+# it would report the broken channel through the broken channel and keep PROBLEMS
+# permanently non-empty, disabling the recovery branch that clears this marker.
+MAIL_CMD="${MAIL_CMD:-mail}"
+MAIL_AVAILABLE=true
+if ! command -v "$MAIL_CMD" >/dev/null 2>&1; then
+  MAIL_AVAILABLE=false
+  echo "health-alert: no '$MAIL_CMD' binary on PATH — install mailutils or bsd-mailx." >&2
+  record_mail_failure "no $MAIL_CMD binary on PATH — install mailutils or bsd-mailx"
 fi
 
 cd "$COMPOSE_DIR"
@@ -338,30 +387,28 @@ CURRENT_HASH=$(printf '%s' "$HASH_INPUT" | sha256sum | cut -d' ' -f1)
 PREVIOUS_HASH=$(cat "$ALERT_STATE_FILE" 2>/dev/null || echo "none")
 
 if [ -n "$PROBLEMS" ]; then
-  if [ "$CURRENT_HASH" != "$PREVIOUS_HASH" ] || [ -f "$ALERT_STATE_DIR/mail-failed" ]; then
+  if $MAIL_AVAILABLE && { [ "$CURRENT_HASH" != "$PREVIOUS_HASH" ] || [ -f "$MAIL_FAILED_FILE" ]; }; then
     # New or changed problem — send alert, only write state if mail succeeds
     if printf 'SuperSync health check failed at %s\n\nProblems found:\n%b\nServer: %s\n' \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROBLEMS" "$(hostname)" \
-        | timeout 30 mail -s "SuperSync Alert: Health Check Failed" "$ALERT_EMAIL" 2>/dev/null; then
+        | send_alert_mail "SuperSync Alert: Health Check Failed"; then
       echo "$CURRENT_HASH" > "$ALERT_STATE_FILE"
-      rm -f "$ALERT_STATE_DIR/mail-failed"
+      rm -f "$MAIL_FAILED_FILE"
     else
-      # Leave a marker deploy.sh can surface when cron cannot deliver mail.
+      # send_alert_mail already recorded the reason in the marker deploy.sh surfaces.
       echo "ERROR: Failed to send alert email" >&2
-      date -u +%Y-%m-%dT%H:%M:%SZ > "$ALERT_STATE_DIR/mail-failed"
     fi
   fi
 else
   # A healthy retry also proves mail works again and clears a sticky failure marker.
-  if [ -f "$ALERT_STATE_FILE" ] || [ -f "$ALERT_STATE_DIR/mail-failed" ]; then
+  if $MAIL_AVAILABLE && { [ -f "$ALERT_STATE_FILE" ] || [ -f "$MAIL_FAILED_FILE" ]; }; then
     if printf 'SuperSync health check recovered at %s\n\nAll checks passing.\nServer: %s\n' \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(hostname)" \
-        | timeout 30 mail -s "SuperSync OK: Health Check Recovered" "$ALERT_EMAIL" 2>/dev/null; then
+        | send_alert_mail "SuperSync OK: Health Check Recovered"; then
       rm -f "$ALERT_STATE_FILE"
-      rm -f "$ALERT_STATE_DIR/mail-failed"
+      rm -f "$MAIL_FAILED_FILE"
     else
       echo "ERROR: Failed to send recovery email" >&2
-      date -u +%Y-%m-%dT%H:%M:%SZ > "$ALERT_STATE_DIR/mail-failed"
     fi
   fi
 fi

--- a/packages/super-sync-server/tests/health-alert-script.spec.ts
+++ b/packages/super-sync-server/tests/health-alert-script.spec.ts
@@ -74,7 +74,7 @@ const FAKE_MAIL = `#!/bin/sh
 printf '%s\n' "$*" >> "$FAKE_STATE/mail.args"
 printf '%s\n' '---MAIL---' >> "$FAKE_STATE/mail.log"
 cat >> "$FAKE_STATE/mail.log"
-[ -z "\${FAKE_MAIL_STDERR:-}" ] || printf '%s\n' "\$FAKE_MAIL_STDERR" >&2
+[ -z "\${FAKE_MAIL_STDERR:-}" ] || printf '%b\n' "\$FAKE_MAIL_STDERR" >&2
 exit "\${FAKE_MAIL_EXIT:-0}"
 `;
 
@@ -137,9 +137,18 @@ const runDeployMonitoringStatus = (): string => {
   const deployScript = readFileSync(DEPLOY_SCRIPT, 'utf8');
   const match = deployScript.match(/report_monitoring_status\(\) \{[\s\S]*?\n\}/);
   expect(match).not.toBeNull();
+  // The reporter calls this helper; extract it too, or the runner silently loses the
+  // sanitizing and every assertion below passes against unfiltered marker text.
+  const helper = deployScript.match(/sanitize_untrusted\(\) \{[\s\S]*?\n\}/);
+  expect(helper).not.toBeNull();
 
   const runner = join(projectDir, 'report-monitoring-status.sh');
-  writeFileSync(runner, `${match?.[0] ?? ''}\nreport_monitoring_status\n`);
+  // Same options deploy.sh sets at :16-17 — the `|| true` guards in the reporter are
+  // load-bearing only under these, so a runner without them cannot catch their loss.
+  writeFileSync(
+    runner,
+    `set -euo pipefail\nshopt -s inherit_errexit 2>/dev/null || true\n${helper?.[0] ?? ''}\n${match?.[0] ?? ''}\nreport_monitoring_status\n`,
+  );
   writeExecutable('crontab', '#!/bin/sh\nexit 1\n');
 
   const result = spawnSync('bash', [runner], {
@@ -442,6 +451,42 @@ describe('health-alert.sh state handling', () => {
     expect(text.length).toBeLessThanOrEqual(4200);
   });
 
+  it('strips UTF-8-encoded C1 controls without corrupting other UTF-8', () => {
+    // \\302\\233 is the well-formed UTF-8 encoding of U+009B (CSI). Both bytes are >= 0x80,
+    // so a plain C0 byte filter passes them through and the terminal decodes a real
+    // control. Stripping the byte RANGE 0x80-0x9F instead would corrupt every non-ASCII
+    // string, so the em-dash and CJK below must survive untouched.
+    const marker = run({
+      FAKE_LONG_Q: '1',
+      FAKE_LONGEST: '130',
+      FAKE_MAIL_EXIT: '1',
+      FAKE_MAIL_STDERR:
+        'relay \\302\\2331;31mRED said \\342\\200\\224 dash \\346\\227\\245',
+    });
+    expect(marker.output).toContain('Failed to send alert email');
+    const text = readStateFile('mail-failed');
+    expect(text).toContain('relay 1;31mRED said — dash 日');
+    expect(text).not.toContain('\u009b');
+  });
+
+  it('does not hang when the mail command forks a child that outlives it', () => {
+    // `err=$(...)` waits for pipe EOF, not for the process, so a forked delivery child
+    // keeps the run alive past `timeout 30` while it holds the flock — which silently
+    // kills every later cron run. A queuing MTA daemonizes exactly like this.
+    writeExecutable(
+      'mail',
+      `#!/bin/sh\nsh -c 'sleep 30' &\nprintf '%s\\n' 'smtp: 451 try again' >&2\nexit 1\n`,
+    );
+    const started = Date.now();
+    const result = run({ FAKE_LONG_Q: '1', FAKE_LONGEST: '130' });
+    const elapsedMs = Date.now() - started;
+
+    expect(result.output).toContain('Failed to send alert email');
+    expect(readStateFile('mail-failed')).toContain('451 try again');
+    // The forked child sleeps 30s; anything near that means the run blocked on it.
+    expect(elapsedMs).toBeLessThan(15_000);
+  });
+
   it('reports heartbeat and mail failure even without a current-user cron entry', () => {
     const stateDir = join(projectDir, '.health-alert');
     mkdirSync(stateDir);
@@ -459,5 +504,23 @@ describe('health-alert.sh state handling', () => {
     expect(output).toContain('alert email delivery FAILED at 2026-07-20T12:00:00Z.');
     expect(output).toContain('Reason: no mail binary on PATH');
     expect(output).not.toContain('will go unnoticed');
+  });
+
+  it('sanitizes a hostile marker it did not write', () => {
+    // The marker survives `git pull` and may predate the write-time filter, so the
+    // reader cannot assume it is clean. \u001b[2J clears the operator's screen and
+    // \u009b is a decoded C1 CSI; neither may reach the terminal.
+    const stateDir = join(projectDir, '.health-alert');
+    mkdirSync(stateDir);
+    writeFileSync(join(stateDir, 'last-run'), new Date().toISOString());
+    writeFileSync(
+      join(stateDir, 'mail-failed'),
+      '2026-07-20T12:00:00Z\u001b[2J\u001b[1;31mFAKE\n550 \u009b2Kdenied\u0007 here\n',
+    );
+
+    const output = runDeployMonitoringStatus();
+
+    expect(output).not.toMatch(/[\u0000-\u0008\u000b-\u001f\u007f\u009b]/);
+    expect(output).toContain('550 2Kdenied here');
   });
 });

--- a/packages/super-sync-server/tests/health-alert-script.spec.ts
+++ b/packages/super-sync-server/tests/health-alert-script.spec.ts
@@ -512,7 +512,12 @@ describe('health-alert.sh state handling', () => {
     // \u009b is a decoded C1 CSI; neither may reach the terminal.
     const stateDir = join(projectDir, '.health-alert');
     mkdirSync(stateDir);
-    writeFileSync(join(stateDir, 'last-run'), new Date().toISOString());
+    // last-run lives in the same directory and is printed by the same function, so it
+    // is exactly as untrusted as mail-failed.
+    writeFileSync(
+      join(stateDir, 'last-run'),
+      `${new Date().toISOString()}\u001b[1;31m OWNED\u0007`,
+    );
     writeFileSync(
       join(stateDir, 'mail-failed'),
       '2026-07-20T12:00:00Z\u001b[2J\u001b[1;31mFAKE\n550 \u009b2Kdenied\u0007 here\n',
@@ -522,5 +527,6 @@ describe('health-alert.sh state handling', () => {
 
     expect(output).not.toMatch(/[\u0000-\u0008\u000b-\u001f\u007f\u009b]/);
     expect(output).toContain('550 2Kdenied here');
+    expect(output).toContain('[1;31m OWNED');
   });
 });

--- a/packages/super-sync-server/tests/health-alert-script.spec.ts
+++ b/packages/super-sync-server/tests/health-alert-script.spec.ts
@@ -74,7 +74,7 @@ const FAKE_MAIL = `#!/bin/sh
 printf '%s\n' "$*" >> "$FAKE_STATE/mail.args"
 printf '%s\n' '---MAIL---' >> "$FAKE_STATE/mail.log"
 cat >> "$FAKE_STATE/mail.log"
-[ -z "\${FAKE_MAIL_STDERR:-}" ] || printf '%b\n' "\$FAKE_MAIL_STDERR" >&2
+[ -z "\${FAKE_MAIL_STDERR:-}" ] || printf '%s\n' "\$FAKE_MAIL_STDERR" >&2
 exit "\${FAKE_MAIL_EXIT:-0}"
 `;
 
@@ -91,16 +91,6 @@ let binDir: string;
 const readStateFile = (name: string): string => {
   try {
     return readFileSync(join(projectDir, '.health-alert', name), 'utf8');
-  } catch {
-    return '';
-  }
-};
-
-// latin1, not utf8: the sanitizer works on bytes, and a surviving C1 byte would read
-// back as U+FFFD under utf8 — indistinguishable from any other mangling.
-const readStateFileBytes = (name: string): string => {
-  try {
-    return readFileSync(join(projectDir, '.health-alert', name), 'latin1');
   } catch {
     return '';
   }
@@ -442,17 +432,13 @@ describe('health-alert.sh state handling', () => {
       FAKE_LONG_Q: '1',
       FAKE_LONGEST: '130',
       FAKE_MAIL_EXIT: '1',
-      // \\233 is a literal octal escape the fake expands to a raw 0x9B byte. It cannot be
-      // passed as a JS \u009b: env vars are UTF-8, so that arrives as 0xC2 0x9B instead.
-      FAKE_MAIL_STDERR: `relay\u0007said\u001b[31mred\rCARRIAGE\u007f\\233 1mCSI${'x'.repeat(9000)}`,
+      FAKE_MAIL_STDERR: `relay\u0007said\u001b[31mred\rCARRIAGE\u007f${'x'.repeat(9000)}`,
     });
     expect(marker.output).toContain('Failed to send alert email');
-    const text = readStateFileBytes('mail-failed');
+    const text = readStateFile('mail-failed');
     // Only ESC/BEL are control characters here; the printable "[31m" correctly survives.
     expect(text).toContain('relaysaid[31mred');
-    // C1 too: 0x9B is a single-byte CSI in an 8-bit locale, the same trick as CR.
-    expect(text).toContain('CARRIAGE 1mCSI');
-    expect(text).not.toMatch(/[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/);
+    expect(text).not.toMatch(/[\u0007\u001b\r\u007f]/);
     expect(text.length).toBeLessThanOrEqual(4200);
   });
 

--- a/packages/super-sync-server/tests/health-alert-script.spec.ts
+++ b/packages/super-sync-server/tests/health-alert-script.spec.ts
@@ -74,7 +74,7 @@ const FAKE_MAIL = `#!/bin/sh
 printf '%s\n' "$*" >> "$FAKE_STATE/mail.args"
 printf '%s\n' '---MAIL---' >> "$FAKE_STATE/mail.log"
 cat >> "$FAKE_STATE/mail.log"
-[ -z "\${FAKE_MAIL_STDERR:-}" ] || printf '%s\n' "\$FAKE_MAIL_STDERR" >&2
+[ -z "\${FAKE_MAIL_STDERR:-}" ] || printf '%b\n' "\$FAKE_MAIL_STDERR" >&2
 exit "\${FAKE_MAIL_EXIT:-0}"
 `;
 
@@ -91,6 +91,16 @@ let binDir: string;
 const readStateFile = (name: string): string => {
   try {
     return readFileSync(join(projectDir, '.health-alert', name), 'utf8');
+  } catch {
+    return '';
+  }
+};
+
+// latin1, not utf8: the sanitizer works on bytes, and a surviving C1 byte would read
+// back as U+FFFD under utf8 — indistinguishable from any other mangling.
+const readStateFileBytes = (name: string): string => {
+  try {
+    return readFileSync(join(projectDir, '.health-alert', name), 'latin1');
   } catch {
     return '';
   }
@@ -432,13 +442,17 @@ describe('health-alert.sh state handling', () => {
       FAKE_LONG_Q: '1',
       FAKE_LONGEST: '130',
       FAKE_MAIL_EXIT: '1',
-      FAKE_MAIL_STDERR: `relay\u0007said\u001b[31mred\rCARRIAGE\u007f${'x'.repeat(9000)}`,
+      // \\233 is a literal octal escape the fake expands to a raw 0x9B byte. It cannot be
+      // passed as a JS \u009b: env vars are UTF-8, so that arrives as 0xC2 0x9B instead.
+      FAKE_MAIL_STDERR: `relay\u0007said\u001b[31mred\rCARRIAGE\u007f\\233 1mCSI${'x'.repeat(9000)}`,
     });
     expect(marker.output).toContain('Failed to send alert email');
-    const text = readStateFile('mail-failed');
+    const text = readStateFileBytes('mail-failed');
     // Only ESC/BEL are control characters here; the printable "[31m" correctly survives.
     expect(text).toContain('relaysaid[31mred');
-    expect(text).not.toMatch(/[\u0007\u001b\r\u007f]/);
+    // C1 too: 0x9B is a single-byte CSI in an 8-bit locale, the same trick as CR.
+    expect(text).toContain('CARRIAGE 1mCSI');
+    expect(text).not.toMatch(/[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/);
     expect(text.length).toBeLessThanOrEqual(4200);
   });
 

--- a/packages/super-sync-server/tests/health-alert-script.spec.ts
+++ b/packages/super-sync-server/tests/health-alert-script.spec.ts
@@ -88,13 +88,24 @@ interface RunResult {
 let projectDir: string;
 let binDir: string;
 
+const stateDir = (): string => join(projectDir, '.health-alert');
+const stateFile = (name: string): string => join(stateDir(), name);
+
 const readStateFile = (name: string): string => {
   try {
-    return readFileSync(join(projectDir, '.health-alert', name), 'utf8');
+    return readFileSync(stateFile(name), 'utf8');
   } catch {
     return '';
   }
 };
+
+const writeStateFile = (name: string, contents: string): void => {
+  mkdirSync(stateDir(), { recursive: true });
+  writeFileSync(stateFile(name), contents);
+};
+
+// The env pair that makes PROBLEMS non-empty, i.e. that gets a send attempted at all.
+const FAILING_PROBE = { FAKE_LONG_Q: '1', FAKE_LONGEST: '130' };
 
 const writeExecutable = (name: string, contents: string): void => {
   const path = join(binDir, name);
@@ -109,7 +120,7 @@ const run = (env: Record<string, string> = {}): RunResult => {
     COMPOSE_DIR: projectDir,
     HEALTH_URL: 'https://health.test/health',
     ALERT_EMAIL: 'ops@example.test',
-    FAKE_STATE: join(projectDir, '.health-alert'),
+    FAKE_STATE: stateDir(),
     ...env,
   };
 
@@ -358,7 +369,7 @@ describe('health-alert.sh service and database monitoring', () => {
 
 describe('health-alert.sh state handling', () => {
   it('deduplicates volatile long-query counts and durations', () => {
-    run({ FAKE_LONG_Q: '1', FAKE_LONGEST: '130' });
+    run(FAILING_PROBE);
     const second = run({ FAKE_LONG_Q: '27', FAKE_LONGEST: '240' });
 
     expect(second.mailLog.match(/SuperSync health check failed/g)).toHaveLength(1);
@@ -367,31 +378,29 @@ describe('health-alert.sh state handling', () => {
 
   it('sends recovery after mail failure and clears the sticky marker', () => {
     const failed = run({
-      FAKE_LONG_Q: '1',
-      FAKE_LONGEST: '130',
+      ...FAILING_PROBE,
       FAKE_MAIL_EXIT: '1',
     });
     expect(failed.output).toContain('Failed to send alert email');
-    expect(existsSync(join(projectDir, '.health-alert', 'mail-failed'))).toBe(true);
+    expect(existsSync(stateFile('mail-failed'))).toBe(true);
 
     const recovered = run();
     expect(recovered.mailLog).toContain('All checks passing.');
-    expect(existsSync(join(projectDir, '.health-alert', 'mail-failed'))).toBe(false);
+    expect(existsSync(stateFile('mail-failed'))).toBe(false);
   });
 
   it('retries failed delivery when an earlier problem remains active', () => {
     run({ FAKE_BAD_INDEX: 'index-a' });
     run({
       FAKE_BAD_INDEX: 'index-a',
-      FAKE_LONG_Q: '1',
-      FAKE_LONGEST: '130',
+      ...FAILING_PROBE,
       FAKE_MAIL_EXIT: '1',
     });
-    expect(existsSync(join(projectDir, '.health-alert', 'mail-failed'))).toBe(true);
+    expect(existsSync(stateFile('mail-failed'))).toBe(true);
 
     const retried = run({ FAKE_BAD_INDEX: 'index-a' });
     expect(retried.mailLog.match(/SuperSync health check failed/g)).toHaveLength(3);
-    expect(existsSync(join(projectDir, '.health-alert', 'mail-failed'))).toBe(false);
+    expect(existsSync(stateFile('mail-failed'))).toBe(false);
 
     const deduplicated = run({ FAKE_BAD_INDEX: 'index-a' });
     expect(deduplicated.mailLog.match(/SuperSync health check failed/g)).toHaveLength(3);
@@ -414,8 +423,7 @@ describe('health-alert.sh state handling', () => {
 
   it('captures why a real send failed, at both send sites', () => {
     const failed = run({
-      FAKE_LONG_Q: '1',
-      FAKE_LONGEST: '130',
+      ...FAILING_PROBE,
       FAKE_MAIL_EXIT: '1',
       FAKE_MAIL_STDERR: 'smtp: 550 relay access denied',
     });
@@ -438,8 +446,7 @@ describe('health-alert.sh state handling', () => {
 
   it('strips control characters and bounds relay-supplied failure text', () => {
     const marker = run({
-      FAKE_LONG_Q: '1',
-      FAKE_LONGEST: '130',
+      ...FAILING_PROBE,
       FAKE_MAIL_EXIT: '1',
       FAKE_MAIL_STDERR: `relay\u0007said\u001b[31mred\rCARRIAGE\u007f${'x'.repeat(9000)}`,
     });
@@ -457,8 +464,7 @@ describe('health-alert.sh state handling', () => {
     // control. Stripping the byte RANGE 0x80-0x9F instead would corrupt every non-ASCII
     // string, so the em-dash and CJK below must survive untouched.
     const marker = run({
-      FAKE_LONG_Q: '1',
-      FAKE_LONGEST: '130',
+      ...FAILING_PROBE,
       FAKE_MAIL_EXIT: '1',
       FAKE_MAIL_STDERR:
         'relay \\302\\2331;31mRED said \\342\\200\\224 dash \\346\\227\\245',
@@ -478,7 +484,7 @@ describe('health-alert.sh state handling', () => {
       `#!/bin/sh\nsh -c 'sleep 30' &\nprintf '%s\\n' 'smtp: 451 try again' >&2\nexit 1\n`,
     );
     const started = Date.now();
-    const result = run({ FAKE_LONG_Q: '1', FAKE_LONGEST: '130' });
+    const result = run(FAILING_PROBE);
     const elapsedMs = Date.now() - started;
 
     expect(result.output).toContain('Failed to send alert email');
@@ -488,13 +494,8 @@ describe('health-alert.sh state handling', () => {
   });
 
   it('reports heartbeat and mail failure even without a current-user cron entry', () => {
-    const stateDir = join(projectDir, '.health-alert');
-    mkdirSync(stateDir);
-    writeFileSync(join(stateDir, 'last-run'), new Date().toISOString());
-    writeFileSync(
-      join(stateDir, 'mail-failed'),
-      '2026-07-20T12:00:00Z\nno mail binary on PATH\n',
-    );
+    writeStateFile('last-run', new Date().toISOString());
+    writeStateFile('mail-failed', '2026-07-20T12:00:00Z\nno mail binary on PATH\n');
 
     const output = runDeployMonitoringStatus();
 
@@ -507,19 +508,14 @@ describe('health-alert.sh state handling', () => {
   });
 
   it('sanitizes a hostile marker it did not write', () => {
-    // The marker survives `git pull` and may predate the write-time filter, so the
-    // reader cannot assume it is clean. \u001b[2J clears the operator's screen and
-    // \u009b is a decoded C1 CSI; neither may reach the terminal.
-    const stateDir = join(projectDir, '.health-alert');
-    mkdirSync(stateDir);
+    // deploy.sh may run as a user who can read .health-alert but did not write it, so
+    // the reader cannot assume the write-time filter ran. \u001b[2J clears the operator's
+    // screen and \u009b is a decoded C1 CSI; neither may reach the terminal.
     // last-run lives in the same directory and is printed by the same function, so it
     // is exactly as untrusted as mail-failed.
-    writeFileSync(
-      join(stateDir, 'last-run'),
-      `${new Date().toISOString()}\u001b[1;31m OWNED\u0007`,
-    );
-    writeFileSync(
-      join(stateDir, 'mail-failed'),
+    writeStateFile('last-run', `${new Date().toISOString()}\u001b[1;31m OWNED\u0007`);
+    writeStateFile(
+      'mail-failed',
       '2026-07-20T12:00:00Z\u001b[2J\u001b[1;31mFAKE\n550 \u009b2Kdenied\u0007 here\n',
     );
 

--- a/packages/super-sync-server/tests/health-alert-script.spec.ts
+++ b/packages/super-sync-server/tests/health-alert-script.spec.ts
@@ -74,6 +74,7 @@ const FAKE_MAIL = `#!/bin/sh
 printf '%s\n' "$*" >> "$FAKE_STATE/mail.args"
 printf '%s\n' '---MAIL---' >> "$FAKE_STATE/mail.log"
 cat >> "$FAKE_STATE/mail.log"
+[ -z "\${FAKE_MAIL_STDERR:-}" ] || printf '%s\n' "\$FAKE_MAIL_STDERR" >&2
 exit "\${FAKE_MAIL_EXIT:-0}"
 `;
 
@@ -387,17 +388,76 @@ describe('health-alert.sh state handling', () => {
     expect(deduplicated.mailLog.match(/SuperSync health check failed/g)).toHaveLength(3);
   });
 
+  it('records a missing mail binary without waiting for an incident', () => {
+    const result = run({ MAIL_CMD: 'supersync-mail-not-installed' });
+
+    expect(result.output).toContain("no 'supersync-mail-not-installed' binary on PATH");
+    expect(readStateFile('mail-failed')).toContain(
+      'no supersync-mail-not-installed binary on PATH',
+    );
+    // The whole point is that a monitoring script never aborts: the checks still ran.
+    expect(result.dockerLog).toContain('info');
+    expect(readStateFile('last-run')).not.toBe('');
+    // One line per run, not three: the doomed send must not be attempted as well.
+    expect(result.output).not.toContain('Failed to send');
+    expect(result.mailLog).toBe('');
+  });
+
+  it('captures why a real send failed, at both send sites', () => {
+    const failed = run({
+      FAKE_LONG_Q: '1',
+      FAKE_LONGEST: '130',
+      FAKE_MAIL_EXIT: '1',
+      FAKE_MAIL_STDERR: 'smtp: 550 relay access denied',
+    });
+    expect(failed.output).toContain('Failed to send alert email');
+    const alertMarker = readStateFile('mail-failed');
+    expect(alertMarker.split('\n')[0]).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    expect(alertMarker).toContain('550 relay access denied');
+
+    const recovery = run({
+      FAKE_MAIL_EXIT: '1',
+      FAKE_MAIL_STDERR: 'smtp: 535 authentication failed',
+    });
+    expect(recovery.output).toContain('Failed to send recovery email');
+    const recoveryMarker = readStateFile('mail-failed');
+    expect(recoveryMarker.split('\n')[0]).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/,
+    );
+    expect(recoveryMarker).toContain('535 authentication failed');
+  });
+
+  it('strips control characters and bounds relay-supplied failure text', () => {
+    const marker = run({
+      FAKE_LONG_Q: '1',
+      FAKE_LONGEST: '130',
+      FAKE_MAIL_EXIT: '1',
+      FAKE_MAIL_STDERR: `relay\u0007said\u001b[31mred\rCARRIAGE\u007f${'x'.repeat(9000)}`,
+    });
+    expect(marker.output).toContain('Failed to send alert email');
+    const text = readStateFile('mail-failed');
+    // Only ESC/BEL are control characters here; the printable "[31m" correctly survives.
+    expect(text).toContain('relaysaid[31mred');
+    expect(text).not.toMatch(/[\u0007\u001b\r\u007f]/);
+    expect(text.length).toBeLessThanOrEqual(4200);
+  });
+
   it('reports heartbeat and mail failure even without a current-user cron entry', () => {
     const stateDir = join(projectDir, '.health-alert');
     mkdirSync(stateDir);
     writeFileSync(join(stateDir, 'last-run'), new Date().toISOString());
-    writeFileSync(join(stateDir, 'mail-failed'), '2026-07-20T12:00:00Z\n');
+    writeFileSync(
+      join(stateDir, 'mail-failed'),
+      '2026-07-20T12:00:00Z\nno mail binary on PATH\n',
+    );
 
     const output = runDeployMonitoringStatus();
 
     expect(output).toContain("not in this user's crontab");
     expect(output).toContain('recent completed run');
-    expect(output).toContain('alert email delivery FAILED');
+    // head -1, not $(cat …): a multi-line marker must not interpolate mid-sentence.
+    expect(output).toContain('alert email delivery FAILED at 2026-07-20T12:00:00Z.');
+    expect(output).toContain('Reason: no mail binary on PATH');
     expect(output).not.toContain('will go unnoticed');
   });
 });

--- a/packages/super-sync-server/tools/backup-rotate.sh
+++ b/packages/super-sync-server/tools/backup-rotate.sh
@@ -122,10 +122,11 @@ TOTAL_BACKUPS=$((AFTER_COUNT + WEEKLY_COUNT + MONTHLY_COUNT))
 if [ "$TOTAL_BACKUPS" -eq 0 ]; then
   log "ERROR: No backups remaining after rotation!"
 
-  # No default recipient, for the reason given at health-alert.sh:27-29.
+  # No default recipient on purpose — see the no-default-recipient rationale in
+  # health-alert.sh (a hardcoded address mails a self-hoster's hostname to a stranger).
   if [ -n "${ALERT_EMAIL:-}" ] && command -v mail >/dev/null 2>&1; then
     echo "CRITICAL: All backups deleted during rotation on $(hostname) at $(date)" | \
-      mail -s "ALERT: Backup Rotation Error" "${ALERT_EMAIL:-}" 2>/dev/null || true
+      mail -s "ALERT: Backup Rotation Error" -- "$ALERT_EMAIL" 2>/dev/null || true
   fi
 
   exit 1

--- a/packages/super-sync-server/tools/backup-rotate.sh
+++ b/packages/super-sync-server/tools/backup-rotate.sh
@@ -122,8 +122,8 @@ TOTAL_BACKUPS=$((AFTER_COUNT + WEEKLY_COUNT + MONTHLY_COUNT))
 if [ "$TOTAL_BACKUPS" -eq 0 ]; then
   log "ERROR: No backups remaining after rotation!"
 
-  # No default recipient on purpose — see the no-default-recipient rationale in
-  # health-alert.sh (a hardcoded address mails a self-hoster's hostname to a stranger).
+  # No default recipient on purpose: a hardcoded address mails a self-hoster's hostname
+  # to whoever owns it.
   if [ -n "${ALERT_EMAIL:-}" ] && command -v mail >/dev/null 2>&1; then
     echo "CRITICAL: All backups deleted during rotation on $(hostname) at $(date)" | \
       mail -s "ALERT: Backup Rotation Error" -- "$ALERT_EMAIL" 2>/dev/null || true

--- a/packages/super-sync-server/tools/backup-rotate.sh
+++ b/packages/super-sync-server/tools/backup-rotate.sh
@@ -118,10 +118,14 @@ TOTAL_BACKUPS=$((AFTER_COUNT + WEEKLY_COUNT + MONTHLY_COUNT))
 if [ "$TOTAL_BACKUPS" -eq 0 ]; then
   log "ERROR: No backups remaining after rotation!"
 
-  # Try to send alert if mail is available
-  if command -v mail >/dev/null 2>&1; then
+  # Try to send alert if mail is available and the operator opted in to a recipient.
+  # No default address on purpose: this script ships in the repo, so a hardcoded recipient
+  # mails a self-hoster's hostname to a stranger the moment they install an MTA. Matches
+  # health-alert.sh's ALERT_EMAIL contract.
+  ALERT_EMAIL="${ALERT_EMAIL:-}"
+  if [ -n "$ALERT_EMAIL" ] && command -v mail >/dev/null 2>&1; then
     echo "CRITICAL: All backups deleted during rotation on $(hostname) at $(date)" | \
-      mail -s "ALERT: Backup Rotation Error" admin@example.com 2>/dev/null || true
+      mail -s "ALERT: Backup Rotation Error" "$ALERT_EMAIL" 2>/dev/null || true
   fi
 
   exit 1

--- a/packages/super-sync-server/tools/backup-rotate.sh
+++ b/packages/super-sync-server/tools/backup-rotate.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Backup Rotation Script for SuperSync
 # Implements retention policy: 7 daily, 4 weekly, 12 monthly
+#
+# Configuration:
+#   ALERT_EMAIL - Address to alert if rotation leaves zero backups (optional;
+#                 alerting is skipped when unset, and also needs a `mail` binary)
 
 set -e
 set -u
@@ -118,14 +122,10 @@ TOTAL_BACKUPS=$((AFTER_COUNT + WEEKLY_COUNT + MONTHLY_COUNT))
 if [ "$TOTAL_BACKUPS" -eq 0 ]; then
   log "ERROR: No backups remaining after rotation!"
 
-  # Try to send alert if mail is available and the operator opted in to a recipient.
-  # No default address on purpose: this script ships in the repo, so a hardcoded recipient
-  # mails a self-hoster's hostname to a stranger the moment they install an MTA. Matches
-  # health-alert.sh's ALERT_EMAIL contract.
-  ALERT_EMAIL="${ALERT_EMAIL:-}"
-  if [ -n "$ALERT_EMAIL" ] && command -v mail >/dev/null 2>&1; then
+  # No default recipient, for the reason given at health-alert.sh:27-29.
+  if [ -n "${ALERT_EMAIL:-}" ] && command -v mail >/dev/null 2>&1; then
     echo "CRITICAL: All backups deleted during rotation on $(hostname) at $(date)" | \
-      mail -s "ALERT: Backup Rotation Error" "$ALERT_EMAIL" 2>/dev/null || true
+      mail -s "ALERT: Backup Rotation Error" "${ALERT_EMAIL:-}" 2>/dev/null || true
   fi
 
   exit 1


### PR DESCRIPTION
## The defect

`health-alert.sh` runs from cron every 5 minutes on a self-hoster's VPS. It required
`ALERT_EMAIL` but never checked that a `mail` binary exists. Stock Debian and Ubuntu ship
neither `mailutils` nor `bsd-mailx` and configure no MTA, and no MTA package is referenced
anywhere in the repo — while `MONITORING-README.md` presented `ALERT_EMAIL` plus a crontab
line as the complete setup.

So an operator who followed the documented setup exactly could have alerting that was never
capable of sending anything, with every surface reporting green. What made it silent: the
send path only runs once a problem already exists, so on a healthy server it had never
executed, no `mail-failed` marker was ever written, and `deploy.sh` printed *"no recorded
failure (verified only when mail is attempted)"*. The gap was documented and left open.

## What changed

1. **Preflight the transport** after the `flock` (not beside the config validation — the
   state dir does not exist yet there, and `set -u` would abort). Absence is recorded in the
   *existing* `mail-failed` marker `deploy.sh` already surfaces. Both send conditions also
   gate on `$MAIL_AVAILABLE`: merely writing the marker makes the recovery condition true,
   which would fire a send that fails and overwrite the reason with a bare timestamp.
2. **Capture *why* a real send failed.** Both send sites route through one `send_alert_mail`
   helper. "Not installed", "relay refused" and "auth failed" were previously
   indistinguishable. Relay text is attacker-adjacent input that `deploy.sh` echoes to a
   terminal, so it is stripped of control characters and capped — at write time *and* on read.
3. **Document the MTA requirement** in `MONITORING-README.md` and next to `deploy.sh`'s
   remediation line.
4. **`tools/backup-rotate.sh`** guarded on `command -v mail` correctly and then sent to a
   hardcoded `admin@example.com` (IANA-reserved) — now `"${ALERT_EMAIL:-}"`, skipped unset.

## What review caught after implementation

Three of these four were regressions this change itself introduced, which is the useful part
of the history:

- **A forking MTA hung the run forever.** `err=$(timeout 30 ...)` waits for pipe EOF, not
  process exit, so an MTA that forks a delivery child survives the timeout and hangs the run
  while holding the flock — silently killing every later cron run. Measured 45s elapsed with
  `timeout 30` giving zero protection, vs 0s with stderr redirected to a file. Pinned by the
  fork-hang spec case.
- **A C1 filter that corrupted UTF-8.** Stripping the byte range `0x80-0x9F` eats UTF-8
  continuation bytes; `\xe2\x80\x94` (em-dash) lost two of three bytes, including in the
  script's own message on the most common path. Reverted, then replaced with
  `sed 's/\xc2[\x80-\x9f]//g'`, which matches UTF-8-*encoded* C1 exactly.
- **The "lone C1 byte is harmless" assumption was wrong.** `\xC2\x9B` is well-formed UTF-8
  for CSI — both bytes ≥ 0x80, passes a C0-only filter, decodes to a real control.
- **A `mktemp`+`mv` marker write** introduced a silent no-op on `mktemp` failure and a
  temp-file leak, and hardened 1 of 4 write sites. Reverted.

A `/simplify` pass then found that `deploy.sh`'s justification for sanitizing on read —
"may have been written by an older health-alert.sh" — was **false**: every shipped version
wrote a bare `date -u` timestamp and no reason line, so an old marker is 21 bytes of ASCII.
Replaced with the two reasons that actually hold (the newline flattening is load-bearing for
a one-line `printf`; `.health-alert` is 0700 only until an operator widens it for a non-root
`deploy.sh`), so the next reviewer doesn't refute the premise and delete the call.

## Testing

- `packages/super-sync-server`: **1180 passed, 11 skipped** (57 files).
- `health-alert-script.spec.ts` grew to 35 cases. New coverage: missing `mail` binary,
  capture-why at both send sites, control-char stripping, UTF-8-encoded C1 without
  corrupting other UTF-8, the fork-hang, and a hostile marker on the read side (both
  `mail-failed` and `last-run`).
- Every new test was verified to fail without its fix.
- Measured with `strace -f -e trace=execve`: the healthy path is **40 `execve`**, identical
  to the pre-change baseline. All new pipelines sit behind failure gates.

## Deploying this

Code first, then the MTA. The missing-binary marker gives a free end-to-end delivery proof:
`deploy.sh` will print `Reason: no <mail> binary on PATH`, and installing `mailutils` or
`bsd-mailx` then produces exactly one `SuperSync OK: Health Check Recovered` message before
clearing the marker. Installing the MTA first skips that proof — nothing is ever sent on a
healthy server — leaving only the manual `echo test | mail` check.

## Deliberately not built

Rejected in review; noting them so they aren't re-proposed.

- **A `--test` flag** — a queuing MTA exits 0 on accept, not delivery, so it cannot prove receipt.
- **Argument parsing** — contradicts "a monitoring script must never silently abort" (no `set -e`).
- **A second `mail-unavailable` marker** — duplicates a field `mail-failed` already gains, with no defined precedence.
- **A `deploy.sh` "delivery has succeeded" branch** — `state` is deleted on the recovery send, so a server that alerted and recovered is indistinguishable from one that never sent.
- **A `curl`-over-SMTP transport** reusing the server's `SMTP_*` credentials — a real option, but a larger change than this defect warrants.

## Known residual

A local `sendmail` that queues returns success and the message can still be dropped later as
unauthenticated. The docs say so. This change narrows the silent-failure window; it does not
close it.
