### PR TITLE
feat(packaging): add arm64 linux builds

### DIFF
--- a/electron-builder.yaml
+++ b/electron-builder.yaml
@@ -96,10 +96,21 @@ linux:
       # `-bin` value now matches nothing on either session type.
       StartupWMClass: superproductivity
   target:
-    - AppImage
-    - deb
-    - snap
-    - rpm
+    - target: AppImage
+      arch:
+        - x64
+        - arm64
+    - target: deb
+      arch:
+        - x64
+        - arm64
+    - target: rpm
+      arch:
+        - x64
+        - arm64
+    - target: snap
+      arch:
+        - x64
   publish:
     - github
 


### PR DESCRIPTION
## Problem

Currently ARM64 linux builds are not created/published, whilst solutions like FEX exist they need a lot of resources and it'd be nice to run it natively. I had to compile the appimage manually to get it on my laptop

Will close #5470 

## Solution

Adds ARM64 to the electron builder packaging configuration so they should be automatically built going forwards.

Appimage has been tested on a macbook air m1 running the latest fedora asahi remix. Currently wayland idle mode has to be ignored, this is to be fixed

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [ ] My commit messages follow the Angular format (`type(scope): description`)
