### PR TITLE
refactor: prune unused chip-list-input capabilities

### DIFF
--- a/src/app/ui/chip-list-input/chip-list-input.component.html
+++ b/src/app/ui/chip-list-input/chip-list-input.component.html
@@ -13,36 +13,17 @@
           matChipRemove
           >cancel
         </mat-icon>
-
-        @if (additionalActionIcon) {
-          <button
-            (click)="additionalAction.emit(modelItem.id)"
-            [class.isToggled]="isToggled(modelItem.id)"
-            [matTooltip]="
-              isToggled(modelItem.id)
-                ? additionalActionTooltipUnToggle()
-                : additionalActionTooltip()
-            "
-            class="additional"
-            mat-icon-button
-          >
-            <mat-icon style="transform: rotate(45deg)">{{
-              additionalActionIcon
-            }}</mat-icon>
-          </button>
-        }
       </mat-chip-row>
     }
     <input
       #inputElRef
       (matChipInputTokenEnd)="add($event)"
-      [autofocus]="isAutoFocus"
       [formControl]="inputCtrl"
       [matAutocomplete]="autoElRef"
       [matChipInputAddOnBlur]="true"
       [matChipInputFor]="chipListElRef"
       [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-      (keydown)="triggerCtrlEnterSubmit($event)"
+      (keydown)="onInputKeydown($event)"
     />
   </mat-chip-grid>
   <mat-autocomplete

--- a/src/app/ui/chip-list-input/chip-list-input.component.scss
+++ b/src/app/ui/chip-list-input/chip-list-input.component.scss
@@ -5,22 +5,3 @@
     display: block;
   }
 }
-
-.additional {
-  transition: var(--transition-fast);
-  opacity: 0;
-  transform: scale(0.1);
-  width: 0;
-  position: relative;
-  z-index: 1;
-  transform-origin: center center;
-  margin-top: -2px;
-  height: 40px;
-
-  color: var(--text-color);
-
-  mat-icon {
-    font-size: 22px;
-    max-height: 32px;
-  }
-}

--- a/src/app/ui/chip-list-input/chip-list-input.component.spec.ts
+++ b/src/app/ui/chip-list-input/chip-list-input.component.spec.ts
@@ -1,0 +1,105 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+import { COMMA, ENTER } from '@angular/cdk/keycodes';
+import { MatChipInputEvent } from '@angular/material/chips';
+import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
+import { ChipListInputComponent } from './chip-list-input.component';
+
+describe('ChipListInputComponent', () => {
+  let fixture: ComponentFixture<ChipListInputComponent>;
+  let component: ChipListInputComponent;
+
+  const getInput = (): HTMLInputElement =>
+    fixture.nativeElement.querySelector('input') as HTMLInputElement;
+
+  const keydownOnInput = (init: KeyboardEventInit): void => {
+    getInput().dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, ...init }));
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChipListInputComponent, NoopAnimationsModule, TranslateModule.forRoot()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChipListInputComponent);
+    component = fixture.componentInstance;
+    component.suggestions = [
+      { id: 'A', title: 'Apple' },
+      { id: 'B', title: 'Banana' },
+      { id: 'C', title: 'Cherry' },
+    ];
+    component.model = ['A'];
+    fixture.detectChanges();
+  });
+
+  it('renders a chip for each model id with a matching suggestion', () => {
+    expect(component.modelItems.map((s) => s.id)).toEqual(['A']);
+    expect(fixture.nativeElement.querySelectorAll('mat-chip-row').length).toBe(1);
+  });
+
+  it('filters suggestions by title prefix and excludes already added ids', () => {
+    let latest: { id: string }[] = [];
+    const sub = component.filteredSuggestions.subscribe((v) => (latest = v));
+    component.inputCtrl.setValue('ban');
+    expect(latest.map((s) => s.id)).toEqual(['B']);
+    // 'Apple' matches the prefix but its id is already in the model
+    component.inputCtrl.setValue('a');
+    expect(latest.map((s) => s.id)).toEqual([]);
+    sub.unsubscribe();
+  });
+
+  it('emits addItem for a known title and addNewItem for an unknown one', () => {
+    const addSpy = jasmine.createSpy('addItem');
+    const addNewSpy = jasmine.createSpy('addNewItem');
+    component.addItem.subscribe(addSpy);
+    component.addNewItem.subscribe(addNewSpy);
+    component.add({ input: getInput(), value: 'Banana' } as MatChipInputEvent);
+    component.add({ input: getInput(), value: 'Dragonfruit' } as MatChipInputEvent);
+    expect(addSpy).toHaveBeenCalledOnceWith('B');
+    expect(addNewSpy).toHaveBeenCalledOnceWith('Dragonfruit');
+  });
+
+  it('does not emit addItem for an id already in the model', () => {
+    const addSpy = jasmine.createSpy('addItem');
+    component.addItem.subscribe(addSpy);
+    component.selected({
+      option: { value: 'A' },
+    } as unknown as MatAutocompleteSelectedEvent);
+    expect(addSpy).not.toHaveBeenCalled();
+    component.selected({
+      option: { value: 'C' },
+    } as unknown as MatAutocompleteSelectedEvent);
+    expect(addSpy).toHaveBeenCalledOnceWith('C');
+  });
+
+  it('emits removeItem with the removed id', () => {
+    const removeSpy = jasmine.createSpy('removeItem');
+    component.removeItem.subscribe(removeSpy);
+    component.remove('A');
+    expect(removeSpy).toHaveBeenCalledOnceWith('A');
+  });
+
+  it('does not steal focus on init and focuses the input normally on demand', () => {
+    expect(document.activeElement).not.toBe(getInput());
+    getInput().focus();
+    expect(document.activeElement).toBe(getInput());
+  });
+
+  it('switches to Enter-only separators on Cyrillic keys and restores on others', () => {
+    keydownOnInput({ key: 'й' });
+    expect(component.separatorKeysCodes).toEqual([ENTER]);
+    keydownOnInput({ key: 'a' });
+    expect(component.separatorKeysCodes).toEqual([ENTER, COMMA]);
+    keydownOnInput({ key: 'ё' });
+    expect(component.separatorKeysCodes).toEqual([ENTER]);
+    keydownOnInput({ key: 'Ё' });
+    expect(component.separatorKeysCodes).toEqual([ENTER]);
+  });
+
+  it('has no ctrl+enter submit output and Ctrl+Enter keeps default separators', () => {
+    expect('ctrlEnterSubmit' in component).toBeFalse();
+    keydownOnInput({ code: 'Enter', ctrlKey: true });
+    expect(component.separatorKeysCodes).toEqual([ENTER, COMMA]);
+  });
+});

--- a/src/app/ui/chip-list-input/chip-list-input.component.ts
+++ b/src/app/ui/chip-list-input/chip-list-input.component.ts
@@ -4,11 +4,8 @@ import {
   ElementRef,
   Input,
   input,
-  OnDestroy,
   output,
   viewChild,
-  HostAttributeToken,
-  inject,
 } from '@angular/core';
 import { FormsModule, ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
 import { Observable } from 'rxjs';
@@ -30,7 +27,6 @@ import { T } from '../../t.const';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
-import { MatIconButton } from '@angular/material/button';
 import { MatOption } from '@angular/material/core';
 import { TranslatePipe } from '@ngx-translate/core';
 import { AsyncPipe } from '@angular/common';
@@ -59,7 +55,6 @@ interface Suggestion {
     MatIcon,
     MatChipRemove,
     MatTooltip,
-    MatIconButton,
     FormsModule,
     MatAutocompleteTrigger,
     MatChipInput,
@@ -71,34 +66,19 @@ interface Suggestion {
     TagComponent,
   ],
 })
-export class ChipListInputComponent implements OnDestroy {
-  autoFocus = inject(new HostAttributeToken('autoFocus'), { optional: true });
-
-  // TODO maybe use new api
-  // autoFocus = inject(new HostAttributeToken('autoFocus'));
-
+export class ChipListInputComponent {
   T: typeof T = T;
 
   readonly label = input<string>();
-  // TODO: Skipped for migration because:
-  //  This input is used in a control flow expression (e.g. `@if` or `*ngIf`)
-  //  and migrating would break narrowing currently.
-  @Input() additionalActionIcon?: string;
-  readonly additionalActionTooltip = input<string>();
-  readonly additionalActionTooltipUnToggle = input<string>();
-  readonly toggledItems = input<string[]>();
 
   readonly addItem = output<string>();
   readonly addNewItem = output<string>();
   readonly removeItem = output<string>();
-  readonly additionalAction = output<string>();
-  readonly ctrlEnterSubmit = output<void>();
 
   suggestionsIn: Suggestion[] = [];
   modelItems: Suggestion[] = [];
   inputCtrl: UntypedFormControl = new UntypedFormControl();
   separatorKeysCodes: number[] = DEFAULT_SEPARATOR_KEY_CODES;
-  isAutoFocus = false;
   readonly inputEl = viewChild<ElementRef<HTMLInputElement>>('inputElRef');
   readonly matAutocomplete = viewChild<MatAutocomplete>('autoElRef');
   private _modelIds: string[] = [];
@@ -113,26 +93,6 @@ export class ChipListInputComponent implements OnDestroy {
           ),
     ),
   );
-
-  private _autoFocusTimeout?: number;
-
-  constructor() {
-    const autoFocus = this.autoFocus;
-
-    if (typeof autoFocus === 'string') {
-      this.isAutoFocus = true;
-      this._autoFocusTimeout = window.setTimeout(() => {
-        this.inputEl()?.nativeElement.focus();
-        // NOTE: we need to wait a little for the tag dialog to be there
-      }, 300);
-    }
-  }
-
-  ngOnDestroy(): void {
-    if (this._autoFocusTimeout) {
-      window.clearTimeout(this._autoFocusTimeout);
-    }
-  }
 
   // TODO: Skipped for migration because:
   //  Accessor inputs cannot be migrated as they are too complex.
@@ -182,21 +142,12 @@ export class ChipListInputComponent implements OnDestroy {
     this.inputCtrl.setValue(null);
   }
 
-  isToggled(id: string): boolean {
-    const toggledItems = this.toggledItems();
-    return !!toggledItems && toggledItems.includes(id);
-  }
-
-  triggerCtrlEnterSubmit(ev: KeyboardEvent): void {
+  onInputKeydown(ev: KeyboardEvent): void {
     const isCyrillic = /^[А-яёЁ]$/.test(ev.key);
     if (isCyrillic) {
       this.separatorKeysCodes = [ENTER];
     } else {
       this.separatorKeysCodes = DEFAULT_SEPARATOR_KEY_CODES;
-    }
-
-    if (ev.code === 'Enter' && ev.ctrlKey) {
-      this.ctrlEnterSubmit.emit();
     }
   }
 


### PR DESCRIPTION
## Problem

Closes #9116. `ChipListInputComponent` exposes optional additional-action, Ctrl+Enter and host-autofocus capabilities that neither of its two consumers (`dialog-edit-task-repeat-cfg`, `dialog-edit-issue-provider`) binds. Both bind only `label`, `model`, `suggestions` and the `addItem`/`addNewItem`/`removeItem` outputs, so the extra branches add API, lifecycle, template and styling complexity to a shared control for nothing.

## Solution

Remove only the unbound capabilities:

- the additional-action inputs/output, toggle helper, template button block, its exclusive `MatIconButton` import and matching SCSS
- the `ctrlEnterSubmit` output and its emission branch
- the `autoFocus` host-attribute path with its delayed focus timer and `OnDestroy` cleanup

The keydown handler stays for the Cyrillic separator switching and is renamed from `triggerCtrlEnterSubmit` to `onInputKeydown` since the Ctrl+Enter part is gone. No new abstraction is introduced.

Per the safety gate in the issue, a focused spec is added first (8 tests: filtering, duplicate prevention, add/remove, focus, Cyrillic separators, and the no-Ctrl+Enter contract) and passes before and after the prune.

## Verification

Binding searches for every removed input/output across src/ and e2e/ find zero consumers. Component spec 8/8, dialog-edit-task-repeat-cfg 42/42 and dialog-edit-issue-provider 3/3, all green before and after. Production build green.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, removes unused component API only
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
