### PR TITLE
fix(config): distrust legacy hour derived from invalid day-boundary string

### DIFF
--- a/src/app/core/date/date.service.tz.spec.ts
+++ b/src/app/core/date/date.service.tz.spec.ts
@@ -144,9 +144,9 @@ describe('DateService — logical clock helpers', () => {
     expect(service.getStartOfNextDayDiffMs()).toBe(0);
   });
 
-  it('setStartOfNextDayDiff() falls back to legacy hour when a time string is invalid', () => {
+  it('setStartOfNextDayDiff() ignores the legacy hour when a time string is invalid', () => {
     service.setStartOfNextDayDiff('24:00', 2);
-    expect(service.getStartOfNextDayDiffMs()).toBe(2 * 60 * 60 * 1000);
+    expect(service.getStartOfNextDayDiffMs()).toBe(0);
   });
 
   it('setStartOfNextDayDiff() falls back to legacy hour when time is undefined', () => {

--- a/src/app/features/config/normalize-start-of-next-day-config.ts
+++ b/src/app/features/config/normalize-start-of-next-day-config.ts
@@ -22,7 +22,7 @@ export const normalizeStartOfNextDayConfig = (
   // `startOfNextDayTime` wins when valid. When both fields arrive together
   // from sync/REST/plugin payloads we keep minute precision from
   // `startOfNextDayTime` and derive a legacy hour-only `startOfNextDay`.
-  // If the time string is invalid, fall back to a valid legacy numeric value.
+  // If the time string is invalid, reset both fields to the default boundary.
   const normalized: NormalizedMiscConfig = { ...misc };
 
   if (misc.startOfNextDayTime != null) {
@@ -33,11 +33,13 @@ export const normalizeStartOfNextDayConfig = (
     if (hour != null) {
       normalized.startOfNextDay = hour;
     } else {
-      const legacyHour =
-        getValidStartOfNextDayHour(misc.startOfNextDay) ??
-        DEFAULT_GLOBAL_CONFIG.misc.startOfNextDay;
-      normalized.startOfNextDay = legacyHour;
-      normalized.startOfNextDayTime = formatStartOfNextDayTime(legacyHour);
+      // #7645: mirrors getStartOfNextDayDiffMs -- an invalid time string makes the
+      // whole pair untrustworthy, because v18.5.0-v18.6.x derived the legacy hour
+      // from that same string ('24:00' -> 23) and synced both. Repair to the default
+      // (see that util for why we do not try to tell derived values from intent).
+      const defaultHour = DEFAULT_GLOBAL_CONFIG.misc.startOfNextDay;
+      normalized.startOfNextDay = defaultHour;
+      normalized.startOfNextDayTime = formatStartOfNextDayTime(defaultHour);
     }
   }
 

--- a/src/app/features/config/store/global-config.effects.spec.ts
+++ b/src/app/features/config/store/global-config.effects.spec.ts
@@ -243,7 +243,7 @@ describe('GlobalConfigEffects', () => {
         }),
       );
 
-      expect(dateServiceSpy.setStartOfNextDayDiff).toHaveBeenCalledWith('04:00', 4);
+      expect(dateServiceSpy.setStartOfNextDayDiff).toHaveBeenCalledWith('00:00', 0);
     });
   });
 
@@ -314,7 +314,7 @@ describe('GlobalConfigEffects', () => {
         }),
       );
 
-      expect(dateServiceSpy.setStartOfNextDayDiff).toHaveBeenCalledWith('04:00', 4);
+      expect(dateServiceSpy.setStartOfNextDayDiff).toHaveBeenCalledWith('00:00', 0);
     });
   });
 

--- a/src/app/features/config/store/global-config.reducer.spec.ts
+++ b/src/app/features/config/store/global-config.reducer.spec.ts
@@ -508,12 +508,19 @@ describe('GlobalConfigReducer', () => {
       expect(result.misc.startOfNextDayTime).toBe('00:00');
     });
 
-    it('should repair invalid startOfNextDayTime with a valid legacy fallback', () => {
+    // #7645: v18.5.0-v18.6.x accepted any colon-string in the free-text
+    // "start of next day" field and clamped it to 23:59, so the whole app sat one
+    // day behind. That reducer ALSO derived the legacy hour from the same bad
+    // string -- getStartOfNextDayHourFromTimeString('24:00') returned 23 -- and
+    // persisted/synced the pair below. Trusting that derived 23 as a "valid legacy
+    // fallback" repairs the config to a 23h offset, which is still yesterday for
+    // 23 of every 24 hours. The legacy hour is poisoned, not independent intent.
+    it('should not fall back to a legacy hour derived from the invalid time string (#7645)', () => {
       const snapshotConfig: any = {
         ...DEFAULT_GLOBAL_CONFIG,
         misc: {
           ...DEFAULT_GLOBAL_CONFIG.misc,
-          startOfNextDay: 4,
+          startOfNextDay: 23,
           startOfNextDayTime: '24:00',
         },
       };
@@ -525,8 +532,8 @@ describe('GlobalConfigReducer', () => {
         }),
       );
 
-      expect(result.misc.startOfNextDay).toBe(4);
-      expect(result.misc.startOfNextDayTime).toBe('04:00');
+      expect(result.misc.startOfNextDayTime).toBe('00:00');
+      expect(result.misc.startOfNextDay).toBe(0);
     });
 
     it('should repair fully invalid startOfNextDay config to the default day boundary', () => {

--- a/src/app/op-log/backup/backup.service.spec.ts
+++ b/src/app/op-log/backup/backup.service.spec.ts
@@ -368,8 +368,8 @@ describe('BackupService', () => {
         .args[0] as Parameters<typeof mockOpLogStore.runDestructiveStateReplacement>[0];
 
       const appendedPayload = args.syncImportOp.payload as any;
-      expect(appendedPayload.globalConfig.misc.startOfNextDay).toBe(4);
-      expect(appendedPayload.globalConfig.misc.startOfNextDayTime).toBe('04:00');
+      expect(appendedPayload.globalConfig.misc.startOfNextDay).toBe(0);
+      expect(appendedPayload.globalConfig.misc.startOfNextDayTime).toBe('00:00');
     });
 
     it('should pass archiveYoung to the atomic replacement when present in backup', async () => {

--- a/src/app/op-log/backup/migrate-legacy-backup.spec.ts
+++ b/src/app/op-log/backup/migrate-legacy-backup.spec.ts
@@ -6,6 +6,7 @@ import { validateFull } from '../validation/validation-fn';
 import { AppDataComplete, MODEL_CONFIGS } from '../model/model-config';
 import { WorkContextType } from '../../features/work-context/work-context.model';
 import fixture from './test-fixtures/legacy-v10-backup.json';
+import { getDbDateStr } from '../../util/get-db-date-str';
 
 /**
  * Creates a minimal v10-era legacy backup structure.
@@ -390,6 +391,37 @@ describe('migrate-legacy-backup', () => {
       const task = result.task.entities['task-1'];
       expect(task.dueWithTime).toBe(1704110400000);
       expect(task.plannedAt).toBeUndefined();
+    });
+
+    // #7645: this is the one raw caller of getStartOfNextDayDiffMs -- it feeds
+    // un-normalized config straight in and uses the resulting todayStr to assign
+    // dueDay / evict tasks from TODAY_TAG. v18.5.0-v18.6.x could persist
+    // `{ startOfNextDayTime: '24:00', startOfNextDay: 23 }`, which resolved to a
+    // ~24h offset and put the whole import on yesterday.
+    it('should not shift the day boundary for a poisoned start-of-next-day pair (#7645)', () => {
+      const data = createLegacyBackup();
+      data.globalConfig.misc.startOfNextDayTime = '24:00';
+      data.globalConfig.misc.startOfNextDay = 23;
+      data.tag.entities.TODAY.taskIds = ['task-1'];
+
+      const result = migrateLegacyBackup(data) as any;
+
+      expect(result.tag.entities.TODAY.taskIds).toEqual(['task-1']);
+      expect(result.task.entities['task-1'].dueDay).toBe(getDbDateStr(new Date()));
+    });
+
+    const FOUR_HOURS_MS = 4 * 60 * 60 * 1000;
+
+    it('should honour a genuine legacy start-of-next-day hour without a time string', () => {
+      const data = createLegacyBackup();
+      data.globalConfig.misc.startOfNextDay = 4;
+      data.tag.entities.TODAY.taskIds = ['task-1'];
+
+      const result = migrateLegacyBackup(data) as any;
+
+      expect(result.task.entities['task-1'].dueDay).toBe(
+        getDbDateStr(new Date(Date.now() - FOUR_HOURS_MS)),
+      );
     });
 
     it('should migrate legacy task reminders to task.remindAt', () => {

--- a/src/app/op-log/persistence/sync-hydration.service.spec.ts
+++ b/src/app/op-log/persistence/sync-hydration.service.spec.ts
@@ -478,12 +478,12 @@ describe('SyncHydrationService', () => {
 
       const validatedData = mockValidateStateService.validateAndRepair.calls.mostRecent()
         .args[0] as any;
-      expect(validatedData.globalConfig.misc.startOfNextDay).toBe(4);
-      expect(validatedData.globalConfig.misc.startOfNextDayTime).toBe('04:00');
+      expect(validatedData.globalConfig.misc.startOfNextDay).toBe(0);
+      expect(validatedData.globalConfig.misc.startOfNextDayTime).toBe('00:00');
 
       const savedState = getCommittedBaseline().state as any;
-      expect(savedState.globalConfig.misc.startOfNextDay).toBe(4);
-      expect(savedState.globalConfig.misc.startOfNextDayTime).toBe('04:00');
+      expect(savedState.globalConfig.misc.startOfNextDay).toBe(0);
+      expect(savedState.globalConfig.misc.startOfNextDayTime).toBe('00:00');
     });
 
     it('should handle null downloadedMainModelData by using only DB data', async () => {

--- a/src/app/util/start-of-next-day.util.spec.ts
+++ b/src/app/util/start-of-next-day.util.spec.ts
@@ -122,8 +122,15 @@ describe('start-of-next-day util', () => {
       expect(getStartOfNextDayDiffMs('24:00', undefined)).toBe(0);
     });
 
-    it('falls back to the legacy numeric hour when the time string is invalid', () => {
-      expect(getStartOfNextDayDiffMs('24:00', 2)).toBe(2 * 60 * 60 * 1000);
+    // #7645: the legacy hour is not independent intent when a time string is
+    // present but invalid -- v18.5.0-v18.6.x derived it from that same string.
+    it('ignores the legacy numeric hour when the time string is invalid', () => {
+      expect(getStartOfNextDayDiffMs('24:00', 2)).toBe(0);
+      expect(getStartOfNextDayDiffMs('24:00', 23)).toBe(0);
+      // Also for strings the old deriver could not parse, where the legacy hour
+      // may be real intent -- a deliberate trade-off, see the util.
+      expect(getStartOfNextDayDiffMs('abc', 4)).toBe(0);
+      expect(getStartOfNextDayDiffMs('', 4)).toBe(0);
     });
 
     it('returns 0 for invalid legacy numeric values', () => {

--- a/src/app/util/start-of-next-day.util.ts
+++ b/src/app/util/start-of-next-day.util.ts
@@ -61,10 +61,14 @@ export const getStartOfNextDayDiffMs = (
   startOfNextDayTime: string | undefined,
   startOfNextDay: number | undefined,
 ): number => {
-  if (
-    typeof startOfNextDayTime === 'string' &&
-    START_OF_NEXT_DAY_TIME_RE.test(startOfNextDayTime)
-  ) {
+  if (typeof startOfNextDayTime === 'string') {
+    if (!START_OF_NEXT_DAY_TIME_RE.test(startOfNextDayTime)) {
+      // #7645: an invalid time string makes the whole pair untrustworthy, because
+      // v18.5.0-v18.6.x derived the legacy hour from that same string and synced
+      // both -- honouring it leaves the app a day behind. Reset to the default
+      // instead of trying to tell derived values from intent (see the spec cases).
+      return 0;
+    }
     return (
       clampStartOfNextDayMinutes(parseStartOfNextDayTimeToMinutes(startOfNextDayTime)) *
       60 *
@@ -72,6 +76,7 @@ export const getStartOfNextDayDiffMs = (
     );
   }
 
+  // No time string at all (pre-v18.5.0 data): the legacy hour is genuine user intent.
   const hour = getValidStartOfNextDayHour(startOfNextDay);
   if (hour != null) {
     return hour * MINUTES_PER_HOUR * 60 * 1000;


### PR DESCRIPTION
Fixes the app-wide "one day behind" state reported in #7645, and the incomplete repair that left affected installs broken after the original hole was closed.

## What users saw

The reporter's console log is the whole diagnosis:

```
DAY_CHANGE 2026-05-17        ← before config load, offset = 0 → true local date
[a][Global Config] Update Global Config Section
DAY_CHANGE 2026-05-16        ← after config load → day jumps BACKWARDS
[task] [TaskDueEffects] … processing tasks for: 2026-05-16
```

Not a Schedule-panel bug — `TaskDueEffects` ran on the wrong day too, so everything date-derived (Today tag, due dates, repeat creation, tracking date) was off by one. The issue title blames timezone; that's a red herring, the failure is timezone-independent.

## Root cause

v18.5.0 (#7483) turned "start of next day" into a free-text field (`type: 'text'` + an HTML `pattern`, which only marks invalid — it does not block the value). The parser then accepted any string containing a colon and clamped the result to 23:59:

| stored value | offset in v18.5.0–v18.6.x |
|---|---|
| `24:00` | 23.98 h |
| `25:30` | 23.98 h |
| `99:00` | 23.98 h |

A 23h59m offset makes "logical today" = yesterday for all but the last minute of every day — exactly "always exactly 1 day behind". The reporter was on 18.6.0, dead centre in the window (v18.5.0 2026-05-07 → v18.7.0 2026-05-18).

## Why it survived the v18.7.0 fix

`7675be0982` (v18.7.0) regex-validated the input, so **new** corruption is impossible. But that same v18.5/18.6 reducer had also derived the legacy hour from the bad string and persisted/synced the pair:

```
getStartOfNextDayHourFromTimeString('24:00')  // floor(clamp(1440)/60) → 23
```

Verified against the exact historical parser: `'24:00'`, `'111'`, `'25:99'` all wrote `23`; `''` wrote `0`; `'abc'` wrote nothing. So affected installs carry `{ startOfNextDayTime: '24:00', startOfNextDay: 23 }` — and the repair path honoured that `23` as a "valid legacy fallback", rewriting the config to `'23:00'`. Still yesterday for 23 of every 24 hours, now behind a valid-looking value in Settings, which makes it *harder* to notice, not easier.

## The fix

Treat a present-but-invalid time string as a corrupt pair and reset to the default boundary, in two places:

- **`start-of-next-day.util.ts`** — covers `migrate-legacy-backup.ts:377`, the one caller that passes raw un-normalized config straight in and uses the result to assign `dueDay` and evict tasks from `TODAY_TAG`.
- **`normalize-start-of-next-day-config.ts`** — repairs both persisted fields. Load-bearing on its own: without it, normalize rewrites the poisoned pair to a *valid* `'23:00'`, which the util then correctly honours as 23h.

Data with no time string at all (pre-v18.5.0) still honours its legacy hour — untouched and still covered by a passing test.

### Deliberate trade-off

This also discards a legacy hour sitting beside a string the old deriver could *not* parse (`'abc'` wrote no hour, so a `4` next to it may be real intent). Telling the two apart would mean keeping the dead v18.5 parser around forever to re-derive what it would have written — not worth it for a shape the UI cannot produce (native `time` input + validator) and that the user can re-set in one click. Pinned by spec cases so it can't be reverted silently.

## Sync-correctness notes

- Both functions stay pure and deterministic — no replay-determinism impact.
- The repair is **local-only**: it runs on `loadAllData` / hydration / backup-import, none of which capture ops. No op storm, nothing written back to sync; each device heals itself on next load.
- Mixed-fleet: a still-running v18.5/18.6 client computes `23` where a fixed client computes `0`. Self-limiting — it needs a user edit on the old client to propagate, and only affects installs already carrying the poisoned pair.
- No schema bump (rule 10) and no new persisted field (rule 11).

## Testing

Both new cases were confirmed to **fail without the fix**, not just pass with it:

- `migrate-legacy-backup.spec.ts` — a legacy import carrying the poisoned pair stamps `dueDay: '2026-08-26'` (yesterday) without the fix: `Expected '2026-08-26' to be '2026-08-27'`. Plus a second case pinning the genuine pre-v18.5.0 legacy-hour path.
- `start-of-next-day.util.spec.ts` — reverting the util makes all four assertions fail (`7200000`, `82800000`, `14400000`, `14400000` where `0` is expected).

Five existing specs that pinned the old fallback are updated; the superseded reducer test is replaced by the real-world `{ startOfNextDay: 23, startOfNextDayTime: '24:00' }` shape.

Full suite green in **Europe/Berlin** (the reporter's own offset), **America/Los_Angeles** and **Asia/Tokyo** — 14421 / 14407 passing, no failures.

## Open question

Whether *this reporter* hit this path is unconfirmed — it needs their current Settings value (`23:00` would confirm it). The fix doesn't depend on the answer; that only sizes how many users it reaches.

Refs #7645

https://claude.ai/code/session_01CaQYc9apc7TAe6nwEmSkgY
