### PR TITLE
fix(monitoring): stop the db probe blocking on inherited stdin

### DIFF
--- a/packages/super-sync-server/scripts/health-alert.sh
+++ b/packages/super-sync-server/scripts/health-alert.sh
@@ -309,13 +309,10 @@ main()
 NODE
 )
 
-    # `</dev/null` is load-bearing. `docker compose exec -T` keeps stdin attached and will
-    # not exit until it sees EOF, so with an inherited stdin the $(...) capture blocks long
-    # past the probe's own exit: `timeout` SIGTERMs at 20s, compose ignores it, -k SIGKILLs
-    # at 25s, and compose's buffered stdout dies with it. Every key is then missing and the
-    # check reports a flat failure. Measured on a live host: 25s/exit 137 without it, 1s/exit
-    # 0 with. Cron happens to pass /dev/null already, so this fails only for a human running
-    # the script by hand — i.e. exactly when someone is verifying that monitoring works.
+    # `</dev/null` is load-bearing: `docker compose exec -T` keeps stdin attached and does
+    # not exit until EOF, so an inherited stdin leaves the $(...) capture hanging until -k
+    # SIGKILLs it and compose's buffered stdout dies with it — a healthy server then reports
+    # every probe key missing. Measured live: 25s/exit 137 without it, 1s/exit 0 with.
     # Allow Prisma's 5s pool wait plus its 12s transaction bound to finish.
     DB_OUTPUT=$(timeout -k 5 20 docker compose exec -T \
       -e "HEALTH_MAX_QUERY_SECONDS=$MAX_QUERY_SECONDS" \
@@ -353,11 +350,9 @@ NODE
       ! [[ "$LONGEST" =~ ^[0-9]+$ ]] ||
       ! [[ "$POOL_IN_USE" =~ ^[0-9]+$ ]]; then
       DB_RESULTS_OK=false
-      # Name the exit status: 124/137 mean the probe was timed out or killed, 126/127 a
-      # broken exec, 1 a probe error, 0 a probe that returned incomplete output. Without it
-      # this one string covers all of them and a live incident took an afternoon to tell
-      # apart. Deliberately not the probe's stderr: PROBLEMS is the dedupe hash input, so
-      # text that varies between runs would re-alert every five minutes.
+      # The status separates a timeout or kill (124/137) from a broken exec (126/127), a
+      # probe error (1) and incomplete output (0). Not the probe's stderr: PROBLEMS is the
+      # dedupe hash input, so text that varies per run would re-alert every five minutes.
       PROBLEMS="${PROBLEMS}Database monitoring checks failed (exit ${DB_STATUS})\n"
     fi
 

--- a/packages/super-sync-server/scripts/health-alert.sh
+++ b/packages/super-sync-server/scripts/health-alert.sh
@@ -309,10 +309,17 @@ main()
 NODE
 )
 
+    # `</dev/null` is load-bearing. `docker compose exec -T` keeps stdin attached and will
+    # not exit until it sees EOF, so with an inherited stdin the $(...) capture blocks long
+    # past the probe's own exit: `timeout` SIGTERMs at 20s, compose ignores it, -k SIGKILLs
+    # at 25s, and compose's buffered stdout dies with it. Every key is then missing and the
+    # check reports a flat failure. Measured on a live host: 25s/exit 137 without it, 1s/exit
+    # 0 with. Cron happens to pass /dev/null already, so this fails only for a human running
+    # the script by hand — i.e. exactly when someone is verifying that monitoring works.
     # Allow Prisma's 5s pool wait plus its 12s transaction bound to finish.
     DB_OUTPUT=$(timeout -k 5 20 docker compose exec -T \
       -e "HEALTH_MAX_QUERY_SECONDS=$MAX_QUERY_SECONDS" \
-      supersync timeout 18 node -e "$DB_PROBE_JS" 2>/dev/null)
+      supersync timeout 18 node -e "$DB_PROBE_JS" </dev/null 2>/dev/null)
     DB_STATUS=$?
 
     LONG_Q=""
@@ -346,7 +353,12 @@ NODE
       ! [[ "$LONGEST" =~ ^[0-9]+$ ]] ||
       ! [[ "$POOL_IN_USE" =~ ^[0-9]+$ ]]; then
       DB_RESULTS_OK=false
-      PROBLEMS="${PROBLEMS}Database monitoring checks failed\n"
+      # Name the exit status: 124/137 mean the probe was timed out or killed, 126/127 a
+      # broken exec, 1 a probe error, 0 a probe that returned incomplete output. Without it
+      # this one string covers all of them and a live incident took an afternoon to tell
+      # apart. Deliberately not the probe's stderr: PROBLEMS is the dedupe hash input, so
+      # text that varies between runs would re-alert every five minutes.
+      PROBLEMS="${PROBLEMS}Database monitoring checks failed (exit ${DB_STATUS})\n"
     fi
 
     if $DB_RESULTS_OK; then

--- a/packages/super-sync-server/tests/health-alert-script.spec.ts
+++ b/packages/super-sync-server/tests/health-alert-script.spec.ts
@@ -1,9 +1,11 @@
 import { spawnSync } from 'node:child_process';
 import {
   chmodSync,
+  closeSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -46,6 +48,8 @@ if [ "\${1:-}" = "ps" ]; then
 fi
 
 if [ "\${1:-}" = "exec" ]; then
+  # Real \`docker compose exec -T\` keeps stdin attached and does not exit until EOF.
+  cat > /dev/null
   [ "\${FAKE_DB_EXIT:-0}" = "0" ] || exit "$FAKE_DB_EXIT"
   if [ "\${FAKE_DB_MALFORMED:-0}" = "1" ]; then
     printf 'not monitor data\n'
@@ -107,13 +111,28 @@ const writeStateFile = (name: string, contents: string): void => {
 // The env pair that makes PROBLEMS non-empty, i.e. that gets a send attempted at all.
 const FAILING_PROBE = { FAKE_LONG_Q: '1', FAKE_LONGEST: '130' };
 
+// spawnSync hands the child an already-closed stdin, so a descriptor that never reaches
+// EOF is the only way to reproduce what an interactive shell gives the script. A FIFO
+// opened read-write keeps a writer around for as long as the fd is held.
+const runWithOpenStdin = (env: Record<string, string> = {}): RunResult => {
+  const fifo = join(projectDir, 'stdin.fifo');
+  spawnSync('mkfifo', [fifo]);
+  const fd = openSync(fifo, 'r+');
+  try {
+    return run(env, fd);
+  } finally {
+    closeSync(fd);
+    rmSync(fifo, { force: true });
+  }
+};
+
 const writeExecutable = (name: string, contents: string): void => {
   const path = join(binDir, name);
   writeFileSync(path, contents);
   chmodSync(path, 0o755);
 };
 
-const run = (env: Record<string, string> = {}): RunResult => {
+const run = (env: Record<string, string> = {}, stdin?: number): RunResult => {
   const childEnv: NodeJS.ProcessEnv = {
     ...process.env,
     PATH: `${binDir}:${process.env.PATH ?? ''}`,
@@ -133,6 +152,7 @@ const run = (env: Record<string, string> = {}): RunResult => {
   const result = spawnSync('bash', [SCRIPT], {
     encoding: 'utf8',
     env: childEnv,
+    stdio: [stdin ?? 'pipe', 'pipe', 'pipe'],
     timeout: 10_000,
   });
 
@@ -286,6 +306,25 @@ describe('health-alert.sh service and database monitoring', () => {
     expect(result.mailLog.match(/Database monitoring checks failed/g)).toHaveLength(1);
     expect(result.mailLog).toContain('Health endpoint returned HTTP 503');
     expect(result.mailLog).toContain('Disk usage at 90% on /');
+  });
+
+  it('completes the database probe when stdin never reaches EOF', () => {
+    // `docker compose exec -T` does not exit until stdin closes, so without `</dev/null`
+    // the $(...) capture outlives the probe, `timeout -k` SIGKILLs it, and every key goes
+    // missing — turning a healthy server into "Database monitoring checks failed".
+    const result = runWithOpenStdin();
+
+    expect(result.status).toBe(0);
+    expect(result.mailLog).not.toContain('Database monitoring checks failed');
+  });
+
+  it('names the probe exit status instead of one flat failure string', () => {
+    // 137 is SIGKILL, the signature of `timeout -k` giving up. That is a different fault
+    // from a probe that threw (1) or an exec that never started (127), and the message
+    // used to be identical for all three.
+    const result = run({ FAKE_DB_EXIT: '137' });
+
+    expect(result.mailLog).toContain('Database monitoring checks failed (exit 137)');
   });
 
   it('treats malformed probe output as a database monitoring failure', () => {


### PR DESCRIPTION
## What

`health-alert.sh`'s database probe ran `docker compose exec -T ... node -e "$DB_PROBE_JS"` with an inherited stdin. `exec -T` keeps stdin attached and does not exit until it sees EOF, so the `$(...)` capture outlived the probe itself: `timeout` SIGTERMed at 20s, compose ignored it, `-k` SIGKILLed at 25s, and compose's buffered stdout died with it. Every probe key went missing and a **healthy** server reported `Database monitoring checks failed`.

Measured on the live host: **25s / exit 137** before, **1s / exit 0** after.

## Why it hid for so long

Cron already passes `/dev/null`, so this only ever misfired for a human running the script manually — i.e. exactly when someone is verifying that monitoring works. That is how it was found.

## Second change: name the exit status

`124`/`137` (timed out or killed), `126`/`127` (broken exec), `1` (probe threw) and `0` (incomplete output) all produced one identical alert string. Telling them apart cost an afternoon during a live incident, so the status is now in the message.

Deliberately **not** the probe's stderr: `PROBLEMS` is the dedupe hash input, so text that varies between runs would re-alert every five minutes.

## Tests

Two cases in `health-alert-script.spec.ts`, both verified to fail without the fix:

- `completes the database probe when stdin never reaches EOF` — hits the 10s `spawnSync` timeout without `</dev/null`. Reproducing it needs a descriptor that never reaches EOF, since `spawnSync` hands the child an already-closed stdin, so the spec opens a FIFO read-write; the docker fake now consumes stdin (`cat > /dev/null`) the way real compose does.
- `names the probe exit status instead of one flat failure string` — asserts `(exit 137)`.

Full server suite: 1186 passed, 17 skipped.

## Risk

Shell-only, no sync/op-log surface. The `</dev/null` redirect can only narrow what the probe reads; the probe never consumed stdin. The message change appends to an existing string, and the existing assertions use `toContain`, so alert dedupe behaviour is unchanged for a given exit status.