### PR TITLE
feat(plugin): add task repeat config methods to plugin API

### DIFF
--- a/packages/plugin-api/README.md
+++ b/packages/plugin-api/README.md
@@ -133,6 +133,9 @@ Add these to your manifest.json based on what your plugin needs:
 - `getSelectedTask` - Read the task selected in the task detail panel
 - `getFocusedTask` - Read the currently focused task row, if any
 - `addTask` - Create tasks
+- `addTaskRepeatCfg` - Make a task repeatable (create a repeat config for it)
+- `updateTaskRepeatCfg` - Update a task repeat config
+- `deleteTaskRepeatCfg` - Delete a task repeat config
 - `getAllProjects` - Read projects
 - `addProject` - Create projects
 - `getAllTags` - Read tags

--- a/packages/plugin-api/src/types.ts
+++ b/packages/plugin-api/src/types.ts
@@ -495,6 +495,10 @@ export interface PluginTaskRepeatCfg {
   lastTaskCreationDay?: string;
   quickSetting?: string;
   remindAt?: string;
+  notes?: string;
+  repeatFromCompletionDate?: boolean;
+  waitForCompletion?: boolean;
+  skipOverdue?: boolean;
 }
 
 export interface PluginSimpleCounterFull {
@@ -660,6 +664,26 @@ export interface PluginAPI {
 
   deleteTask(taskId: string): Promise<void>;
 
+  /**
+   * Make a task repeatable by creating a repeat config for it, mirroring the
+   * "Repeat" dialog. Unset fields fall back to the dialog's defaults. Rejected
+   * for sub tasks and for tasks that already have a repeat config.
+   * @returns the id of the created repeat config
+   */
+  addTaskRepeatCfg(
+    taskId: string,
+    cfgData?: PluginCreateTaskRepeatCfgData,
+  ): Promise<string>;
+
+  /** Update an existing task repeat config */
+  updateTaskRepeatCfg(
+    cfgId: string,
+    changes: PluginCreateTaskRepeatCfgData,
+  ): Promise<void>;
+
+  /** Delete a task repeat config; its task instances are cleaned up like a dialog delete */
+  deleteTaskRepeatCfg(cfgId: string): Promise<void>;
+
   batchUpdateForProject(request: BatchUpdateRequest): Promise<BatchUpdateResult>;
 
   // projects
@@ -805,6 +829,63 @@ export interface PluginCreateTaskData {
   isDone?: boolean;
   /** Due date as ISO date string (YYYY-MM-DD) */
   dueDay?: string | null;
+}
+
+/**
+ * Data for creating or updating a task repeat config via the plugin API.
+ * All fields are optional — on create, unset fields fall back to the same
+ * defaults the "Repeat" dialog uses.
+ *
+ * The recurrence itself is governed by `repeatCycle`, `repeatEvery` and the
+ * per-weekday flags; `quickSetting` is only the grouping label shown in the
+ * dialog form and has no direct effect (matches the internal model).
+ */
+export interface PluginCreateTaskRepeatCfgData {
+  /** Title used for created task instances; defaults to the task's current title */
+  title?: string | null;
+  tagIds?: string[];
+  isPaused?: boolean;
+  repeatCycle?: 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'YEARLY';
+  /** Repeat every N cycles (default 1) */
+  repeatEvery?: number;
+  /** ISO date string (YYYY-MM-DD) the recurrence is anchored to; defaults to today */
+  startDate?: string;
+  /** HH:mm — when set, created instances are scheduled at this time of day */
+  startTime?: string;
+  /** Default time estimate for created instances in milliseconds */
+  defaultEstimate?: number;
+  monday?: boolean;
+  tuesday?: boolean;
+  wednesday?: boolean;
+  thursday?: boolean;
+  friday?: boolean;
+  saturday?: boolean;
+  sunday?: boolean;
+  /** Dialog grouping label only — set the explicit recurrence fields as well */
+  quickSetting?:
+    | 'DAILY'
+    | 'WEEKLY_CURRENT_WEEKDAY'
+    | 'MONTHLY_CURRENT_DATE'
+    | 'MONTHLY_FIRST_DAY'
+    | 'MONTHLY_LAST_DAY'
+    | 'MONTHLY_NTH_WEEKDAY'
+    | 'MONDAY_TO_FRIDAY'
+    | 'YEARLY_CURRENT_DATE'
+    | 'CUSTOM';
+  /** Reminder for scheduled instances; only has an effect together with startTime */
+  remindAt?: 'DoNotRemind' | 'AtStart' | 'm5' | 'm10' | 'm15' | 'm30' | 'h1';
+  /** Notes template for created task instances */
+  notes?: string;
+  /** Base the next occurrence on the completion date instead of the schedule */
+  repeatFromCompletionDate?: boolean;
+  /** Only create the next instance after the current one is completed */
+  waitForCompletion?: boolean;
+  /**
+   * Silently skip missed/overdue instances instead of creating them.
+   * Defaults to the dialog's schedule-aware default (ON only for a plain
+   * everyday schedule).
+   */
+  skipOverdue?: boolean;
 }
 
 export interface PluginShortcutCfg {

--- a/src/app/plugins/plugin-api.ts
+++ b/src/app/plugins/plugin-api.ts
@@ -12,6 +12,7 @@ import {
   PluginAppState,
   PluginBaseCfg,
   PluginCreateTaskData,
+  PluginCreateTaskRepeatCfgData,
   PluginHeaderBtnCfg,
   PluginHookHandler,
   PluginHooks,
@@ -243,6 +244,29 @@ export class PluginAPI implements PluginAPIInterface {
   async deleteTask(taskId: string): Promise<void> {
     PluginLog.log(`Plugin ${this.#pluginId} requested to delete task ${taskId}`);
     return this.#pluginBridge.deleteTask(taskId);
+  }
+
+  async addTaskRepeatCfg(
+    taskId: string,
+    cfgData?: PluginCreateTaskRepeatCfgData,
+  ): Promise<string> {
+    PluginLog.log(
+      `Plugin ${this.#pluginId} requested to add repeat config to task ${taskId}`,
+    );
+    return this.#pluginBridge.addTaskRepeatCfg(taskId, cfgData);
+  }
+
+  async updateTaskRepeatCfg(
+    cfgId: string,
+    changes: PluginCreateTaskRepeatCfgData,
+  ): Promise<void> {
+    PluginLog.log(`Plugin ${this.#pluginId} requested to update repeat config ${cfgId}`);
+    return this.#pluginBridge.updateTaskRepeatCfg(cfgId, changes);
+  }
+
+  async deleteTaskRepeatCfg(cfgId: string): Promise<void> {
+    PluginLog.log(`Plugin ${this.#pluginId} requested to delete repeat config ${cfgId}`);
+    return this.#pluginBridge.deleteTaskRepeatCfg(cfgId);
   }
 
   async getAllProjects(): Promise<Project[]> {

--- a/src/app/plugins/plugin-bridge-add-task.service.spec.ts
+++ b/src/app/plugins/plugin-bridge-add-task.service.spec.ts
@@ -6,6 +6,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { PluginBridgeService } from './plugin-bridge.service';
+import { TaskRepeatCfgService } from '../features/task-repeat-cfg/task-repeat-cfg.service';
 import { TaskService } from '../features/tasks/task.service';
 import { ProjectService } from '../features/project/project.service';
 import { TagService } from '../features/tag/tag.service';
@@ -73,6 +74,7 @@ describe('PluginBridgeService.addTask() — subtask creation', () => {
     TestBed.configureTestingModule({
       providers: [
         PluginBridgeService,
+        { provide: TaskRepeatCfgService, useValue: {} },
         { provide: Store, useValue: storeSpy },
         { provide: TaskService, useValue: taskServiceSpy },
         { provide: ProjectService, useValue: projectServiceSpy },

--- a/src/app/plugins/plugin-bridge-counter.service.spec.ts
+++ b/src/app/plugins/plugin-bridge-counter.service.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { Store } from '@ngrx/store';
 import { of } from 'rxjs';
 import { PluginBridgeService } from './plugin-bridge.service';
+import { TaskRepeatCfgService } from '../features/task-repeat-cfg/task-repeat-cfg.service';
 import {
   SimpleCounter,
   SimpleCounterType,
@@ -65,6 +66,7 @@ describe('PluginBridgeService.setCounter()', () => {
     TestBed.configureTestingModule({
       providers: [
         PluginBridgeService,
+        { provide: TaskRepeatCfgService, useValue: {} },
         { provide: Store, useValue: storeSpy },
         { provide: TaskService, useValue: taskServiceSpy },
         { provide: ProjectService, useValue: projectServiceSpy },

--- a/src/app/plugins/plugin-bridge-task-repeat-cfg.service.spec.ts
+++ b/src/app/plugins/plugin-bridge-task-repeat-cfg.service.spec.ts
@@ -1,0 +1,308 @@
+import { TestBed } from '@angular/core/testing';
+import { Injector, signal } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { of } from 'rxjs';
+import { MatDialog } from '@angular/material/dialog';
+import { Router } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
+import { PluginBridgeService } from './plugin-bridge.service';
+import { TaskService } from '../features/tasks/task.service';
+import { ProjectService } from '../features/project/project.service';
+import { TagService } from '../features/tag/tag.service';
+import { WorkContextService } from '../features/work-context/work-context.service';
+import { SnackService } from '../core/snack/snack.service';
+import { NotifyService } from '../core/notify/notify.service';
+import { PluginHooksService } from './plugin-hooks';
+import { PluginUserPersistenceService } from './plugin-user-persistence.service';
+import { PluginConfigService } from './plugin-config.service';
+import { TaskArchiveService } from '../features/archive/task-archive.service';
+import { SyncWrapperService } from '../imex/sync/sync-wrapper.service';
+import { GlobalThemeService } from '../core/theme/global-theme.service';
+import { PluginIssueProviderRegistryService } from './issue-provider/plugin-issue-provider-registry.service';
+import { IssueSyncAdapterRegistryService } from '../features/issue/two-way-sync/issue-sync-adapter-registry.service';
+import { PluginHttpService } from './issue-provider/plugin-http.service';
+import { DataInitService } from '../core/data-init/data-init.service';
+import { GlobalConfigService } from '../features/config/global-config.service';
+import { TaskRepeatCfgService } from '../features/task-repeat-cfg/task-repeat-cfg.service';
+import { TaskRepeatCfg } from '../features/task-repeat-cfg/task-repeat-cfg.model';
+import { Task } from '../features/tasks/task.model';
+import { DEFAULT_GLOBAL_CONFIG } from '../features/config/default-global-config.const';
+import { getDbDateStr } from '../util/get-db-date-str';
+
+// Covers the plugin API's task-repeat-config methods, which delegate to
+// TaskRepeatCfgService (the same single persistent action the "Repeat" dialog
+// dispatches) after validating the target task / config. The default-derivation
+// cases pin down dialog parity: title from the task, startDate anchored today,
+// and the schedule-aware skipOverdue default from get-default-skip-overdue.ts.
+describe('PluginBridgeService task repeat config methods', () => {
+  const TASK = {
+    id: 'task-1',
+    title: 'Water the plants',
+    projectId: 'p1',
+    subTasks: [],
+  } as unknown as Task;
+
+  const setup = (
+    taskInStore: unknown = TASK,
+    existingCfg: TaskRepeatCfg | undefined = undefined,
+  ): {
+    service: PluginBridgeService;
+    repeatCfgService: jasmine.SpyObj<TaskRepeatCfgService>;
+  } => {
+    const storeSpy = jasmine.createSpyObj('Store', ['select', 'dispatch']);
+    storeSpy.select.and.returnValue(of(taskInStore));
+
+    const taskServiceSpy = jasmine.createSpyObj('TaskService', ['add', 'update']);
+    taskServiceSpy.allTasks$ = of([]);
+
+    const repeatCfgServiceSpy = jasmine.createSpyObj('TaskRepeatCfgService', [
+      'addTaskRepeatCfgToTask',
+      'updateTaskRepeatCfg',
+      'deleteTaskRepeatCfg',
+      'getTaskRepeatCfgByIdAllowUndefined$',
+    ]);
+    repeatCfgServiceSpy.addTaskRepeatCfgToTask.and.returnValue('cfg-1');
+    repeatCfgServiceSpy.getTaskRepeatCfgByIdAllowUndefined$.and.returnValue(
+      of(existingCfg),
+    );
+
+    // 't1' exists so tests can pass tagIds without tripping
+    // _validateTaskReferences.
+    const projectServiceSpy = jasmine.createSpyObj('ProjectService', [], {
+      list$: of([{ id: 'p1' }]),
+    });
+    const tagServiceSpy = jasmine.createSpyObj('TagService', [], {
+      tags$: of([{ id: 't1' }]),
+    });
+
+    const globalConfigSpy = {
+      cfg: signal(DEFAULT_GLOBAL_CONFIG),
+    } as unknown as GlobalConfigService;
+
+    TestBed.configureTestingModule({
+      providers: [
+        PluginBridgeService,
+        { provide: Store, useValue: storeSpy },
+        { provide: TaskService, useValue: taskServiceSpy },
+        { provide: TaskRepeatCfgService, useValue: repeatCfgServiceSpy },
+        { provide: ProjectService, useValue: projectServiceSpy },
+        { provide: TagService, useValue: tagServiceSpy },
+        {
+          provide: WorkContextService,
+          useValue: jasmine.createSpyObj('WorkContextService', [], {
+            activeWorkContext$: of(null),
+          }),
+        },
+        {
+          provide: SnackService,
+          useValue: jasmine.createSpyObj('SnackService', ['open']),
+        },
+        {
+          provide: NotifyService,
+          useValue: jasmine.createSpyObj('NotifyService', ['notify']),
+        },
+        { provide: MatDialog, useValue: jasmine.createSpyObj('MatDialog', ['open']) },
+        { provide: Router, useValue: jasmine.createSpyObj('Router', ['navigate']) },
+        {
+          provide: PluginHooksService,
+          useValue: jasmine.createSpyObj('PluginHooksService', ['registerHook']),
+        },
+        {
+          provide: PluginUserPersistenceService,
+          useValue: jasmine.createSpyObj('PluginUserPersistenceService', ['get', 'set']),
+        },
+        {
+          provide: PluginConfigService,
+          useValue: jasmine.createSpyObj('PluginConfigService', ['get', 'set']),
+        },
+        {
+          provide: TaskArchiveService,
+          useValue: jasmine.createSpyObj('TaskArchiveService', ['getAll']),
+        },
+        {
+          provide: TranslateService,
+          useValue: {
+            // Keep the params in the string so error assertions can see which
+            // validation message was raised.
+            instant: (key: string, params?: object) =>
+              params ? `${key} ${JSON.stringify(params)}` : key,
+          },
+        },
+        {
+          provide: SyncWrapperService,
+          useValue: jasmine.createSpyObj('SyncWrapperService', ['sync']),
+        },
+        Injector,
+        { provide: GlobalThemeService, useValue: {} },
+        { provide: PluginIssueProviderRegistryService, useValue: {} },
+        { provide: IssueSyncAdapterRegistryService, useValue: {} },
+        { provide: PluginHttpService, useValue: {} },
+        { provide: DataInitService, useValue: { reInit: () => Promise.resolve() } },
+        { provide: GlobalConfigService, useValue: globalConfigSpy },
+      ],
+    });
+
+    const service = TestBed.inject(PluginBridgeService);
+    const repeatCfgService = TestBed.inject(
+      TaskRepeatCfgService,
+    ) as jasmine.SpyObj<TaskRepeatCfgService>;
+
+    return { service, repeatCfgService };
+  };
+
+  describe('addTaskRepeatCfg()', () => {
+    it('creates a config with dialog defaults derived from the task', async () => {
+      const { service, repeatCfgService } = setup();
+
+      const cfgId = await service.addTaskRepeatCfg('task-1');
+
+      expect(cfgId).toBe('cfg-1');
+      expect(repeatCfgService.addTaskRepeatCfgToTask).toHaveBeenCalledWith(
+        'task-1',
+        'p1',
+        jasmine.objectContaining({
+          title: 'Water the plants',
+          projectId: 'p1',
+          startDate: getDbDateStr(),
+          // DEFAULT quickSetting is DAILY → schedule-aware default is ON
+          skipOverdue: true,
+        }),
+      );
+    });
+
+    it('honours explicit fields and keeps skipOverdue OFF for non-everyday schedules', async () => {
+      const { service, repeatCfgService } = setup();
+
+      await service.addTaskRepeatCfg('task-1', {
+        title: 'Weekly watering',
+        quickSetting: 'CUSTOM',
+        repeatCycle: 'WEEKLY',
+        monday: false,
+        tuesday: false,
+        wednesday: true,
+        thursday: false,
+        friday: false,
+        saturday: false,
+        sunday: false,
+        startDate: '2030-01-01',
+        startTime: '12:45',
+        remindAt: 'AtStart',
+      });
+
+      expect(repeatCfgService.addTaskRepeatCfgToTask).toHaveBeenCalledWith(
+        'task-1',
+        'p1',
+        jasmine.objectContaining({
+          title: 'Weekly watering',
+          quickSetting: 'CUSTOM',
+          repeatCycle: 'WEEKLY',
+          monday: false,
+          wednesday: true,
+          startDate: '2030-01-01',
+          startTime: '12:45',
+          remindAt: 'AtStart',
+          skipOverdue: false,
+        }),
+      );
+    });
+
+    it('respects an explicit skipOverdue over the schedule-aware default', async () => {
+      const { service, repeatCfgService } = setup();
+
+      // Default schedule is the plain everyday one, whose derived default is ON
+      await service.addTaskRepeatCfg('task-1', { skipOverdue: false });
+
+      expect(repeatCfgService.addTaskRepeatCfgToTask).toHaveBeenCalledWith(
+        'task-1',
+        'p1',
+        jasmine.objectContaining({ skipOverdue: false }),
+      );
+    });
+
+    it('throws for an unknown task', async () => {
+      // null (not undefined) — an explicit undefined would trigger the
+      // default-parameter fallback to TASK
+      const { service, repeatCfgService } = setup(null);
+
+      await expectAsync(service.addTaskRepeatCfg('nope')).toBeRejectedWithError(
+        /TASK_NOT_FOUND/,
+      );
+      expect(repeatCfgService.addTaskRepeatCfgToTask).not.toHaveBeenCalled();
+    });
+
+    it('rejects sub tasks', async () => {
+      const { service, repeatCfgService } = setup({ ...TASK, parentId: 'parent-1' });
+
+      await expectAsync(service.addTaskRepeatCfg('task-1')).toBeRejectedWithError(
+        /Sub tasks cannot be made repeatable/,
+      );
+      expect(repeatCfgService.addTaskRepeatCfgToTask).not.toHaveBeenCalled();
+    });
+
+    it('rejects a task that already has a repeat config', async () => {
+      const { service, repeatCfgService } = setup({ ...TASK, repeatCfgId: 'cfg-old' });
+
+      await expectAsync(service.addTaskRepeatCfg('task-1')).toBeRejectedWithError(
+        /already has a repeat config/,
+      );
+      expect(repeatCfgService.addTaskRepeatCfgToTask).not.toHaveBeenCalled();
+    });
+
+    it('rejects unknown tags', async () => {
+      const { service, repeatCfgService } = setup();
+
+      await expectAsync(
+        service.addTaskRepeatCfg('task-1', { tagIds: ['nope'] }),
+      ).toBeRejectedWithError(/TAGS_DO_NOT_EXIST/);
+      expect(repeatCfgService.addTaskRepeatCfgToTask).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateTaskRepeatCfg()', () => {
+    it('throws when the config does not exist', async () => {
+      const { service, repeatCfgService } = setup(TASK, undefined);
+
+      await expectAsync(
+        service.updateTaskRepeatCfg('cfg-x', { startTime: '09:00' }),
+      ).toBeRejectedWithError(/No task repeat config found/);
+      expect(repeatCfgService.updateTaskRepeatCfg).not.toHaveBeenCalled();
+    });
+
+    it('passes changes through to the service', async () => {
+      const { service, repeatCfgService } = setup(TASK, {
+        id: 'cfg-1',
+      } as TaskRepeatCfg);
+
+      await service.updateTaskRepeatCfg('cfg-1', {
+        startTime: '09:00',
+        remindAt: 'm10',
+      });
+
+      expect(repeatCfgService.updateTaskRepeatCfg).toHaveBeenCalledWith(
+        'cfg-1',
+        jasmine.objectContaining({ startTime: '09:00', remindAt: 'm10' }),
+      );
+    });
+  });
+
+  describe('deleteTaskRepeatCfg()', () => {
+    it('throws when the config does not exist', async () => {
+      const { service, repeatCfgService } = setup(TASK, undefined);
+
+      await expectAsync(service.deleteTaskRepeatCfg('cfg-x')).toBeRejectedWithError(
+        /No task repeat config found/,
+      );
+      expect(repeatCfgService.deleteTaskRepeatCfg).not.toHaveBeenCalled();
+    });
+
+    it('delegates to the service when the config exists', async () => {
+      const { service, repeatCfgService } = setup(TASK, {
+        id: 'cfg-1',
+      } as TaskRepeatCfg);
+
+      await service.deleteTaskRepeatCfg('cfg-1');
+
+      expect(repeatCfgService.deleteTaskRepeatCfg).toHaveBeenCalledWith('cfg-1');
+    });
+  });
+});

--- a/src/app/plugins/plugin-bridge-work-context.service.spec.ts
+++ b/src/app/plugins/plugin-bridge-work-context.service.spec.ts
@@ -6,6 +6,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { PluginBridgeService } from './plugin-bridge.service';
+import { TaskRepeatCfgService } from '../features/task-repeat-cfg/task-repeat-cfg.service';
 import { TaskService } from '../features/tasks/task.service';
 import { ProjectService } from '../features/project/project.service';
 import { TagService } from '../features/tag/tag.service';
@@ -93,6 +94,7 @@ describe('PluginBridgeService.workContext — header buttons + embed slot', () =
     TestBed.configureTestingModule({
       providers: [
         PluginBridgeService,
+        { provide: TaskRepeatCfgService, useValue: {} },
         {
           provide: Store,
           useValue: jasmine.createSpyObj('Store', ['select', 'dispatch']),

--- a/src/app/plugins/plugin-bridge.service.spec.ts
+++ b/src/app/plugins/plugin-bridge.service.spec.ts
@@ -5,6 +5,7 @@ import { TestBed } from '@angular/core/testing';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
 import { PluginBridgeService } from './plugin-bridge.service';
+import { TaskRepeatCfgService } from '../features/task-repeat-cfg/task-repeat-cfg.service';
 import { selectAllSimpleCounters } from '../features/simple-counter/store/simple-counter.reducer';
 import {
   updateSimpleCounter,
@@ -64,6 +65,7 @@ describe('PluginBridgeService - Counter Methods', () => {
     TestBed.configureTestingModule({
       providers: [
         PluginBridgeService,
+        { provide: TaskRepeatCfgService, useValue: {} },
         provideMockStore({
           selectors: [
             { selector: selectAllSimpleCounters, value: [mockExistingCounter] },
@@ -301,6 +303,7 @@ describe('PluginBridgeService - dispatchAction privacy (#7619)', () => {
     TestBed.configureTestingModule({
       providers: [
         PluginBridgeService,
+        { provide: TaskRepeatCfgService, useValue: {} },
         provideMockStore(),
         { provide: SnackService, useValue: {} },
         { provide: NotifyService, useValue: {} },
@@ -400,6 +403,7 @@ describe('PluginBridgeService - iframe task selection methods', () => {
     TestBed.configureTestingModule({
       providers: [
         PluginBridgeService,
+        { provide: TaskRepeatCfgService, useValue: {} },
         provideMockStore(),
         { provide: SnackService, useValue: {} },
         { provide: NotifyService, useValue: {} },
@@ -473,6 +477,7 @@ describe('PluginBridgeService - request()', () => {
     TestBed.configureTestingModule({
       providers: [
         PluginBridgeService,
+        { provide: TaskRepeatCfgService, useValue: {} },
         provideMockStore(),
         { provide: SnackService, useValue: {} },
         { provide: NotifyService, useValue: {} },
@@ -600,6 +605,7 @@ describe('PluginBridgeService - openDialog', () => {
     TestBed.configureTestingModule({
       providers: [
         PluginBridgeService,
+        { provide: TaskRepeatCfgService, useValue: {} },
         provideMockStore(),
         { provide: SnackService, useValue: {} },
         { provide: NotifyService, useValue: {} },
@@ -691,6 +697,7 @@ describe('PluginBridgeService - nodeExecution grant tokens', () => {
     TestBed.configureTestingModule({
       providers: [
         PluginBridgeService,
+        { provide: TaskRepeatCfgService, useValue: {} },
         provideMockStore(),
         { provide: SnackService, useValue: {} },
         { provide: NotifyService, useValue: {} },
@@ -800,6 +807,7 @@ describe('PluginBridgeService - getAppState credential redaction', () => {
     TestBed.configureTestingModule({
       providers: [
         PluginBridgeService,
+        { provide: TaskRepeatCfgService, useValue: {} },
         provideMockStore(),
         { provide: SnackService, useValue: {} },
         { provide: NotifyService, useValue: {} },

--- a/src/app/plugins/plugin-bridge.service.ts
+++ b/src/app/plugins/plugin-bridge.service.ts
@@ -34,6 +34,7 @@ import {
   OAuthFlowConfig,
   OAuthTokenResult,
   PluginAppState,
+  PluginCreateTaskRepeatCfgData,
   PluginManifest,
   PluginNote,
   PluginRequestOptions,
@@ -74,7 +75,13 @@ import { TranslateService } from '@ngx-translate/core';
 import { T } from '../t.const';
 import { SyncWrapperService } from '../imex/sync/sync-wrapper.service';
 import { Log, PluginLog } from '../core/log';
-import { TaskCopy } from '../features/tasks/task.model';
+import { TaskCopy, TaskReminderOptionId } from '../features/tasks/task.model';
+import { TaskRepeatCfgService } from '../features/task-repeat-cfg/task-repeat-cfg.service';
+import {
+  DEFAULT_TASK_REPEAT_CFG,
+  TaskRepeatCfgCopy,
+} from '../features/task-repeat-cfg/task-repeat-cfg.model';
+import { getDefaultSkipOverdue } from '../features/task-repeat-cfg/dialog-edit-task-repeat-cfg/get-default-skip-overdue';
 import { ProjectCopy } from '../features/project/project.model';
 import { TagCopy } from '../features/tag/tag.model';
 import { MAX_BATCH_OPERATIONS_SIZE } from '../op-log/core/operation-log.const';
@@ -149,6 +156,7 @@ export class PluginBridgeService implements OnDestroy {
   private _pluginHooksService = inject(PluginHooksService);
   private _taskService = inject(TaskService);
   private _taskFocusService = inject(TaskFocusService);
+  private _taskRepeatCfgService = inject(TaskRepeatCfgService);
   private _workContextService = inject(WorkContextService);
   private _projectService = inject(ProjectService);
   private _tagService = inject(TagService);
@@ -1018,6 +1026,124 @@ export class PluginBridgeService implements OnDestroy {
       PluginLog.err('PluginBridge: Failed to delete task:', error);
       throw error;
     }
+  }
+
+  /**
+   * Make a task repeatable by creating a repeat config for it.
+   *
+   * Thin wrapper over TaskRepeatCfgService.addTaskRepeatCfgToTask() — the same
+   * single persistent action the "Repeat" dialog dispatches, so persistence
+   * metadata, first-occurrence calculation, lastTaskCreationDay and the
+   * task↔config link all stay with the existing service/effects (#5594).
+   */
+  async addTaskRepeatCfg(
+    taskId: string,
+    cfgData?: PluginCreateTaskRepeatCfgData,
+  ): Promise<string> {
+    typia.assert<string>(taskId);
+    typia.assert<PluginCreateTaskRepeatCfgData | undefined>(cfgData);
+
+    const task = await firstValueFrom(
+      this._store.select((state) => selectTaskByIdWithSubTaskData(state, { id: taskId })),
+    );
+    if (!task?.id) {
+      throw new Error(
+        this._translateService.instant(T.PLUGINS.TASK_NOT_FOUND, { taskId }),
+      );
+    }
+    // Mirrors the UI, which offers the repeat dialog for main tasks only:
+    // repeat instances are always created as main tasks, so a repeat config on
+    // a sub task could never re-create its own shape.
+    if (task.parentId) {
+      throw new Error(
+        'Sub tasks cannot be made repeatable. Use the parent task instead.',
+      );
+    }
+    // A task holds at most one repeat config; silently replacing the link would
+    // orphan the previous config without cleaning up its instances.
+    if (task.repeatCfgId) {
+      throw new Error(
+        `Task already has a repeat config (${task.repeatCfgId}). Use updateTaskRepeatCfg() instead.`,
+      );
+    }
+
+    await this._validateTaskReferences(undefined, cfgData?.tagIds);
+
+    const { remindAt, skipOverdue, title, ...rest } = cfgData ?? {};
+    const cfgBase: Omit<TaskRepeatCfgCopy, 'id'> = {
+      ...DEFAULT_TASK_REPEAT_CFG,
+      // Dialog parity for NEW configs: anchor the recurrence today unless the
+      // caller provides an explicit startDate (in `rest`) — the DEFAULT leaves
+      // it undefined, which is only meant for legacy configs.
+      startDate: getDbDateStr(),
+      title: title !== undefined ? title : task.title,
+      ...rest,
+      ...(remindAt !== undefined ? { remindAt: remindAt as TaskReminderOptionId } : {}),
+      // The config always belongs to the task's project; a caller-provided
+      // projectId could silently split the config from its task.
+      projectId: task.projectId ?? null,
+    };
+    const cfg: Omit<TaskRepeatCfgCopy, 'id'> = {
+      ...cfgBase,
+      // Dialog parity: schedule-aware default (see get-default-skip-overdue.ts)
+      skipOverdue: skipOverdue ?? getDefaultSkipOverdue(cfgBase),
+    };
+
+    const cfgId = this._taskRepeatCfgService.addTaskRepeatCfgToTask(
+      task.id,
+      task.projectId ?? null,
+      cfg,
+    );
+    PluginLog.log('PluginBridge: Task repeat config added successfully', {
+      taskId,
+      cfgId,
+    });
+    return cfgId;
+  }
+
+  /**
+   * Update an existing task repeat config.
+   */
+  async updateTaskRepeatCfg(
+    cfgId: string,
+    changes: PluginCreateTaskRepeatCfgData,
+  ): Promise<void> {
+    typia.assert<string>(cfgId);
+    typia.assert<PluginCreateTaskRepeatCfgData>(changes);
+
+    const existing = await firstValueFrom(
+      this._taskRepeatCfgService.getTaskRepeatCfgByIdAllowUndefined$(cfgId),
+    );
+    if (!existing) {
+      throw new Error(`No task repeat config found for id ${cfgId}`);
+    }
+
+    await this._validateTaskReferences(undefined, changes.tagIds);
+
+    const { remindAt, ...rest } = changes;
+    this._taskRepeatCfgService.updateTaskRepeatCfg(cfgId, {
+      ...rest,
+      ...(remindAt !== undefined ? { remindAt: remindAt as TaskReminderOptionId } : {}),
+    });
+    PluginLog.log('PluginBridge: Task repeat config updated successfully', { cfgId });
+  }
+
+  /**
+   * Delete a task repeat config. Task instances are cleaned up by the shared
+   * delete action, exactly like a delete from the dialog.
+   */
+  async deleteTaskRepeatCfg(cfgId: string): Promise<void> {
+    typia.assert<string>(cfgId);
+
+    const existing = await firstValueFrom(
+      this._taskRepeatCfgService.getTaskRepeatCfgByIdAllowUndefined$(cfgId),
+    );
+    if (!existing) {
+      throw new Error(`No task repeat config found for id ${cfgId}`);
+    }
+
+    this._taskRepeatCfgService.deleteTaskRepeatCfg(cfgId);
+    PluginLog.log('PluginBridge: Task repeat config deleted successfully', { cfgId });
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds three methods to the plugin API for managing recurring tasks programmatically:

- `addTaskRepeatCfg(taskId, cfgData?)` — make a task repeatable; returns the new config's id
- `updateTaskRepeatCfg(cfgId, changes)`
- `deleteTaskRepeatCfg(cfgId)`

## Motivation

Repeat configs are already *readable* by plugins (`getAppState().taskRepeatCfgs`), but there is no way to create or maintain one from a plugin:

- there is no PluginAPI method for them, and
- the `TaskRepeatCfg` actions are (sensibly) not part of `ALLOWED_PLUGIN_ACTIONS` — and dispatching them raw would bypass the factory-attached op-log persistence meta anyway.

This blocks automation/integration plugins from setting up recurring tasks: everything else about a task can be automated through the API, but recurrence still requires opening the Repeat dialog by hand for every series. (My concrete case: an MCP bridge plugin that lets an AI assistant manage tasks — it can create scheduled tasks with reminders, but cannot make them recurring.)

## Design

- **Service-backed, not dispatch-based.** The bridge methods delegate to `TaskRepeatCfgService` (`addTaskRepeatCfgToTask` / `updateTaskRepeatCfg` / `deleteTaskRepeatCfg`) — the same single persistent action per call that the Repeat dialog dispatches. Persistence meta, first-occurrence calculation, `lastTaskCreationDay` and task↔config linking stay with the existing service/effects (#5594). One replay-atomic transition = one operation, per the contributor sync model; no new effects, reducers or actions.
- **Dialog parity for defaults.** Unset fields fall back to `DEFAULT_TASK_REPEAT_CFG`; `title` defaults to the task's current title, `startDate` is anchored to today, and `skipOverdue` uses the schedule-aware default from `get-default-skip-overdue.ts`.
- **Guards.** Unknown task/config → error; unknown tags → error (reuses `_validateTaskReferences`); sub tasks are rejected (matches the UI, which offers the dialog for main tasks only); a task that already has a `repeatCfgId` is rejected instead of silently re-linking, which would orphan the previous config. `projectId` always comes from the task, never from the caller, so a config can't be split from its task.
- **Input validation** with `typia.assert`, same pattern as `addTask` / `updateTask`.

## Changes

- `packages/plugin-api/src/types.ts` — new `PluginCreateTaskRepeatCfgData` type + the three `PluginAPI` methods. `PluginTaskRepeatCfg` gains optional `notes` / `skipOverdue` / `waitForCompletion` / `repeatFromCompletionDate` (read parity: these already flow through `getAppState()` at runtime, the type just didn't declare them).
- `src/app/plugins/plugin-api.ts` — thin logging wrappers.
- `src/app/plugins/plugin-bridge.service.ts` — validation + delegation.
- `src/app/plugins/plugin-bridge-task-repeat-cfg.service.spec.ts` — 11 specs: defaults derivation (title/startDate/skipOverdue), explicit fields incl. `remindAt`, and every guard (unknown task, sub task, existing config, unknown tags, unknown config on update/delete).
- `packages/plugin-api/README.md` — method list.
- Existing plugin-bridge specs (`add-task` / `counter` / `work-context` / core) get a `TaskRepeatCfgService` mock provider, since the bridge now injects it (the real service's field initializers don't survive a spied `Store`).

## Testing

- New spec: 11/11 green.
- All plugin suites (`plugin-bridge*` + `plugin-api`): 106/106 green (ChromeHeadless, `TZ=Europe/Berlin`).
- `packages/plugin-api` builds clean; eslint clean on touched files (only the pre-existing `max-lines` warning on the bridge).

## Notes

- No i18n keys added: reused `T.PLUGINS.TASK_NOT_FOUND` / `TAGS_DO_NOT_EXIST`; the new guard messages are plain strings, matching existing bridge messages like the sub-task move guard.
- `quickSetting` is documented as the dialog's grouping label only (as in the internal model); callers set the explicit recurrence fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
