### PR TITLE
fix(task-detail-panel): make isOverdue flip on day rollover

### DIFF
--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.spec.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.spec.ts
@@ -7,6 +7,7 @@ import { TaskAttachmentService } from '../task-attachment/task-attachment.servic
 import { TaskService } from '../task.service';
 import { LayoutService } from '../../../core-ui/layout/layout.service';
 import { GlobalConfigService } from '../../config/global-config.service';
+import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
 import { IssueService } from '../../issue/issue.service';
 import { TaskRepeatCfgService } from '../../task-repeat-cfg/task-repeat-cfg.service';
 import { MatDialog } from '@angular/material/dialog';
@@ -36,9 +37,11 @@ describe('TaskDetailPanelComponent', () => {
   let mockAttachmentService: jasmine.SpyObj<TaskAttachmentService>;
   let mockTaskService: jasmine.SpyObj<TaskService>;
   let isXs: WritableSignal<boolean>;
+  let todayDateStr: WritableSignal<string>;
 
   beforeEach(async () => {
     isXs = signal(true);
+    todayDateStr = signal('2027-01-01');
     mockClipboardImageService = jasmine.createSpyObj('ClipboardImageService', [
       'handlePasteWithProgress',
     ]);
@@ -111,6 +114,7 @@ describe('TaskDetailPanelComponent', () => {
         { provide: DateTimeFormatService, useValue: mockDateTimeFormatService },
         { provide: Store, useValue: mockStore },
         { provide: MentionConfigService, useValue: { mentionConfig$: EMPTY } },
+        { provide: GlobalTrackingIntervalService, useValue: { todayDateStr } },
       ],
     })
       .overrideComponent(TaskContextMenuComponent, {
@@ -323,6 +327,24 @@ describe('TaskDetailPanelComponent', () => {
       expect(component.showScheduleIcon()).toBe('today');
     });
   });
+
+  describe('isOverdue day rollover (#9393)', () => {
+    it('flips to overdue when the day changes while the panel stays open', () => {
+      componentRef.setInput('task', {
+        ...MOCK_TASK,
+        isDone: false,
+        dueDay: '2027-01-01',
+        dueWithTime: undefined,
+      });
+      fixture.detectChanges();
+      expect(component.isOverdue()).toBe(false);
+
+      // midnight passes while the panel stays open on the same task reference
+      todayDateStr.set('2027-01-02');
+
+      expect(component.isOverdue()).toBe(true);
+    });
+  });
 });
 
 const fakeTask = (id: string): TaskWithSubTasks =>
@@ -373,6 +395,10 @@ describe('TaskDetailPanelComponent stale-focus guard', () => {
         { provide: Store, useValue: { select: () => EMPTY, dispatch: () => undefined } },
         { provide: TranslateService, useValue: { instant: (k: string) => k } },
         { provide: MentionConfigService, useValue: { mentionConfig$: EMPTY } },
+        {
+          provide: GlobalTrackingIntervalService,
+          useValue: { todayDateStr: () => '2027-01-01' },
+        },
       ],
     })
       // Drop the real template/child components — only the focus timing logic is under test.
@@ -489,6 +515,10 @@ describe('TaskDetailPanelComponent notes target does not auto-edit', () => {
         { provide: Store, useValue: { select: () => EMPTY, dispatch: () => undefined } },
         { provide: TranslateService, useValue: { instant: (k: string) => k } },
         { provide: MentionConfigService, useValue: { mentionConfig$: EMPTY } },
+        {
+          provide: GlobalTrackingIntervalService,
+          useValue: { todayDateStr: () => '2027-01-01' },
+        },
       ],
     })
       .overrideComponent(TaskDetailPanelComponent, {
@@ -589,6 +619,10 @@ describe('TaskDetailPanelComponent add sub-task', () => {
         { provide: Store, useValue: { select: () => EMPTY, dispatch: () => undefined } },
         { provide: TranslateService, useValue: { instant: (k: string) => k } },
         { provide: MentionConfigService, useValue: { mentionConfig$: EMPTY } },
+        {
+          provide: GlobalTrackingIntervalService,
+          useValue: { todayDateStr: () => '2027-01-01' },
+        },
       ],
     })
       .overrideComponent(TaskDetailPanelComponent, {

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
@@ -47,6 +47,7 @@ import { HISTORY_STATE, IS_ELECTRON } from '../../../app.constants';
 import { LayoutService } from '../../../core-ui/layout/layout.service';
 import { devError } from '../../../util/dev-error';
 import { GlobalConfigService } from '../../config/global-config.service';
+import { GlobalTrackingIntervalService } from '../../../core/global-tracking-interval/global-tracking-interval.service';
 import { DEFAULT_GLOBAL_CONFIG } from '../../config/default-global-config.const';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { getTaskRepeatInfoText } from './get-task-repeat-info-text.util';
@@ -140,6 +141,7 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
 
   private _clipboardImageService = inject(ClipboardImageService);
   private _globalConfigService = inject(GlobalConfigService);
+  private _globalTrackingIntervalService = inject(GlobalTrackingIntervalService);
   private _issueService = inject(IssueService);
   private _jiraElectronBridge = inject(JiraElectronBridgeService);
   private _taskRepeatCfgService = inject(TaskRepeatCfgService);
@@ -366,13 +368,18 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
 
   isOverdue = computed(() => {
     const t = this.task();
+    // Day-change dependency, so the overdue state flips at the day boundary
+    // while the panel stays open instead of freezing at first render (#9393).
+    // dueWithTime deliberately stays on Date.now(): no per-minute tick for a
+    // colour class; the day-change recompute refreshes it at least daily.
+    const todayStr = this._globalTrackingIntervalService.todayDateStr();
     return !!(
       !t.isDone &&
       ((t.dueWithTime && t.dueWithTime < Date.now()) ||
         (t.dueDay &&
           isDBDateStr(t.dueDay) &&
-          t.dueDay !== getDbDateStr() &&
-          t.dueDay < getDbDateStr()))
+          t.dueDay !== todayStr &&
+          t.dueDay < todayStr))
     );
   });
 


### PR DESCRIPTION
## Problem

Closes #9393. The `isOverdue` computed in the task detail panel reads `Date.now()` and the argless `getDbDateStr()`, neither of which is reactive, so its only dependency is `task()`. With the panel open on a task that is not being tracked or edited, the overdue colour on the schedule row never flips when the due time passes or the day rolls over.

## Solution

Same shape as the sibling fix in #9380: inject `GlobalTrackingIntervalService` and read its `todayDateStr()` signal inside the computed, replacing both argless `getDbDateStr()` calls. That gives the `dueDay` comparison a reactive day-boundary dependency, and as a side effect uses the logical day (start-of-next-day offset) instead of the raw calendar day, matching the sibling fix and sync rule 4.

The `dueWithTime < Date.now()` half deliberately stays as is: flipping a colour class mid-day would need a per-minute recompute, which does not seem to earn its place; the day-change recompute now refreshes it at least daily. Happy to add a coarse tick if you want that case covered too.

Noticed but left out of scope: `isPlannedForTodayDay` and `isDeadlineOverdue` in the same file still read the non-reactive argless `getDbDateStr()` and have the same latent staleness. Can follow up if wanted.

## Verification

New spec case drives the mocked `todayDateStr` signal across a day boundary without a new task reference and asserts `isOverdue()` flips. It fails without the component change (`Expected false to be true`, 1 FAILED of 29) and the full spec is 29/29 green with it. `npm run checkFile` clean on both files. Production build green.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, no user-facing setting or API change
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
