### PR TITLE
docs(sync-server): correct the payload_bytes boot-gate cost comment

### DIFF
--- a/packages/super-sync-server/src/sync/services/storage-quota.service.ts
+++ b/packages/super-sync-server/src/sync/services/storage-quota.service.ts
@@ -399,11 +399,26 @@ export class StorageQuotaService {
    * the CASE-WHEN fallback for legacy rows — small drift, but unnecessary
    * given the env-flag's whole purpose.
    *
-   * One indexed-probe at startup closes the trust hole. The query relies on a
-   * full table scan-with-LIMIT-1; for a fully backfilled table that is one
-   * row visit on the first encountered row (cheap), and for a partially
-   * backfilled table it returns immediately. Worst case (zero rows in
-   * `operations`, e.g. fresh deployment) is also one round-trip.
+   * One indexed probe at startup closes the trust hole, but its cost is the
+   * opposite way round from how it reads. A *partially* backfilled table is the
+   * cheap case: `operations_payload_bytes_unbackfilled_idx` still holds live
+   * entries and the scan stops at the first one. The *completed* backfill is the
+   * expensive case — proving that no row matches means reading the whole index.
+   * `payload_bytes` sits in that index's predicate, so every backfill update was
+   * non-HOT and left entries pointing at dead heap tuples, each of which must be
+   * visited until VACUUM or LP_DEAD hints clear them; and with statistics still
+   * describing the pre-backfill distribution the planner may abandon the index and
+   * sequentially scan the table instead. On a multi-GB `operations` that is minutes,
+   * not one round-trip — and it runs before `/health` is registered, so the container
+   * never reports healthy while it is happening (#9504 §2).
+   *
+   * Which of the two costs dominates has not been measured on a real instance, so
+   * neither `scripts/migrate-payload-bytes.ts` nor this probe tries to pre-empt it:
+   * refreshing statistics does nothing about dead index entries, and vice versa. The
+   * migration that creates the index makes the same wrong claim ("physically drains
+   * to empty"), but applied migrations are never edited in place
+   * (`prisma/migrations/README.md`), so this is the correction of record. Worst case
+   * (zero rows in `operations`, e.g. a fresh deployment) is still one round-trip.
    */
   async assertPayloadBytesBackfillComplete(): Promise<void> {
     const result = await prisma.$queryRaw<[{ exists: boolean }]>`


### PR DESCRIPTION
## What

Comment-only. `assertPayloadBytesBackfillComplete`'s docblock had its two cases **exactly inverted**.

It claimed a fully backfilled table costs "one row visit on the first encountered row (cheap)". The opposite is true:

- A **partially** backfilled table is the cheap case — `operations_payload_bytes_unbackfilled_idx` still holds live entries and the scan stops at the first one.
- The **completed** backfill is the expensive case — proving that no row matches means reading the whole index. `payload_bytes` sits in that index's predicate (`WHERE "payload_bytes" = 0`), so every backfill update was non-HOT and left entries pointing at dead heap tuples, each of which must be visited until VACUUM or LP_DEAD hints clear them. And with statistics still describing the pre-backfill distribution, the planner may abandon the index and sequentially scan the table instead.

On a multi-GB `operations` that is minutes, not one round-trip — and the probe runs at `server.ts:445`, before `/health` is registered at `:454`, so the container never reports healthy while it happens (#9504 §2).

## Why the comment and not the migration

`prisma/migrations/20260514000002_.../migration.sql:3` carries the same wrong claim ("the index physically drains to empty"), but applied migrations are never edited in place (`prisma/migrations/README.md:157`), so this comment is the correction of record.

## No behaviour change

Which of the two costs dominates has not been measured on a real instance, so neither `scripts/migrate-payload-bytes.ts` nor the probe tries to pre-empt it — refreshing statistics does nothing about dead index entries, and vice versa. Adding a mitigation before the failure is observed would be hardening ahead of evidence, so this PR only fixes the claim.