### PR TITLE
chore(supersync-server): drop the unused operations (userId, clientId) index

### DIFF
--- a/packages/super-sync-server/prisma/migrations/20260828000000_drop_unused_operations_user_id_client_id_index/migration.sql
+++ b/packages/super-sync-server/prisma/migrations/20260828000000_drop_unused_operations_user_id_client_id_index/migration.sql
@@ -1,0 +1,12 @@
+-- Remove write amplification on the hottest table for an index no query can
+-- use. Downloads only exclude by client_id (clientId not-equals), which cannot
+-- seek this btree. Duplicate checks hit the (user_id, server_seq) unique key.
+-- Conflict detection uses (user_id, entity_type, entity_id, server_seq).
+-- Device lookups by client_id go to sync_devices, not operations.
+-- (user_id, received_at) is deliberately KEPT: the old-ops fresh-prefix probe
+-- orders by received_at to hold its measured 9-buffer plan (PR #9733, guarded
+-- by tests/integration/old-ops-probe-plan.integration.spec.ts).
+-- Reinstating is cheap if a future query filters operations by client_id.
+-- Single statement so prisma migrate deploy applies it natively without the
+-- out-of-band CONCURRENTLY recovery.
+DROP INDEX CONCURRENTLY IF EXISTS "operations_user_id_client_id_idx";

--- a/packages/super-sync-server/prisma/schema.prisma
+++ b/packages/super-sync-server/prisma/schema.prisma
@@ -109,7 +109,6 @@ model Operation {
 
   @@unique([userId, serverSeq])
   @@index([userId, entityType, entityId, serverSeq])
-  @@index([userId, clientId])
   @@index([userId, receivedAt])
   // Multi-entity conflict lookups (#8334) probe entity_ids with @> / &&. This MUST stay
   // modelled here, not only in the 20260613000001 raw migration: `prisma db push` builds

--- a/packages/super-sync-server/tests/migration-sql.spec.ts
+++ b/packages/super-sync-server/tests/migration-sql.spec.ts
@@ -78,6 +78,30 @@ describe('performance migrations', () => {
     expect(migrationSql).not.toMatch(/\bBEGIN\b|\bCOMMIT\b/i);
   });
 
+  it('drops the unused (user_id, client_id) index as a single native-apply statement', () => {
+    const migrationSql = readMigration(
+      '20260828000000_drop_unused_operations_user_id_client_id_index',
+    );
+
+    expect(migrationSql).toContain(
+      'DROP INDEX CONCURRENTLY IF EXISTS "operations_user_id_client_id_idx"',
+    );
+    // The received_at index is load-bearing for the old-ops fresh-prefix probe
+    // plan and must never be dropped here.
+    expect(migrationSql).not.toContain('"operations_user_id_received_at_idx"');
+    // Single statement so `prisma migrate deploy` applies it natively without
+    // the out-of-band CONCURRENTLY recovery.
+    const sqlWithoutComments = migrationSql
+      .split('\n')
+      .filter((line) => !line.trimStart().startsWith('--'))
+      .join('\n');
+    expect(sqlWithoutComments.match(/;/g)).toHaveLength(1);
+    expect(migrationSql).not.toMatch(/\bCREATE\b/i);
+    expect(migrationSql).not.toMatch(/\bDROP\s+TABLE\b/i);
+    expect(migrationSql).not.toMatch(/\bALTER\s+TABLE\b/i);
+    expect(migrationSql).not.toMatch(/\bBEGIN\b|\bCOMMIT\b/i);
+  });
+
   it('adds partial encrypted-op sequence index concurrently', () => {
     const migrationSql = readFileSync(
       join(


### PR DESCRIPTION
## Problem

Closes #8352. The issue's audit found two `operations` indexes no query can use, both pure write amplification on the hottest table. Re-verifying at HEAD, only half of that still holds:

- `@@index([userId, clientId])`: still unused. Downloads only exclude by `clientId: { not: ... }`, which cannot seek this btree; duplicate checks hit the `(userId, serverSeq)` unique; conflict detection uses `(userId, entityType, entityId, serverSeq)`; `clientId` equality lookups go to `sync_devices`, not `operations`.
- `@@index([userId, receivedAt])`: no longer droppable. Since #9733 the old-ops fresh-prefix probe orders by `receivedAt` specifically so the planner holds the measured 9-buffer plan instead of the 60,329-buffer `(user_id, server_seq)` plan that hit the 60s statement timeout in production, and `tests/integration/old-ops-probe-plan.integration.spec.ts` names the index. Dropping it would deterministically force the catastrophic plan. The issue predates that fix.

## Solution

Drop only `operations_user_id_client_id_idx`: a new migration mirroring the 20260512 prune pattern plus the matching `@@index` removal in `schema.prisma`. The migration is a single `DROP INDEX CONCURRENTLY IF EXISTS` statement, the preferred shape per `prisma/migrations/README.md` (applies natively, no out-of-band recovery), and its comment documents why `(user_id, received_at)` must stay.

A shape test is added to `tests/migration-sql.spec.ts` in the style of the neighboring entries; it also pins that this migration never touches the `received_at` index.

## Verification

`prisma validate` clean. `tests/migration-sql.spec.ts` + `tests/migrate-deploy-script.spec.ts`: 79/79 green. Repo-wide grep for `operations_user_id_client_id_idx` finds only `0_init/migration.sql` (no code or test references).

Pre-merge check for the maintainer, per the issue: confirm `idx_scan = 0` for `operations_user_id_client_id_idx` in `pg_stat_user_indexes` on the hosted instance.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, server schema internals; the migration comment carries the rationale
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
