### PR TITLE
chore(take-a-break): remove the dead LOCK_SCREEN_THROTTLE / FULLSCREEN_BLOCKER_THROTTLE

### DIFF
--- a/src/app/features/take-a-break/take-a-break.service.ts
+++ b/src/app/features/take-a-break/take-a-break.service.ts
@@ -35,9 +35,7 @@ import { SnackService } from '../../core/snack/snack.service';
 const BREAK_TRIGGER_DURATION = 10 * 60 * 1000;
 const PING_UPDATE_BANNER_INTERVAL = 60 * 1000;
 const DESKTOP_NOTIFICATION_THROTTLE = 60 * 1000;
-const LOCK_SCREEN_THROTTLE = 5 * 60 * 1000;
 const LOCK_SCREEN_DELAY = 30 * 1000;
-const FULLSCREEN_BLOCKER_THROTTLE = 5 * 60 * 1000;
 const FULLSCREEN_BLOCKER_DELAY = 30 * 1000;
 
 // required because typescript freaks out
@@ -189,33 +187,24 @@ export class TakeABreakService {
   );
 
   private _triggerLockScreenCounter$: Subject<boolean> = new Subject();
-  private _triggerLockScreenThrottledAndDelayed$: Observable<unknown | never> =
-    IS_ELECTRON
-      ? this._triggerLockScreenCounter$.pipe(
-          distinctUntilChanged(),
-          switchMap((v) =>
-            !!v
-              ? of(v).pipe(throttleTime(LOCK_SCREEN_THROTTLE), delay(LOCK_SCREEN_DELAY))
-              : EMPTY,
-          ),
-        )
-      : EMPTY;
+  // NOTE: no throttle here or on the fullscreen blocker below — the real
+  // spacing between triggers is distinctUntilChanged() (the subject only
+  // re-fires after a reset sets it back to false) plus the break-reminder
+  // cadence feeding it.
+  private _triggerLockScreenDelayed$: Observable<unknown | never> = IS_ELECTRON
+    ? this._triggerLockScreenCounter$.pipe(
+        distinctUntilChanged(),
+        switchMap((v) => (!!v ? of(v).pipe(delay(LOCK_SCREEN_DELAY)) : EMPTY)),
+      )
+    : EMPTY;
 
   private _triggerFullscreenBlocker$: Subject<boolean> = new Subject();
-  private _triggerFullscreenBlockerThrottledAndDelayed$: Observable<unknown | never> =
-    IS_ELECTRON
-      ? this._triggerFullscreenBlocker$.pipe(
-          distinctUntilChanged(),
-          switchMap((v) =>
-            !!v
-              ? of(v).pipe(
-                  throttleTime(FULLSCREEN_BLOCKER_THROTTLE),
-                  delay(FULLSCREEN_BLOCKER_DELAY),
-                )
-              : EMPTY,
-          ),
-        )
-      : EMPTY;
+  private _triggerFullscreenBlockerDelayed$: Observable<unknown | never> = IS_ELECTRON
+    ? this._triggerFullscreenBlocker$.pipe(
+        distinctUntilChanged(),
+        switchMap((v) => (!!v ? of(v).pipe(delay(FULLSCREEN_BLOCKER_DELAY)) : EMPTY)),
+      )
+    : EMPTY;
 
   private _triggerBanner$: Observable<[number, GlobalConfigState, boolean, boolean]> =
     this.timeWorkingWithoutABreak$.pipe(
@@ -260,11 +249,11 @@ export class TakeABreakService {
     });
 
     if (IS_ELECTRON) {
-      this._triggerLockScreenThrottledAndDelayed$.subscribe(() => {
+      this._triggerLockScreenDelayed$.subscribe(() => {
         window.ea.lockScreen();
       });
 
-      this._triggerFullscreenBlockerThrottledAndDelayed$
+      this._triggerFullscreenBlockerDelayed$
         .pipe(
           withLatestFrom(this._configService.takeABreak$, this.timeWorkingWithoutABreak$),
         )


### PR DESCRIPTION
## Problem

Closes #9356. `throttleTime(LOCK_SCREEN_THROTTLE)` is applied inside the `switchMap` to a freshly created single-value `of(v)`, so a brand-new throttle instance is created per emission and always lets its first value through. The 5-minute constants have therefore never throttled anything, but anyone reading them would reasonably believe there is a 5-minute floor between invocations. Same shape for the fullscreen blocker.

## Solution

The delete option the issue leans toward: remove both constants and both `throttleTime` calls, and state in a NOTE comment that the real spacing is `distinctUntilChanged()` (the subject has to reset to false before another true counts) plus the break-reminder cadence. The two streams are also renamed from `...ThrottledAndDelayed$` to `...Delayed$` so the names stop claiming a throttle that does not exist. The 30s delays and `distinctUntilChanged()` are unchanged.

## Verification

Repo-wide search finds zero remaining references to either constant. `take-a-break.service.spec.ts` 18/18 green. Production build green.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, no behavior change
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable) — n/a, the removed code never had observable behavior; existing service spec covers the streams
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
