### PR TITLE
test(setup): stop the unit suite saving files into the download folder

### DIFF
--- a/src/test-download-guard.spec.ts
+++ b/src/test-download-guard.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * Pins the file-saving guard installed in `src/test.ts`. Without it every spec
+ * that reaches `download()` writes a real file into the browser's download
+ * directory, which on a dev machine is the user's ~/Downloads.
+ */
+describe('test harness download guard', () => {
+  it('should swallow a click on an anchor that saves a file', () => {
+    const a = document.createElement('a');
+    a.download = 'should-never-be-written.json';
+    a.href = 'data:text/plain,x';
+    let didFire = false;
+    a.addEventListener('click', () => (didFire = true));
+
+    a.click();
+
+    expect(didFire).toBeFalse();
+  });
+
+  it('should leave a plain anchor click alone', () => {
+    const a = document.createElement('a');
+    let didFire = false;
+    a.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      didFire = true;
+    });
+
+    a.click();
+
+    expect(didFire).toBeTrue();
+  });
+});

--- a/src/test.ts
+++ b/src/test.ts
@@ -133,6 +133,21 @@ if (!(window.confirm as jasmine.Spy).and) {
   window.confirm = jasmine.createSpy('confirm').and.returnValue(true);
 }
 
+// Neutralize file-saving clicks. `download()` (src/app/util/download.ts) saves a
+// file by creating an `<a download>` and clicking it, so any spec that reaches a
+// download path writes a real file into the browser's download directory — the
+// user's ~/Downloads on a dev machine. Whether the browser honours it depends on
+// the Chrome version (headless Chrome <= 150 wrote the file, 151 does not), so
+// the leak is silent and comes back with a browser update rather than a code
+// change. Anchor clicks without a `download` attribute keep their real behaviour.
+const originalAnchorClick = HTMLAnchorElement.prototype.click;
+HTMLAnchorElement.prototype.click = function (this: HTMLAnchorElement): void {
+  if (this.hasAttribute('download')) {
+    return;
+  }
+  originalAnchorClick.call(this);
+};
+
 // Configure the TestBed providers globally
 const originalConfigureTestingModule = TestBed.configureTestingModule;
 TestBed.configureTestingModule = function (


### PR DESCRIPTION
## Problem

Two spec files call methods that save a file, without stubbing the util that does it:

- `FileImexComponent`'s `downloadBackup` / `privacyAppDataDownload` specs → `sp-backup_<timestamp>.json`, `sp-backup-anonymized_<timestamp>.json`
- `UserProfileService`'s `exportProfile` spec → `profile-<id>.json`

Both reach `download()` (`src/app/util/download.ts`), which in a browser creates an `<a download>`, appends it, and clicks it. That click is a real save, so Karma's Chrome writes the file into its download directory — on a contributor machine, `~/Downloads`. I found ~130 of them there, accumulated over a month of running the suite.

The data is `createAppDataCompleteMock()` (`project.ids: []`, no inbox project, empty `menuTree`) and, for the profile spec, its `'stale'` / `'live'` fixtures — so the files are junk, and nothing in either spec asserts on them. Both specs only assert that the underlying load was called.

### Why it stays unnoticed

Exactly one file lands per suite run: Chrome permits one automatic download per session and blocks the rest, and a single-spec run ends before the download commits, so `npm run test:file` on either spec produces nothing. It only shows up when the whole suite runs, which is also when nobody is watching their downloads folder.

Measured just now on Chrome Headless 151, same machine, same command:

```
npm run test:once   (without this patch)   → TOTAL: 14402 SUCCESS
                                             ~/Downloads/sp-backup_2026-08-24_200023.json  ← new

npm run test:once   (with this patch)      → TOTAL: 14404 SUCCESS
                                             no new file
```

E2E got the equivalent treatment in f67bd288b ("fix(e2e): configure downloads path to prevent leaking to ~/Downloads"); the Karma side never did.

## Fix

Neutralize file-saving clicks in the harness (`src/test.ts`), next to the existing global `alert` / `confirm` mocks:

```ts
const originalAnchorClick = HTMLAnchorElement.prototype.click;
HTMLAnchorElement.prototype.click = function (this: HTMLAnchorElement): void {
  if (this.hasAttribute('download')) {
    return;
  }
  originalAnchorClick.call(this);
};
```

Harness-level rather than per-spec because the leak is a property of the download path, not of one spec — it already had two callers, and the next one would have to remember to stub it. Anchor clicks without a `download` attribute keep their real behavior, so the existing anchor specs (`task-attachment-link.directive.spec.ts`, `plugin-security.spec.ts`, `inline-markdown.component.spec.ts`) are unaffected; they dispatch events rather than calling `.click()` anyway.

## Test

`src/test-download-guard.spec.ts` pins the guard from both sides: a click on an `<a download>` fires no click event, a plain anchor click still does. Verified by breaking it — with the `hasAttribute('download')` branch disabled, the first spec fails with `Expected true to be false`.

Full suite green in both timezone lanes: **14404 / 14420 (16 skipped) SUCCESS** in `Europe/Berlin` and `America/Los_Angeles`. `npm run lint` clean.
