### PR TITLE
chore(supersync-server): expire pending passkey registrations and abandoned unverified users

### DIFF
--- a/packages/super-sync-server/src/sync/cleanup.ts
+++ b/packages/super-sync-server/src/sync/cleanup.ts
@@ -12,6 +12,9 @@ const reconcileTimers: Set<NodeJS.Timeout> = new Set();
 const RECONCILE_INTERVAL_MS = 5_000;
 const RECONCILE_BUDGET_MS = 60 * 60 * 1000;
 const INITIAL_CLEANUP_DELAY_MS = 10_000;
+// Grace window before an abandoned (never-verified, nothing in flight) account is
+// deleted — reuses the unified retention period rather than adding a second knob.
+const UNVERIFIED_USER_GRACE_MS = DEFAULT_SYNC_CONFIG.retentionMs;
 
 /**
  * Runs all cleanup tasks in a single daily job.
@@ -71,6 +74,32 @@ const runDailyCleanup = async (): Promise<void> => {
     }
   } catch (error) {
     Logger.error(`Cleanup [request-dedup] failed: ${error}`);
+  }
+
+  // 5. Delete expired pending passkey registrations (expiry is otherwise only
+  // checked at read time, so abandoned rows would be retained forever)
+  try {
+    const deleted = await syncService.deleteExpiredPendingPasskeyRegistrations(
+      Date.now(),
+    );
+    if (deleted > 0) {
+      Logger.info(`Cleanup [pending-passkeys]: removed ${deleted} entries`);
+    }
+  } catch (error) {
+    Logger.error(`Cleanup [pending-passkeys] failed: ${error}`);
+  }
+
+  // 6. Delete abandoned unverified users (never verified, no registration still
+  // in flight, older than the grace window; verified users can never match)
+  try {
+    const deleted = await syncService.deleteAbandonedUnverifiedUsers(
+      Date.now() - UNVERIFIED_USER_GRACE_MS,
+    );
+    if (deleted > 0) {
+      Logger.info(`Cleanup [unverified-users]: removed ${deleted} entries`);
+    }
+  } catch (error) {
+    Logger.error(`Cleanup [unverified-users] failed: ${error}`);
   }
 };
 

--- a/packages/super-sync-server/src/sync/sync.service.ts
+++ b/packages/super-sync-server/src/sync/sync.service.ts
@@ -906,6 +906,42 @@ export class SyncService {
   }
 
   /**
+   * Delete pending passkey registrations whose verification token expired
+   * before `beforeTime`. Expiry is otherwise only enforced at read time
+   * (verifyEmail), so rows for abandoned registration attempts — including
+   * their credential public keys — would linger forever.
+   */
+  async deleteExpiredPendingPasskeyRegistrations(beforeTime: number): Promise<number> {
+    const result = await prisma.pendingPasskeyRegistration.deleteMany({
+      where: { verificationTokenExpiresAt: { lt: BigInt(beforeTime) } },
+    });
+    return result.count;
+  }
+
+  /**
+   * Delete unverified users created before `createdBefore` with no registration
+   * still in flight: no pending passkey registration row and no unexpired
+   * verification token (re-registering refreshes the token on the same row).
+   * Verified users can never match, and unverified users are denied auth, so
+   * nothing of value is lost when their related rows (operations, devices,
+   * sync state, passkeys, pending registrations) cascade on delete.
+   */
+  async deleteAbandonedUnverifiedUsers(createdBefore: number): Promise<number> {
+    const result = await prisma.user.deleteMany({
+      where: {
+        isVerified: 0,
+        createdAt: { lt: new Date(createdBefore) },
+        pendingPasskeyRegistrations: { none: {} },
+        OR: [
+          { verificationTokenExpiresAt: null },
+          { verificationTokenExpiresAt: { lt: BigInt(Date.now()) } },
+        ],
+      },
+    });
+    return result.count;
+  }
+
+  /**
    * Delete ALL sync data for a user. Used for encryption password changes.
    * Deletes operations, devices, and resets sync state.
    */

--- a/packages/super-sync-server/tests/cleanup.spec.ts
+++ b/packages/super-sync-server/tests/cleanup.spec.ts
@@ -6,6 +6,8 @@
  * - Stale device cleanup (using retentionMs cutoff)
  * - Rate limit counter cleanup
  * - Request deduplication cleanup
+ * - Expired pending passkey registration cleanup
+ * - Abandoned unverified user cleanup (using retentionMs as grace window)
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { startCleanupJobs, stopCleanupJobs } from '../src/sync/cleanup';
@@ -21,6 +23,8 @@ const mockSyncService = {
   deleteStaleDevices: vi.fn().mockResolvedValue(0),
   cleanupExpiredRateLimitCounters: vi.fn().mockReturnValue(0),
   cleanupExpiredRequestDedupEntries: vi.fn().mockReturnValue(0),
+  deleteExpiredPendingPasskeyRegistrations: vi.fn().mockResolvedValue(0),
+  deleteAbandonedUnverifiedUsers: vi.fn().mockResolvedValue(0),
   updateStorageUsage: vi.fn().mockResolvedValue(undefined),
 };
 
@@ -60,6 +64,8 @@ describe('Cleanup Jobs', () => {
       expect(mockSyncService.deleteStaleDevices).toHaveBeenCalled();
       expect(mockSyncService.cleanupExpiredRateLimitCounters).toHaveBeenCalled();
       expect(mockSyncService.cleanupExpiredRequestDedupEntries).toHaveBeenCalled();
+      expect(mockSyncService.deleteExpiredPendingPasskeyRegistrations).toHaveBeenCalled();
+      expect(mockSyncService.deleteAbandonedUnverifiedUsers).toHaveBeenCalled();
     });
 
     it('should use retentionMs for cutoff calculation', async () => {
@@ -78,6 +84,17 @@ describe('Cleanup Jobs', () => {
       // Cutoff should be approximately Date.now() - retentionMs
       const expectedCutoff = Date.now() - DEFAULT_SYNC_CONFIG.retentionMs;
       expect(Math.abs(cutoffCall - expectedCutoff)).toBeLessThan(100);
+
+      // Pending passkey registrations are pruned against "now" (their own
+      // expiry timestamp decides), abandoned unverified users against the
+      // retentionMs grace window.
+      const pendingCutoffCall =
+        mockSyncService.deleteExpiredPendingPasskeyRegistrations.mock.calls[0][0];
+      expect(Math.abs(pendingCutoffCall - Date.now())).toBeLessThan(100);
+
+      const unverifiedCutoffCall =
+        mockSyncService.deleteAbandonedUnverifiedUsers.mock.calls[0][0];
+      expect(Math.abs(unverifiedCutoffCall - expectedCutoff)).toBeLessThan(100);
     });
 
     it('should run cleanup daily', async () => {
@@ -209,6 +226,20 @@ describe('Cleanup Jobs', () => {
       expect(mockSyncService.deleteOldSyncedOpsForAllUsers).toHaveBeenCalled();
       expect(mockSyncService.cleanupExpiredRateLimitCounters).toHaveBeenCalled();
       expect(mockSyncService.cleanupExpiredRequestDedupEntries).toHaveBeenCalled();
+      expect(mockSyncService.deleteExpiredPendingPasskeyRegistrations).toHaveBeenCalled();
+      expect(mockSyncService.deleteAbandonedUnverifiedUsers).toHaveBeenCalled();
+    });
+
+    it('should continue cleanup even if pending passkey cleanup fails', async () => {
+      mockSyncService.deleteExpiredPendingPasskeyRegistrations.mockRejectedValueOnce(
+        new Error('DB error'),
+      );
+
+      startCleanupJobs();
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      // The abandoned-user step should still run
+      expect(mockSyncService.deleteAbandonedUnverifiedUsers).toHaveBeenCalled();
     });
   });
 });

--- a/packages/super-sync-server/tests/sync.service.spec.ts
+++ b/packages/super-sync-server/tests/sync.service.spec.ts
@@ -786,6 +786,59 @@ vi.mock('../src/db', async () => {
           return state.users.get(args.where.id) || null;
         }),
         update: vi.fn().mockResolvedValue({}),
+        // Emulates exactly the where-shape deleteAbandonedUnverifiedUsers
+        // issues: isVerified equality, createdAt.lt, relation none, token OR.
+        deleteMany: vi.fn().mockImplementation(async (args: any) => {
+          const where = args.where ?? {};
+          let deleted = 0;
+          for (const [id, user] of state.users) {
+            if (where.isVerified !== undefined && user.isVerified !== where.isVerified) {
+              continue;
+            }
+            if (
+              where.createdAt?.lt !== undefined &&
+              !(user.createdAt instanceof Date && user.createdAt < where.createdAt.lt)
+            ) {
+              continue;
+            }
+            if (where.pendingPasskeyRegistrations?.none !== undefined) {
+              const hasPending = Array.from(
+                state.pendingPasskeyRegistrations.values(),
+              ).some((p: any) => p.userId === id);
+              if (hasPending) continue;
+            }
+            if (where.OR !== undefined) {
+              const matchesOr = where.OR.some((cond: any) => {
+                if (cond.verificationTokenExpiresAt === null) {
+                  return user.verificationTokenExpiresAt == null;
+                }
+                if (cond.verificationTokenExpiresAt?.lt !== undefined) {
+                  return (
+                    user.verificationTokenExpiresAt != null &&
+                    user.verificationTokenExpiresAt < cond.verificationTokenExpiresAt.lt
+                  );
+                }
+                return false;
+              });
+              if (!matchesOr) continue;
+            }
+            state.users.delete(id);
+            deleted++;
+          }
+          return { count: deleted };
+        }),
+      },
+      pendingPasskeyRegistration: {
+        deleteMany: vi.fn().mockImplementation(async (args: any) => {
+          const lt = args.where?.verificationTokenExpiresAt?.lt;
+          let deleted = 0;
+          for (const [id, row] of state.pendingPasskeyRegistrations) {
+            if (lt !== undefined && row.verificationTokenExpiresAt >= lt) continue;
+            state.pendingPasskeyRegistrations.delete(id);
+            deleted++;
+          }
+          return { count: deleted };
+        }),
       },
       $queryRaw: vi.fn().mockResolvedValue([{ total: BigInt(0) }]),
       $executeRaw: vi.fn().mockResolvedValue(0),
@@ -4168,6 +4221,73 @@ describe('SyncService', () => {
       );
 
       expect(deleted).toBe(0);
+    });
+
+    it('should delete expired pending passkey registrations and keep unexpired ones', async () => {
+      const service = getSyncService();
+      const hourMs = 60 * 60 * 1000;
+
+      testState.pendingPasskeyRegistrations.set('expired', {
+        id: 'expired',
+        userId: 21,
+        verificationTokenExpiresAt: BigInt(Date.now() - hourMs),
+      });
+      testState.pendingPasskeyRegistrations.set('active', {
+        id: 'active',
+        userId: 22,
+        verificationTokenExpiresAt: BigInt(Date.now() + hourMs),
+      });
+
+      const deleted = await service.deleteExpiredPendingPasskeyRegistrations(Date.now());
+
+      expect(deleted).toBe(1);
+      expect(testState.pendingPasskeyRegistrations.has('expired')).toBe(false);
+      expect(testState.pendingPasskeyRegistrations.has('active')).toBe(true);
+    });
+
+    it('should delete abandoned unverified users but never verified or in-flight ones', async () => {
+      const service = getSyncService();
+      const dayMs = 24 * 60 * 60 * 1000;
+      const addUser = (id: number, overrides: Record<string, unknown>): void => {
+        testState.users.set(id, {
+          id,
+          email: `user-${id}@test.com`,
+          isVerified: 0,
+          verificationTokenExpiresAt: BigInt(Date.now() - dayMs),
+          createdAt: new Date(Date.now() - 60 * dayMs),
+          ...overrides,
+        });
+      };
+
+      // Abandoned: old, unverified, expired token, nothing pending
+      addUser(31, {});
+      // Abandoned with the token column already cleared
+      addUser(32, { verificationTokenExpiresAt: null });
+      // Verified users are never touched, no matter how old
+      addUser(33, { isVerified: 1 });
+      // Unverified but still within the grace window
+      addUser(34, { createdAt: new Date(Date.now() - dayMs) });
+      // Unverified with a passkey registration still pending
+      addUser(35, {});
+      testState.pendingPasskeyRegistrations.set('pending-35', {
+        id: 'pending-35',
+        userId: 35,
+        verificationTokenExpiresAt: BigInt(Date.now() + dayMs),
+      });
+      // Unverified with a magic-link re-registration in flight (live token)
+      addUser(36, { verificationTokenExpiresAt: BigInt(Date.now() + dayMs) });
+
+      const deleted = await service.deleteAbandonedUnverifiedUsers(
+        Date.now() - 45 * dayMs,
+      );
+
+      expect(deleted).toBe(2);
+      expect(testState.users.has(31)).toBe(false);
+      expect(testState.users.has(32)).toBe(false);
+      expect(testState.users.has(33)).toBe(true);
+      expect(testState.users.has(34)).toBe(true);
+      expect(testState.users.has(35)).toBe(true);
+      expect(testState.users.has(36)).toBe(true);
     });
   });
 

--- a/packages/super-sync-server/tests/sync.service.test-state.ts
+++ b/packages/super-sync-server/tests/sync.service.test-state.ts
@@ -9,6 +9,7 @@ export const testState = {
   syncDevices: new Map<string, any>(),
   userSyncStates: new Map<number, any>(),
   users: new Map<number, any>(),
+  pendingPasskeyRegistrations: new Map<string, any>(),
   serverSeqCounter: 0,
   batchConflictQueryCount: 0,
   entityConflictFindFirstCount: 0,
@@ -21,6 +22,7 @@ export function resetTestState(): void {
   testState.syncDevices = new Map();
   testState.userSyncStates = new Map();
   testState.users = new Map();
+  testState.pendingPasskeyRegistrations = new Map();
   testState.serverSeqCounter = 0;
   testState.batchConflictQueryCount = 0;
   testState.entityConflictFindFirstCount = 0;


### PR DESCRIPTION
## Problem

Closes #9031. `runDailyCleanup` purges old ops, stale devices, expired rate-limit counters and request-dedup entries, but nothing prunes expired `pending_passkey_registrations` rows (expiry is only checked at read time in auth.ts, rows are only physically deleted when the verification link is clicked) or abandoned unverified `user` rows. Abandoned registrations therefore retain PII (email plus credential public key) indefinitely, and a patient or distributed client can accumulate unbounded rows past the per-IP rate limit.

## Solution

Two new steps in `runDailyCleanup`, in the exact try/catch + logging shape of steps 2 to 4, backed by two methods in `SyncService` next to `deleteStaleDevices`:

- Step 5 deletes `pending_passkey_registrations` whose `verificationTokenExpiresAt` is past, using the same strict comparison auth.ts applies at read time.
- Step 6 deletes unverified users older than a grace window with nothing in flight: `isVerified: 0`, `createdAt` past the window, no pending passkey registration row, and no live verification token. The last guard goes one step beyond the issue's sketch, deliberately: `registerWithMagicLink` refreshes the token on the same old user row without bumping `createdAt`, so without it the sweep could delete an old row while a freshly emailed magic link is still valid.

Grace window reuses the unified `retentionMs` (45 days) rather than adding a second knob; verification tokens live 24h, so the margin is wide. Verified users can never match the predicate, and unverified users are denied all authenticated routes, so the cascading deletes (operations, devices, sync state, passkeys, pending registrations) cannot touch real sync data.

## Verification

New cases in `cleanup.spec.ts` (both steps wired into the daily job, cutoffs asserted, one step failing does not stop the others) and `sync.service.spec.ts` (expired pending row deleted, unexpired kept; abandoned old user deleted; verified never deleted; recent, has-pending, and live-token users all kept), mirroring the existing harnesses. Targeted suites: 171/171 green (cleanup, sync.service, sync-operations, device.service). The full package run has 58 pre-existing failures that are identical on the pristine tree (stale local `@sp/sync-core` dist, unrelated to this change; verified by stashing). `npm run checkFile` clean on all five changed files.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Other (please describe): server data-hygiene / PII retention fix

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, no operator-facing config change; the constants and predicates are documented in code
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
