### PR TITLE
chore(take-a-break): remove the dead idle-dialog break-counter branch

### DIFF
--- a/src/app/features/take-a-break/take-a-break.service.spec.ts
+++ b/src/app/features/take-a-break/take-a-break.service.spec.ts
@@ -98,6 +98,12 @@ describe('TakeABreakService', () => {
       title: 'Some task',
       simpleCounterToggleBtns: [],
     };
+    const TASK_ITEM: IdleTrackItem = {
+      type: 'TASK',
+      time: 'IDLE_TIME',
+      title: 'Some task',
+      simpleCounterToggleBtns: [],
+    };
 
     const dialogResult = (
       trackItems: IdleTrackItem[],
@@ -139,9 +145,16 @@ describe('TakeABreakService', () => {
       expect(current()).toBe(10000);
     });
 
-    it('adds tracked task time but not break time when not resetting', () => {
+    // idle time tracked to tasks does not count toward the break reminder,
+    // regardless of the shape the dialog mode sends (#9352)
+    it("does not add idle time tracked to tasks ('IDLE_TIME' shape)", () => {
+      actions$.next(dialogResult([BREAK_ITEM, TASK_ITEM], false));
+      expect(current()).toBe(10000);
+    });
+
+    it('does not add idle time tracked to tasks (SPLIT numeric shape)', () => {
       actions$.next(dialogResult([BREAK_ITEM, SPLIT_TASK_ITEM], false));
-      expect(current()).toBe(10000 + 60000);
+      expect(current()).toBe(10000);
     });
 
     it('dismisses the reminder banner when the timer is reset', () => {
@@ -341,17 +354,16 @@ describe('TakeABreakService', () => {
     // The other half of the same overlap, and the reason the reset is edge- and
     // not level-triggered: once it has fired, time added later in the SAME
     // untracked stretch survives. With a level trigger the next tick wiped it
-    // again -- and every tick after -- so unchecking the dialog's reset box was
-    // inert for any absence over BREAK_TRIGGER_DURATION. SPLIT is the only mode
-    // that sends a resolved number, and handleIdleDialogResult$ re-selects a task
-    // only for a single task item, so with 2+ items the stretch keeps running.
-    it('keeps task time from an opt-out added after the untracked-stretch reset', () => {
+    // again -- and every tick after. Idle-dialog results no longer feed the
+    // counter at all (#9352), so the late addition comes from otherNoBreakTIme$.
+    it('keeps time added after the untracked-stretch reset', () => {
       const emitted: number[] = [];
       const sub = service.timeWorkingWithoutABreak$.subscribe((v) => emitted.push(v));
 
       tick$.next({ duration: 11 * 60000, date: '2026-07-28', timestamp: 0 });
       expect(emitted[emitted.length - 1]).toBe(0);
 
+      // a SPLIT-mode opt-out contributes nothing to the counter (#9352)
       actions$.next(
         idleDialogResult({
           trackItems: [
@@ -363,13 +375,16 @@ describe('TakeABreakService', () => {
           idleTime: 11 * 60000,
         }),
       );
-      expect(emitted[emitted.length - 1]).toBe(11 * 60000);
+      expect(emitted[emitted.length - 1]).toBe(0);
+
+      service.otherNoBreakTIme$.next(60000);
+      expect(emitted[emitted.length - 1]).toBe(60000);
 
       // still untracked: a level trigger would re-zero this on the next tick
       tick$.next({ duration: 60000, date: '2026-07-28', timestamp: 0 });
       tick$.next({ duration: 60000, date: '2026-07-28', timestamp: 0 });
 
-      expect(emitted[emitted.length - 1]).toBe(11 * 60000);
+      expect(emitted[emitted.length - 1]).toBe(60000);
       sub.unsubscribe();
     });
   });

--- a/src/app/features/take-a-break/take-a-break.service.ts
+++ b/src/app/features/take-a-break/take-a-break.service.ts
@@ -98,23 +98,8 @@ export class TakeABreakService {
       map((tick) => tick.duration),
       filter(() => !!this._taskService.currentTaskId()),
     ),
-    this._actions$.pipe(ofType(idleDialogResult)).pipe(
-      switchMap(({ trackItems, isResetBreakTimer }) => {
-        // a requested reset is a reset event, not a measurement — it goes
-        // through _triggerReset$ so it also tears the reminder down
-        if (isResetBreakTimer) {
-          return EMPTY;
-        }
-        // without a reset, time tracked to tasks still counts as work; break
-        // items don't (but they don't reset the timer either).
-        // NOTE: only SPLIT mode sends numbers here — BREAK/TASK send the
-        // 'IDLE_TIME' placeholder, so this contributes 0 for them. See #9352.
-        const noBreakTime = trackItems
-          .filter((t) => t.type === 'TASK')
-          .reduce((acc, t) => acc + (typeof t.time === 'number' ? t.time : 0), 0);
-        return noBreakTime > 0 ? of(noBreakTime) : EMPTY;
-      }),
-    ),
+    // NOTE: idle-dialog results deliberately don't feed the counter (see #9352);
+    // the dialog's reset checkbox goes through _triggerIdleDialogReset$ instead
     this.otherNoBreakTIme$,
   ).pipe(
     // Additions only. The seedless scan below treats any value <= 0 as a reset,


### PR DESCRIPTION
## Problem

Closes #9352. The `idleDialogResult` arm of the break counter's `_tick$` merge has been dead for the common paths since Jan 2025: BREAK and TASK modes send the `'IDLE_TIME'` placeholder rather than numbers, so the reduce yields 0 and the arm returns `EMPTY`. Only the rare SPLIT shape ever contributed, the code comment described behavior that no longer happened, and the guarding test used a SPLIT-shaped fixture the dialog never produces in TASK mode, so it passed vacuously.

## Solution

Option B from the issue: delete the arm entirely, so idle-dialog results never feed the break counter. Rationale: this has been the effective behavior for BREAK/TASK for 18 months with no complaints, and option A (counting idle time as work) inherits the double-count the issue documents, since live ticks before the idle trigger already accumulated the same window. The dialog's reset checkbox is unaffected: it flows through `_triggerIdleDialogReset$` into `_triggerReset$`, verified by the existing reset specs which pass unchanged.

A NOTE at the merge site records the decision and points at the reset path.

The spec's vacuous fixture is replaced with the real payload shapes: a `time: 'IDLE_TIME'` item (BREAK/TASK mode) and the SPLIT numeric shape, both now asserted not to advance the counter, with the edge-trigger coverage of the old opt-out test preserved via `otherNoBreakTIme$`.

Behavior change to be aware of: SPLIT-mode idle time tracked to tasks previously did count toward the reminder; after this it does not. That is what option B means, and flipping to option A later is a small diff on top of the new non-vacuous fixtures.

## Verification

The reworked SPLIT assertions fail against the old service (Expected 70000 to be 10000, etc.) and the full suite is 19/19 green with the deletion. `npm run checkFile` clean on both files.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, no user-facing setting or API change
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
