### PR TITLE
fix(tools): report css custom property offenders with posix paths

### DIFF
--- a/tools/check-css-vars.js
+++ b/tools/check-css-vars.js
@@ -43,6 +43,8 @@ const ROOT_STYLESHEET = path.join(SRC_DIR, 'styles.scss');
 // Carries a real document-level <style> block.
 const INDEX_HTML = path.join(SRC_DIR, 'index.html');
 
+const toPosix = (p) => p.split(path.sep).join('/');
+
 /**
  * Custom properties that are set at runtime rather than declared in CSS.
  * Add here ONLY with a verified source — never to silence a real typo.
@@ -229,7 +231,9 @@ for (const file of sourceFiles) {
         const componentScoped = anyDefs.has(name);
         anyComponentScoped ||= componentScoped;
         offenders.push({
-          location: `${path.relative(REPO_ROOT, file)}:${idx + 1}`,
+          // Reported paths stay posix-style so the output (and the specs that
+          // match it) reads the same on Windows as it does on macOS and Linux.
+          location: `${toPosix(path.relative(REPO_ROOT, file))}:${idx + 1}`,
           name: componentScoped ? `${name}   (component-scoped)` : name,
         });
       }


### PR DESCRIPTION
## Problem

`tools/check-css-vars.js` builds each offender location with `path.relative`, so on Windows it reports

```
  --standard-border-radius   (component-scoped)
    src\styles\components\formly-rows.scss:1
```

while its own test asserts `/styles\/components\/formly-rows\.scss:1/`:

```
node --test tools/check-css-vars.test.js
✖ flags a global stylesheet reaching for a component-scoped declaration
  operator: 'match'
  expected: /styles\/components\/formly-rows\.scss:1/
```

`npm run lint` runs the tool tests and the pre-commit hook runs `npm run lint`, so on Windows every commit is blocked by this, whatever the change touches. I hit it committing an unrelated test fix (#9720).

## Fix

Normalize the reported path to forward slashes. Beyond making the test pass, offender output is meant to be pasted into an issue or compared between machines, so one separator on every platform is the right form on its own.

`node --test tools/check-css-vars.test.js` → 19/19 pass (was 18/19 on Windows). No behavior change on macOS/Linux, where `path.sep` is already `/`.
