### PR TITLE
docs(sync-server): warn that a cancelled backfill strands a user's counter

### DIFF
--- a/packages/super-sync-server/scripts/migrate-payload-bytes.ts
+++ b/packages/super-sync-server/scripts/migrate-payload-bytes.ts
@@ -135,6 +135,12 @@ const run = async (): Promise<void> => {
     const userIds = await fetchUserIdsWithUnbackfilledRows(lastUserId);
     if (userIds.length === 0) break;
 
+    // Backfill then reconcile, per user — and a cancel in the gap between them is not
+    // recoverable by re-running. The user has no unbackfilled rows left, so
+    // fetchUserIdsWithUnbackfilledRows never returns them again and their
+    // storage_used_bytes stays stale; assertPayloadBytesBackfillComplete cannot see it
+    // either, since it only reads `operations`. Recover by calling
+    // reconcileUserStorageUsage for those ids directly.
     for (const userId of userIds) {
       updated += await backfillUser(userId, batchSize);
       await reconcileUserStorageUsage(userId);


### PR DESCRIPTION
## What

Comment-only, six lines. Follow-up to #9714, which corrected the *boot gate's* comment; this covers a separate hazard in the script that feeds it.

`migrate-payload-bytes.ts` runs `backfillUser(userId)` then `reconcileUserStorageUsage(userId)` **per user**:

```ts
for (const userId of userIds) {
  updated += await backfillUser(userId, batchSize);
  await reconcileUserStorageUsage(userId);
  lastUserId = userId;
}
```

A cancel in the gap between those two calls is **not recoverable by re-running**. That user has no unbackfilled rows left, so `fetchUserIdsWithUnbackfilledRows` never returns them again, and their `users.storage_used_bytes` stays stale permanently.

## Why it's worth a comment

`assertPayloadBytesBackfillComplete` cannot detect this — it only reads `operations`. So a **clean completion gate is fully compatible with wrong per-user counters**, which is the opposite of what the gate's name suggests. Nothing in the script warned about it.

Observed, not hypothetical: two runs were cancelled partway (~145 and ~610 users in) against a ~493-user instance before a third completed.

## Recovery

Call `reconcileUserStorageUsage` for the affected ids directly. They're found by comparing `users.storage_used_bytes` against `SUM(operations.payload_bytes) + octet_length(snapshot_data)`. No new code needed, which is why this is a comment and not a feature.

## Risk

None — comment-only, no behaviour change.