### PR TITLE
fix(schedule): anchor month-view day 0 to the first displayed day

### DIFF
--- a/src/app/features/schedule/map-schedule-data/map-to-schedule-days.ts
+++ b/src/app/features/schedule/map-schedule-data/map-to-schedule-days.ts
@@ -74,6 +74,13 @@ export const mapToScheduleDays = (
     (task) => !(typeof task.dueWithTime === 'number'),
   ) as TaskWithoutReminder[];
 
+  // Span the blocker window across every rendered day. The 10-day default was
+  // tuned for week view, where the visible range always sits inside it; a
+  // month grid is up to 42 days anchored at its first cell, so work-hours
+  // blocks and timed repeat projections would otherwise only cover the first
+  // stretch of the grid. Days outside the rendered range never mattered:
+  // createScheduleDays only consults the map for rendered dayDates, so a
+  // shorter-than-10 span changes nothing for day and week view either.
   const blockerBlocksDayMap = createBlockedBlocksByDayMap(
     scheduledTasks,
     scheduledTaskRepeatCfgs,
@@ -81,7 +88,7 @@ export const mapToScheduleDays = (
     workStartEndCfg,
     lunchBreakCfg,
     now,
-    undefined,
+    dayDates.length,
     realNow,
   );
 

--- a/src/app/features/schedule/map-schedule-data/month-view-repeat-projection-day.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/month-view-repeat-projection-day.spec.ts
@@ -1,6 +1,7 @@
 import { mapToScheduleDays } from './map-to-schedule-days';
 import { TaskRepeatCfg } from '../../task-repeat-cfg/task-repeat-cfg.model';
 import { getDbDateStr } from '../../../util/get-db-date-str';
+import { SVEType } from '../schedule.const';
 
 const H = 60 * 60 * 1000;
 const h = (hr: number): number => hr * H;
@@ -71,5 +72,91 @@ describe('untimed repeat projections resolve to the day they are due', () => {
         '1970-01-02',
       ]),
     ).toEqual(['1970-01-01', '1970-01-02']);
+  });
+});
+
+describe('timed repeat projections cover the whole rendered range', () => {
+  const timedDailyCfg = (add?: Partial<TaskRepeatCfg>): TaskRepeatCfg =>
+    ({
+      id: 'R_TIMED_DAILY',
+      startDate: '1969-12-01',
+      startTime: '10:00',
+      lastTaskCreationDay: '1970-01-15',
+      monday: true,
+      tuesday: true,
+      wednesday: true,
+      thursday: true,
+      friday: true,
+      saturday: true,
+      sunday: true,
+      repeatCycle: 'DAILY',
+      repeatEvery: 1,
+      defaultEstimate: h(1),
+      isPaused: false,
+      ...add,
+    }) as Partial<TaskRepeatCfg> as TaskRepeatCfg;
+
+  const timedProjectionDays = (
+    cfg: TaskRepeatCfg,
+    dayDates: string[],
+    now: number,
+    realNow: number,
+  ): string[] =>
+    mapToScheduleDays(
+      now,
+      dayDates,
+      [],
+      [],
+      [cfg],
+      [],
+      [],
+      null,
+      {},
+      undefined,
+      undefined,
+      realNow,
+    )
+      .flatMap((d) =>
+        d.entries
+          .filter((e) => e.type === SVEType.ScheduledRepeatProjection)
+          .map(() => d.dayDate),
+      )
+      .sort();
+
+  // The blocker window (timed repeat projections, work-hours blocks) used to
+  // span a fixed 10 days from `now`. With contextNow anchored to the month
+  // grid's first cell, a mid-grid today left the window entirely in already
+  // materialized days and the upcoming occurrences vanished from the month.
+  it('projects a timed daily repeat onto month days beyond 10 days from the anchor', () => {
+    // 4-week grid Mon 1969-12-29 .. Sun 1970-01-25; today sits mid-grid.
+    const grid = Array.from({ length: 28 }, (_, i) =>
+      getDbDateStr(new Date(1969, 11, 29 + i).getTime()),
+    );
+    const dayZeroMidnight = new Date(1969, 11, 29).getTime();
+    const realToday = new Date(1970, 0, 15, 12, 0, 0).getTime();
+
+    expect(
+      timedProjectionDays(timedDailyCfg(), grid, dayZeroMidnight, realToday),
+    ).toEqual(
+      Array.from({ length: 10 }, (_, i) =>
+        getDbDateStr(new Date(1970, 0, 16 + i).getTime()),
+      ),
+    );
+  });
+
+  // A range shorter than the old 10-day window must keep its behavior: only
+  // the rendered days ever consumed blocks, and the real today is still
+  // skipped (its instance is materialized as a concrete task).
+  it('still projects onto tomorrow only in a 2-day week-style range', () => {
+    const midDayNow = new Date(1970, 0, 1, 9, 0, 0).getTime();
+
+    expect(
+      timedProjectionDays(
+        timedDailyCfg({ lastTaskCreationDay: '1969-12-31' }),
+        ['1970-01-01', '1970-01-02'],
+        midDayNow,
+        midDayNow,
+      ),
+    ).toEqual(['1970-01-02']);
   });
 });

--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -554,26 +554,37 @@ describe('ScheduleComponent', () => {
   });
 
   describe('_contextNow computed', () => {
-    it('should return current time when viewing today (selectedDate is null)', () => {
-      // Arrange
+    it('should return the live now while today is day 0 of the displayed range', () => {
+      // Arrange - the default getDaysToShow mock starts on the mocked today
+      // (2026-01-20), so day 0 contains the pinned clock.
+      const clock = new Date(2026, 0, 20, 9, 0, 0).getTime();
+      spyOn(Date, 'now').and.callFake(() => clock);
+      // Fresh array instance: the computed already ran against the real clock
+      // on init, and the default mock hands back the same cached instance, so
+      // daysToShow would otherwise not register as changed.
+      mockScheduleService.getDaysToShow.and.returnValue([
+        '2026-01-20',
+        '2026-01-21',
+        '2026-01-22',
+      ]);
+      component['_selectedDate'].set(new Date(2026, 0, 21));
       component['_selectedDate'].set(null);
 
       // Act
       const contextNow = component['_contextNow']();
 
-      // Assert - just check it's a reasonable timestamp (within last hour and next minute)
-      const now = Date.now();
-      // eslint-disable-next-line no-mixed-operators
-      const oneHourAgo = now - 60 * 60 * 1000;
-      // eslint-disable-next-line no-mixed-operators
-      const oneMinuteFromNow = now + 60 * 1000;
-      expect(contextNow).toBeGreaterThan(oneHourAgo);
-      expect(contextNow).toBeLessThan(oneMinuteFromNow);
+      // Assert
+      expect(contextNow).toBe(clock);
     });
 
-    it('should return midnight of selected date when viewing a different date', () => {
+    it('should return midnight of day 0 when viewing a different date', () => {
       // Arrange
       const selectedDate = new Date(2026, 0, 25, 14, 30, 45); // Jan 25, 2026, 2:30:45 PM
+      mockScheduleService.getDaysToShow.and.returnValue([
+        '2026-01-25',
+        '2026-01-26',
+        '2026-01-27',
+      ]);
       component['_selectedDate'].set(selectedDate);
 
       // Act
@@ -595,8 +606,15 @@ describe('ScheduleComponent', () => {
       // tick this pins the layout to whenever the view was first rendered.
       let clock = new Date(2026, 0, 20, 9, 0, 0).getTime();
       spyOn(Date, 'now').and.callFake(() => clock);
-      // Round-trip through a date: the computed already ran against the real
-      // clock on init, and re-setting null over null would not invalidate it.
+      // Fresh array instance + a date round-trip: the computed already ran
+      // against the real clock on init, and the default mock hands back the
+      // same cached instance, so daysToShow would otherwise not register as
+      // changed.
+      mockScheduleService.getDaysToShow.and.returnValue([
+        '2026-01-20',
+        '2026-01-21',
+        '2026-01-22',
+      ]);
       component['_selectedDate'].set(new Date(2026, 0, 21));
       component['_selectedDate'].set(null);
       expect(component['_contextNow']()).toBe(clock);
@@ -613,6 +631,11 @@ describe('ScheduleComponent', () => {
       const clock = new Date(2026, 0, 20, 9, 0, 0).getTime();
       spyOn(Date, 'now').and.callFake(() => clock);
 
+      mockScheduleService.getDaysToShow.and.returnValue([
+        '2026-01-19',
+        '2026-01-20',
+        '2026-01-21',
+      ]);
       component['_selectedDate'].set(new Date(2026, 0, 19));
 
       expect(component['_contextNow']()).toBe(new Date(2026, 0, 19).setHours(0, 0, 0, 0));
@@ -626,6 +649,11 @@ describe('ScheduleComponent', () => {
       const clock = new Date(2026, 0, 21, 2, 0, 0).getTime();
       spyOn(Date, 'now').and.callFake(() => clock);
 
+      mockScheduleService.getDaysToShow.and.returnValue([
+        '2026-01-20',
+        '2026-01-21',
+        '2026-01-22',
+      ]);
       component['_selectedDate'].set(new Date(2026, 0, 20));
 
       const contextNow = component['_contextNow']();
@@ -640,6 +668,11 @@ describe('ScheduleComponent', () => {
       // view does not move, so the day it shows silently becomes today.
       let clock = new Date(2026, 0, 20, 22, 0, 0).getTime();
       spyOn(Date, 'now').and.callFake(() => clock);
+      mockScheduleService.getDaysToShow.and.returnValue([
+        '2026-01-21',
+        '2026-01-22',
+        '2026-01-23',
+      ]);
       component['_selectedDate'].set(new Date(2026, 0, 21));
       expect(component['_contextNow']()).toBe(new Date(2026, 0, 21).setHours(0, 0, 0, 0));
 
@@ -650,12 +683,87 @@ describe('ScheduleComponent', () => {
 
       expect(component['_contextNow']()).toBe(clock);
     });
+
+    // Month view pads the grid back to the first day of the week containing
+    // the 1st, so day 0 is usually a cell from the previous month while the
+    // selected date stays on the 1st. The anchor has to follow the grid cell,
+    // not the selected date (#9071).
+    const monthGridFrom = (start: Date, nrOfDays: number): string[] =>
+      Array.from({ length: nrOfDays }, (_, i) => {
+        const d = new Date(start);
+        d.setDate(start.getDate() + i);
+        return [
+          d.getFullYear(),
+          String(d.getMonth() + 1).padStart(2, '0'),
+          String(d.getDate()).padStart(2, '0'),
+        ].join('-');
+      });
+
+    it('should anchor to the month grid`s first cell, not the selected month`s 1st', () => {
+      // Viewing Feb 2026 (firstDayOfWeek=1): the grid starts on Mon Jan 26.
+      const clock = new Date(2026, 0, 10, 9, 0, 0).getTime();
+      spyOn(Date, 'now').and.callFake(() => clock);
+      mockLayoutService.selectedTimeView.set('month');
+      mockScheduleService.getMonthDaysToShow.and.returnValue(
+        monthGridFrom(new Date(2026, 0, 26), 42),
+      );
+      component['_selectedDate'].set(new Date(2026, 1, 1));
+
+      expect(component['_contextNow']()).toBe(new Date(2026, 0, 26).setHours(0, 0, 0, 0));
+    });
+
+    it('should anchor to the first grid cell when viewing the current month untraveled', () => {
+      // Today (Feb 15) sits mid-grid; day 0 is still the Jan 26 padding cell,
+      // so the live now must not leak into it.
+      const clock = new Date(2026, 1, 15, 10, 0, 0).getTime();
+      spyOn(Date, 'now').and.callFake(() => clock);
+      mockLayoutService.selectedTimeView.set('month');
+      mockScheduleService.getMonthDaysToShow.and.returnValue(
+        monthGridFrom(new Date(2026, 0, 26), 42),
+      );
+      // Round-trip to invalidate the cached computed after pinning the clock.
+      component['_selectedDate'].set(new Date(2026, 1, 1));
+      component['_selectedDate'].set(null);
+
+      expect(component['_contextNow']()).toBe(new Date(2026, 0, 26).setHours(0, 0, 0, 0));
+    });
+
+    it('should return the live now in month view when today is the first grid cell', () => {
+      // Feb 1 2026 is a Sunday: with firstDayOfWeek=0 the grid starts on
+      // today itself, so the anchor keeps tracking the wall clock.
+      const clock = new Date(2026, 1, 1, 10, 0, 0).getTime();
+      spyOn(Date, 'now').and.callFake(() => clock);
+      mockLayoutService.selectedTimeView.set('month');
+      mockScheduleService.getMonthDaysToShow.and.returnValue(
+        monthGridFrom(new Date(2026, 1, 1), 42),
+      );
+      component['_selectedDate'].set(new Date(2026, 1, 1));
+      component['_selectedDate'].set(null);
+
+      expect(component['_contextNow']()).toBe(clock);
+    });
+
+    it('should return the live now in day view while viewing today', () => {
+      const clock = new Date(2026, 0, 20, 9, 0, 0).getTime();
+      spyOn(Date, 'now').and.callFake(() => clock);
+      mockLayoutService.selectedTimeView.set('day');
+      mockScheduleService.getDaysToShow.and.returnValue(['2026-01-20']);
+      component['_selectedDate'].set(new Date(2026, 0, 21));
+      component['_selectedDate'].set(null);
+
+      expect(component['_contextNow']()).toBe(clock);
+    });
   });
 
   describe('scheduleDays computed', () => {
     it('should call createScheduleDaysWithContext with contextNow', () => {
       // Arrange
       const selectedDate = new Date(2026, 0, 25);
+      mockScheduleService.getDaysToShow.and.returnValue([
+        '2026-01-25',
+        '2026-01-26',
+        '2026-01-27',
+      ]);
       component['_selectedDate'].set(selectedDate);
       mockScheduleService.createScheduleDaysWithContext.calls.reset();
 
@@ -667,7 +775,7 @@ describe('ScheduleComponent', () => {
       const callArgs =
         mockScheduleService.createScheduleDaysWithContext.calls.mostRecent().args[0];
       expect(callArgs.contextNow).toBeDefined();
-      // Context now should be midnight of selected date
+      // Context now should be midnight of day 0 of the displayed range
       const contextDate = new Date(callArgs.contextNow);
       expect(contextDate.getHours()).toBe(0);
       expect(contextDate.getMinutes()).toBe(0);
@@ -676,6 +784,11 @@ describe('ScheduleComponent', () => {
     it('should always pass realNow as actual current time', () => {
       // Arrange
       const selectedDate = new Date(2026, 0, 25);
+      mockScheduleService.getDaysToShow.and.returnValue([
+        '2026-01-25',
+        '2026-01-26',
+        '2026-01-27',
+      ]);
       component['_selectedDate'].set(selectedDate);
       mockScheduleService.createScheduleDaysWithContext.calls.reset();
       const before = Date.now();
@@ -697,6 +810,11 @@ describe('ScheduleComponent', () => {
       // would pass for arbitrary wrong values.
       const clock = new Date(2026, 0, 20, 9, 0, 0).getTime();
       spyOn(Date, 'now').and.callFake(() => clock);
+      mockScheduleService.getDaysToShow.and.returnValue([
+        '2026-01-27',
+        '2026-01-28',
+        '2026-01-29',
+      ]);
       component['_selectedDate'].set(new Date(2026, 0, 27));
       mockScheduleService.createScheduleDaysWithContext.calls.reset();
 
@@ -730,6 +848,13 @@ describe('ScheduleComponent', () => {
         },
       ];
       mockScheduleService.createScheduleDaysWithContext.and.returnValue(scheduleDays);
+      // Fresh array instance so daysToShow registers as changed and the
+      // scheduleDays computed re-runs against the overridden mock above.
+      mockScheduleService.getDaysToShow.and.returnValue([
+        '2026-01-20',
+        '2026-01-21',
+        '2026-01-22',
+      ]);
       component['_selectedDate'].set(new Date(2026, 0, 20));
 
       const result = component.monthEvents();

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -44,6 +44,7 @@ import { DEFAULT_FIRST_DAY_OF_WEEK } from '../../../core/locale.constants';
 import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
 import { getWeekNumber } from '../../../util/get-week-number';
 import { parseDbDateStr } from '../../../util/parse-db-date-str';
+import { dateStrToUtcDate } from '../../../util/date-str-to-utc-date';
 
 @Component({
   selector: 'schedule',
@@ -245,31 +246,37 @@ export class ScheduleComponent {
     return cfg !== null && cfg !== undefined ? cfg : DEFAULT_FIRST_DAY_OF_WEEK;
   });
 
-  // Calculate context-aware "now" based on selected date
-  // When viewing a future week, use the start of that week as reference time
+  // Calculate context-aware "now" anchored to the first displayed day
+  // When viewing a future range, use the start of that range as reference time
   private _contextNow = computed(() => {
     // Date.now() is not reactive and computeds cache, so without a time-varying
     // dependency the reference would freeze at whatever instant this last ran.
     // Same 2-min tick currentTimeRow and scheduleDays already refresh on.
     this.scheduleService.scheduleRefreshTick();
 
-    const selectedDate = this._selectedDate();
-    if (selectedDate === null) {
+    // contextNow anchors dayDates[0] (`startTime = i == 0 ? now` in
+    // create-schedule-days), so it has to stay inside that day. Day 0 is not
+    // always the selected date: month view pads the grid back to the start of
+    // the week containing the 1st, so its first cell usually sits in the
+    // previous month, and deriving the anchor from the selected date stamped
+    // that cell with a timestamp from a different day. The bounds therefore
+    // come from daysToShow()[0] itself, via the same helper
+    // create-schedule-days resolves day bounds with. Testing where the wall
+    // clock sits within that day - rather than comparing day strings - lets
+    // the view self-correct once it drifts under a midnight rollover (a day
+    // picked as "tomorrow" becomes today while the view stays put), and can
+    // never hand the mapper a now past day 0's end, which would push every
+    // entry out of the column.
+    const firstDay = this.daysToShow()[0];
+    if (!firstDay) {
       return Date.now();
     }
-
-    // contextNow anchors dayDates[0] (`startTime = i == 0 ? now` in
-    // create-schedule-days), so it has to stay inside that day. Testing where the
-    // wall clock sits within the selected day - rather than comparing day strings -
-    // lets the view self-correct once it drifts under a midnight rollover (a day
-    // picked as "tomorrow" becomes today while the view stays put), and can never
-    // hand the mapper a now past day 0's end, which would push every entry out of
-    // the column.
-    const dayStart = new Date(selectedDate);
+    const dayStart = dateStrToUtcDate(firstDay);
     dayStart.setHours(0, 0, 0, 0);
-    // setDate rather than +24h: DST-safe day advancement.
-    const nextDayStart = new Date(dayStart);
-    nextDayStart.setDate(nextDayStart.getDate() + 1);
+    // setHours(24) rather than +24h: DST-safe day advancement, and exactly how
+    // create-schedule-days derives nextDayStart for the same day string.
+    const nextDayStart = dateStrToUtcDate(firstDay);
+    nextDayStart.setHours(24, 0, 0, 0);
 
     const now = Date.now();
     return now >= dayStart.getTime() && now < nextDayStart.getTime()


### PR DESCRIPTION
## Problem

Closes #9071. In month view, `daysToShow()[0]` and `_contextNow` describe different days. The grid starts on the first day of the week containing the 1st, so day 0 is usually a padding day from the previous month, while `_contextNow` derived its midnight from `_selectedDate` (the 1st). `create-schedule-days` anchors day 0 with that value (`startTime = i == 0 ? now : dayStartTime`), so the padding cell was laid out with a timestamp from a different day, days past its own `nextDayStart`, and day 0's repeat projections were selected for the wrong date.

## Solution

Single-source `_contextNow` from `daysToShow()[0]`, per the direction in the issue: derive the day bounds from the first displayed day with the same helper create-schedule-days uses (`dateStrToUtcDate` + `setHours(0)` / `setHours(24)`), return live `Date.now()` when the wall clock sits inside that day, else day 0's midnight. Week and day views are provably unchanged: `getDaysToShow` places the reference date itself at index 0, so the bounds are identical to the old `_selectedDate` derivation there.

One consumer needed a minimal adaptation, which the fix exposed: `createBlockedBlocksByDayMap` generates work-hours blocks, lunch breaks and timed repeat projections for a fixed 10-day window from the anchor. Tuned for week view, that window no longer covers a 35 to 42 day month grid once the anchor is honest, and current-month view lost timed projections beyond day 10 (reproduced by a new test that got 0 of 10 expected projection days). The window now spans `dayDates.length`; days outside the rendered range were never consulted, so day and week views are unaffected, guarded by a range-parity test.

Also fixed as the same bug class: with a custom start-of-next-day offset, the old null-selectedDate branch returned live now during the 00:00-to-offset window even when that fell outside day 0, pushing every day-0 entry out of its column; the new bounds check covers it, and the existing "never anchor day 0 with a now outside it" contract test applies.

## Verification

New tests: month grid with padding day 0 anchors to day 0 midnight (navigated and current-month cases), today-as-first-cell returns live now, day view unchanged, timed daily repeat projects onto month days beyond 10 days from the anchor, and a 2-day window parity guard. Without the source changes exactly those new tests fail (2 FAILED of 73 in the component spec, 1 FAILED of 4 in the new mapper spec); with them: component 73/73, all 12 map-schedule-data specs 104/104, schedule.service 47/47, schedule-month 36/36. Five pre-existing tests had their `getDaysToShow` mocks aligned with the day range each scenario describes; none deleted, and all adapted tests pass on both old and new code. `npm run checkFile` clean on all four files. Production build green.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, no user-facing setting or API change
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
