### PR TITLE
chore: remove obsolete create-task-placeholder remnants

### DIFF
--- a/src/app/features/schedule/create-task-placeholder/create-task-placeholder.component.scss
+++ b/src/app/features/schedule/create-task-placeholder/create-task-placeholder.component.scss
@@ -93,52 +93,6 @@
       //flex: 1 0 auto;
     }
 
-    .task-type-indicator {
-      display: flex;
-      align-items: center;
-      gap: var(--s-half);
-      font-size: 10px;
-      padding: var(--s-quarter) 6px;
-      border-radius: 12px;
-      font-weight: 500;
-
-      @include mq(xs, max) {
-        font-size: 9px;
-        padding: 1px var(--s-half);
-      }
-
-      &.create {
-        background-color: color-mix(in srgb, var(--c-accent) 15%, transparent);
-        color: var(--c-accent);
-      }
-
-      &.select {
-        background-color: color-mix(in srgb, var(--c-primary) 15%, transparent);
-        color: var(--c-primary);
-      }
-
-      mat-icon {
-        font-size: 12px;
-        width: 12px;
-        height: 12px;
-
-        @include mq(xs, max) {
-          font-size: 10px;
-          width: 10px;
-          height: 10px;
-        }
-      }
-
-      span {
-        @include truncateText();
-        max-width: 120px;
-
-        @include mq(xs, max) {
-          max-width: 80px;
-        }
-      }
-    }
-
     .mode-hint {
       font-size: 12px;
       color: var(--text-color-muted);

--- a/src/app/features/schedule/create-task-placeholder/create-task-placeholder.component.ts
+++ b/src/app/features/schedule/create-task-placeholder/create-task-placeholder.component.ts
@@ -127,19 +127,6 @@ export class CreateTaskPlaceholderComponent implements OnDestroy {
     this._clearTimeouts();
     this.editEnd.emit();
   }
-  onTaskChange(taskOrTaskTitle: Task | string): void {
-    this.isCreate.set(typeof taskOrTaskTitle === 'string');
-
-    if (this.isCreate()) {
-      // New task creation
-      this.newTaskTitle.set(taskOrTaskTitle as string);
-      this.selectedTask.set(null);
-    } else {
-      // Existing task selection
-      this.selectedTask.set(taskOrTaskTitle as Task);
-      this.newTaskTitle.set('');
-    }
-  }
 
   async onTaskSelected(task: Task): Promise<void> {
     this._setState('Selecting');


### PR DESCRIPTION
## Problem

Closes #9114. `CreateTaskPlaceholderComponent` still carries a change handler from the replaced combined create/select UI, and its SCSS still contains an unmatched nested task-type indicator block. The current template uses neither.

## Solution

Delete `onTaskChange` (the template binds `taskSelected`, `textChanged`, `blurred` and `keyPressed` instead) and the `.task-type-indicator` block with its `.create` and `.select` variants. Live handlers, state signals, outputs and the template are untouched.

## Verification

Repo-wide searches for `onTaskChange` bindings on this component and for `task-type-indicator` find zero consumers before and zero references after. Production build green. There is no component spec for this component, matching the issue's note.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, dead code removal with no user-facing change
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable) — n/a, pure deletion and no component harness exists
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
