### PR TITLE
feat(api): add remindAt support to Local REST API

### DIFF
--- a/src/app/core/electron/local-rest-api-handler.service.spec.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.spec.ts
@@ -945,10 +945,48 @@ describe('LocalRestApiHandlerService', () => {
         });
       });
 
+      it('should allow creating a task with remindAt timestamp', async () => {
+        Object.defineProperty(taskServiceMock, 'getByIdOnce$', {
+          get: () => (_id: string) => of(createMockTask('new-task-id')),
+        });
+
+        const remindTimestamp = 1787550900000;
+        const response = await sendRequestAndWait(
+          createRequest('POST', '/tasks', {
+            body: {
+              title: 'Task With Reminder',
+              dueWithTime: 1787551200000,
+              remindAt: remindTimestamp,
+            },
+          }),
+        );
+
+        expect(response.body.ok).toBe(true);
+        expect(response.status).toBe(201);
+        expect(taskServiceMock.add).toHaveBeenCalledWith('Task With Reminder', false, {
+          title: 'Task With Reminder',
+          dueWithTime: 1787551200000,
+          remindAt: remindTimestamp,
+        });
+      });
+
       it('should return 400 when an allowed field has an invalid type', async () => {
         const response = await sendRequestAndWait(
           createRequest('POST', '/tasks', {
             body: { title: 'New Task', timeEstimate: 'not-a-number' },
+          }),
+        );
+
+        expect(response.body.ok).toBe(false);
+        expect(response.status).toBe(400);
+        expect((response.body as any).error.code).toBe('INVALID_INPUT');
+        expect(taskServiceMock.add).not.toHaveBeenCalled();
+      });
+
+      it('should return 400 when remindAt is not a number or null', async () => {
+        const response = await sendRequestAndWait(
+          createRequest('POST', '/tasks', {
+            body: { title: 'New Task', remindAt: 'invalid-string' },
           }),
         );
 
@@ -1163,6 +1201,25 @@ describe('LocalRestApiHandlerService', () => {
 
         expect(taskServiceMock.update).toHaveBeenCalledWith('task-1', {
           title: 'Updated',
+        });
+      });
+
+      it('should allow updating remindAt via PATCH', async () => {
+        const mockTask = createMockTask('task-1');
+        Object.defineProperty(taskServiceMock, 'getByIdOnce$', {
+          get: () => (_id: string) => of(mockTask),
+        });
+
+        const remindTimestamp = 1787550900000;
+        const response = await sendRequestAndWait(
+          createRequest('PATCH', '/tasks/task-1', {
+            body: { remindAt: remindTimestamp },
+          }),
+        );
+
+        expect(response.body.ok).toBe(true);
+        expect(taskServiceMock.update).toHaveBeenCalledWith('task-1', {
+          remindAt: remindTimestamp,
         });
       });
 

--- a/src/app/core/electron/local-rest-api-handler.service.ts
+++ b/src/app/core/electron/local-rest-api-handler.service.ts
@@ -41,6 +41,7 @@ const ALLOWED_TASK_FIELDS = new Set<string>([
   'dueDay',
   'dueWithTime',
   'plannedAt',
+  'remindAt',
 ]);
 
 /**
@@ -88,6 +89,7 @@ interface WritableTaskFields {
   dueDay?: string | null;
   dueWithTime?: number | null;
   plannedAt?: number;
+  remindAt?: number | null;
 }
 
 type FieldTypeError = { path: string; expected: string };


### PR DESCRIPTION
## Summary

Adds support for the `remindAt` field to the Local REST API, allowing external tools (AI coding agents, Raycast extensions, CLI automation scripts) to create and update tasks with scheduled reminder timestamps.

## Changes
- Added `'remindAt'` to `ALLOWED_TASK_FIELDS` and `WritableTaskFields` in `LocalRestApiHandlerService`.
- Added unit test cases for creating a task with `remindAt`, updating `remindAt` via `PATCH`, and validating input types in `local-rest-api-handler.service.spec.ts`.

## Test Plan
- [x] Ran unit tests: `npm run test:file -- 'src/app/core/electron/local-rest-api-handler.service.spec.ts'` (83/83 passed).
- [x] Tested locally with running Electron app via `POST /tasks` with `dueWithTime` + `remindAt` and `PATCH /tasks/:id`.