### PR TITLE
fix(sync): stop reporting IN_SYNC when a full-state upload is deferred

### DIFF
--- a/e2e/pages/supersync.page.ts
+++ b/e2e/pages/supersync.page.ts
@@ -800,9 +800,14 @@ export class SuperSyncPage extends BasePage {
             );
           }
         } else {
-          // Unknown state - log and throw
-          throw new Error(
-            'Unable to determine Client A vs B - sync state unclear after timeout',
+          // No dialog, no spinner, no error, no check icon: sync is configured but
+          // idle with pending ops — the check icon only renders once nothing is
+          // pending. Seen when a full-state upload is deferred by a retryable
+          // server error (CI run 32683405598). Nothing to decide here, so fall
+          // through to the sync-completion wait below, which re-triggers sync once
+          // before failing.
+          console.log(
+            '[SuperSyncPage] Idle with pending ops - no dialog needed, waiting for sync to settle',
           );
         }
       }

--- a/src/app/imex/sync/sync-wrapper.service.spec.ts
+++ b/src/app/imex/sync/sync-wrapper.service.spec.ts
@@ -3277,6 +3277,31 @@ describe('SyncWrapperService', () => {
       expect(mockProviderManager.setSyncStatus).not.toHaveBeenCalledWith('IN_SYNC');
     });
 
+    it('should not report IN_SYNC when a full-state upload was deferred by a retryable error', async () => {
+      // Server migration whose snapshot upload hit a Postgres serialization
+      // conflict: nothing reached the server, the op stays pending for the next
+      // sync — but the wrapper used to fall through to IN_SYNC.
+      mockSyncService.downloadRemoteOps.and.resolveTo({ kind: 'no_new_ops' as const });
+      mockSyncService.uploadPendingOps.and.resolveTo({
+        kind: 'completed' as const,
+        uploadedCount: 0,
+        piggybackedOpsCount: 0,
+        localWinOpsCreated: 0,
+        permanentRejectionCount: 0,
+        hasMorePiggyback: false,
+        rejectedOps: [],
+        fullStateUploadDeferred: true,
+      });
+
+      const result = await service.sync();
+
+      expect(result).toBe(SyncStatus.UpdateRemote);
+      expect(mockProviderManager.setSyncStatus).toHaveBeenCalledWith(
+        'UNKNOWN_OR_CHANGED',
+      );
+      expect(mockProviderManager.setSyncStatus).not.toHaveBeenCalledWith('IN_SYNC');
+    });
+
     it('should stop sync when an LWW re-upload reaches a rejected full-state barrier', async () => {
       mockSyncService.downloadRemoteOps.and.resolveTo({ kind: 'no_new_ops' as const });
       mockSyncService.uploadPendingOps.and.returnValues(

--- a/src/app/imex/sync/sync-wrapper.service.ts
+++ b/src/app/imex/sync/sync-wrapper.service.ts
@@ -777,6 +777,22 @@ export class SyncWrapperService {
         return 'HANDLED_ERROR';
       }
 
+      // A full-state op (server migration / backup restore) that hit a retryable
+      // server error leaves the WHOLE local state unsynced with no rejection to
+      // report — the one upload failure that used to fall through to IN_SYNC.
+      // Checked last so ERROR and permanent rejections keep precedence; not an
+      // ERROR itself, because the op is still pending and the next sync retries
+      // it. Mirrors the LWW-exhaustion path above, WebSocket connect included:
+      // that too is retried on the next sync.
+      if (completedUploadResults.some((result) => result.fullStateUploadDeferred)) {
+        SyncLog.warn(
+          'SyncWrapperService: Full-state upload deferred after a retryable server error. ' +
+            'Reporting UNKNOWN_OR_CHANGED (will retry on next sync).',
+        );
+        this._providerManager.setSyncStatus('UNKNOWN_OR_CHANGED');
+        return SyncStatus.UpdateRemote;
+      }
+
       // Mark as in-sync for all providers after successful sync
       this._providerManager.setSyncStatus('IN_SYNC');
       SyncLog.log('SyncWrapperService: Sync complete, status=IN_SYNC');

--- a/src/app/op-log/core/types/sync-results.types.ts
+++ b/src/app/op-log/core/types/sync-results.types.ts
@@ -180,6 +180,13 @@ export interface UploadResult {
    * A newer successful full-state operation clears the barrier.
    */
   blockedByRejectedFullState?: boolean;
+  /**
+   * True when a full-state operation (SYNC_IMPORT / BACKUP_IMPORT) failed with a
+   * retryable error, so it — and every pending op after it — stayed local for the
+   * next sync. Nothing reached the server, so the caller must not claim IN_SYNC.
+   * Distinct from `blockedByRejectedFullState`, which is a permanent rejection.
+   */
+  fullStateUploadDeferred?: boolean;
 }
 
 /**
@@ -336,6 +343,8 @@ export type UploadOutcome =
       encryptionRequiredKeyMissing?: boolean;
       /** Pending ops depend on an explicit full-state baseline the server rejected. */
       blockedByRejectedFullState?: boolean;
+      /** A full-state op hit a retryable server error; nothing was uploaded this round. */
+      fullStateUploadDeferred?: boolean;
     }
   | {
       /** User cancelled a piggybacked SYNC_IMPORT conflict dialog. */

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -535,6 +535,7 @@ export class OperationLogSyncService {
         ? { encryptionRequiredKeyMissing: true }
         : {}),
       ...(result.blockedByRejectedFullState ? { blockedByRejectedFullState: true } : {}),
+      ...(result.fullStateUploadDeferred ? { fullStateUploadDeferred: true } : {}),
     };
   }
 

--- a/src/app/op-log/sync/operation-log-upload.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.spec.ts
@@ -1507,6 +1507,49 @@ describe('OperationLogUploadService', () => {
         expect(result.blockedByRejectedFullState).toBe(true);
       });
 
+      it('should flag a deferred full-state upload when the server returns a retryable error', async () => {
+        // Observed in CI (scheduled run 32683405598): a server-migration
+        // SYNC_IMPORT was answered with a Postgres serialization conflict.
+        // Nothing was uploaded, so the caller must be able to tell the
+        // difference between this and a clean zero-op sync.
+        const syncImport = createFullStateEntry(
+          1,
+          'migration-import',
+          'client-1',
+          OpType.SyncImport,
+        );
+        const laterOp = createMockEntry(2, 'later-op', 'client-1');
+        mockOpLogStore.getUnsynced.and.resolveTo([syncImport, laterOp]);
+        mockApiProvider.uploadSnapshot.and.resolveTo({
+          accepted: false,
+          error: 'Concurrent transaction conflict - please retry',
+        });
+
+        const result = await service.uploadPendingOps(mockApiProvider);
+
+        expect(result.fullStateUploadDeferred).toBe(true);
+        expect(result.uploadedCount).toBe(0);
+        expect(result.rejectedCount).toBe(0);
+        expect(mockApiProvider.uploadOps).not.toHaveBeenCalled();
+        expect(mockOpLogStore.markSynced).not.toHaveBeenCalled();
+      });
+
+      it('should not flag a deferred full-state upload when the snapshot is accepted', async () => {
+        const syncImport = createFullStateEntry(
+          1,
+          'migration-import',
+          'client-1',
+          OpType.SyncImport,
+        );
+        mockOpLogStore.getUnsynced.and.resolveTo([syncImport]);
+        mockApiProvider.uploadSnapshot.and.resolveTo({ accepted: true, serverSeq: 1 });
+
+        const result = await service.uploadPendingOps(mockApiProvider);
+
+        expect(result.fullStateUploadDeferred).toBeUndefined();
+        expect(result.uploadedCount).toBe(1);
+      });
+
       it('should update server seq after snapshot upload', async () => {
         const entry = createFullStateEntry(1, 'op-1', 'client-1', OpType.SyncImport);
         mockOpLogStore.getUnsynced.and.returnValue(Promise.resolve([entry]));

--- a/src/app/op-log/sync/operation-log-upload.service.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.ts
@@ -132,6 +132,10 @@ export class OperationLogUploadService {
     // unsynced, so the caller can report an honest not-in-sync status (not IN_SYNC).
     let encryptionRequiredKeyMissing = false;
     let blockedByRejectedFullState = false;
+    // Set when a full-state op hit a retryable server error (e.g. a Postgres
+    // serialization conflict). The op stays pending, but nothing reached the
+    // server this round, so the caller must not report IN_SYNC.
+    let fullStateUploadDeferred = false;
     let rejectedFullStateBarrierSeq: number | undefined;
 
     await this.lockService.request(LOCK_NAMES.UPLOAD, async () => {
@@ -334,6 +338,7 @@ export class OperationLogUploadService {
               `OperationLogUploadService: Full-state op ${entry.op.id} failed due to network error, will retry: ${result.error}`,
             );
             // Don't mark as rejected - leave as unsynced for retry
+            fullStateUploadDeferred = true;
           } else {
             // Keep the op pending until OperationLogSyncService has processed
             // piggybacked ops and the central rejection handler has classified
@@ -614,6 +619,7 @@ export class OperationLogUploadService {
       ...(lastServerSeqToPersist !== undefined ? { lastServerSeqToPersist } : {}),
       ...(encryptionRequiredKeyMissing ? { encryptionRequiredKeyMissing: true } : {}),
       ...(blockedByRejectedFullState ? { blockedByRejectedFullState: true } : {}),
+      ...(fullStateUploadDeferred ? { fullStateUploadDeferred: true } : {}),
       ...(options?.deferAcknowledgement
         ? { selectedPendingOps, pendingAcknowledgementSeqs }
         : {}),


### PR DESCRIPTION
## Problem

Scheduled E2E run [32683405598](https://github.com/super-productivity/super-productivity/actions/runs/32683405598) failed one test: `supersync-archive-data-sync.spec.ts:122` › *Server migration SYNC_IMPORT should include archived tasks*, dying in setup with `Unable to determine Client A vs B — sync state unclear after timeout`.

The trace shows a real product bug behind it, not just a flaky selector:

```
ServerMigrationService: Created SYNC_IMPORT operation for server migration.
SuperSyncProvider: uploadSnapshot: Complete {accepted: false, error: Concurrent transaction conflict - please retry}
OperationLogUploadService: Full-state op … failed due to network error, will retry
SyncWrapperService: Upload complete. uploaded=0, piggybacked=0
SyncWrapperService: Sync complete, status=IN_SYNC        ← wrong
```

The server hit a Postgres serialization failure (`sync.service.ts:627`) and rejected the snapshot. The client correctly kept the op pending for retry, but `SyncWrapperService` guards against claiming `IN_SYNC` for *every other* failure mode — permanent rejection, rejected full-state barrier, LWW exhaustion, missing encryption key, validation failure — and had no guard for a **retryable** full-state failure. So a server migration or backup restore whose whole-state upload transiently fails reports "in sync" with nothing on the server.

Not data loss (the next sync retries the pending op), but the status is a lie. The E2E helper then found the UI in the resulting unmodeled state — no spinner, no error icon, no check icon, because `hasNoPendingOps()` is false — and threw.

## Solution

**Product fix.** New `fullStateUploadDeferred` on the upload outcome, set only on the retryable branch in `operation-log-upload.service.ts`, forwarded through `operation-log-sync.service.ts`, consumed in `sync-wrapper.service.ts` → `UNKNOWN_OR_CHANGED` instead of falling through to `IN_SYNC`. Deliberately not `ERROR`: the op is pending and retried. The guard sits after the ERROR and permanent-rejection checks so their precedence is unchanged, and only ever intercepts what would otherwise have been `IN_SYNC`.

`ImmediateUploadService` needs no change (only claims `IN_SYNC` when `uploadedCount > 0`); the WS path never claims `IN_SYNC` at all.

**E2E harness.** `_setupSuperSync`'s fallback probe no longer throws on "sync configured, idle, ops pending" — a legitimate UI state, since the check icon only renders once `hasNoPendingOps()` is true. It falls through to the sync-completion wait below, which already re-triggers sync once before giving up, so a genuinely stalled setup still fails, just after a recovery attempt.

### Risk notes (sync change)

- No persistence or wire impact: `fullStateUploadDeferred` is an optional field on an in-memory result type. No op payload, no stored model, no schema-version implications.
- No replay/vector-clock behavior changes — this only affects the status reported after an upload round.
- Only reachable path changed is the one that previously ended in `IN_SYNC`; every other outcome is bit-for-bit identical.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, no user-facing functionality change
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

### Verification

Both guards carry tests that fail without them — confirmed by disabling each and re-running:

- upload service: `Expected undefined to be true` (1 FAILED / 84)
- wrapper: `Expected 'InSync' to be 'UpdateRemote'` (1 FAILED / 167)

Green with the fix: wrapper 167, upload 84, sync service 160, immediate-upload 36. `npx tsc -p tsconfig.json --noEmit` clean.

The E2E harness change has no test that fails without it — only a real SuperSync run exercises it.
