### PR TITLE
fix(sync): diagnose and recover from invalid sync file prefix (#9627)

### DIFF
--- a/docs/sync-and-op-log/README.md
+++ b/docs/sync-and-op-log/README.md
@@ -45,6 +45,7 @@ tests, or a focused contract.
 | Change SECTION conflict/recovery behavior              | [section-conflict-replay.md](./section-conflict-replay.md) — narrow commutativity, state-projected replay, and released-client compatibility contract |
 | Find executable coverage for a SuperSync scenario      | [supersync-scenarios.md](./supersync-scenarios.md) — scenario-to-test index, not a prose specification                                                |
 | Research rejected alternatives or cross-version policy | [operation-log-architecture.md](./operation-log-architecture.md) — deep rationale and history plus the **normative A.7.11 schema-bump policy**        |
+| Decode an `InvalidFilePrefixError` from a log export   | [diagnosing-invalid-file-prefix.md](./diagnosing-invalid-file-prefix.md) — `headShape`/`prefixAt` decode table (#9627)                                |
 
 ## Reference docs
 
@@ -59,6 +60,7 @@ tests, or a focused contract.
 | Contract | [vector-clocks.md](./vector-clocks.md)                                         | Vector-clock implementation, storage/pruning ownership, and history                                                                               |
 | Contract | [supersync-encryption-architecture.md](./supersync-encryption-architecture.md) | End-to-end encryption wire format, key lifecycle, integrity boundary, and known limitations                                                       |
 | Mixed    | [operation-log-architecture.md](./operation-log-architecture.md)               | Deep rationale and implementation history plus the normative A.7.11 cross-version/schema-bump contract; use executable owners for volatile detail |
+| Triage   | [diagnosing-invalid-file-prefix.md](./diagnosing-invalid-file-prefix.md)       | Decode table for the `InvalidFilePrefixError` log diagnostics (`headShape`, `prefixAt`)                                                           |
 
 ## Executable scenario index
 

--- a/docs/sync-and-op-log/diagnosing-invalid-file-prefix.md
+++ b/docs/sync-and-op-log/diagnosing-invalid-file-prefix.md
@@ -1,0 +1,39 @@
+# Diagnosing `InvalidFilePrefixError` (#9627)
+
+A downloaded sync file must start with the header `pf_[C][E]<modelVersion>__`
+(`C` = compressed, `E` = encrypted). When it does not, the client throws
+`InvalidFilePrefixError`, and the OpLog history (what a user sends as a log
+export) records three fields chosen to answer one question in a single
+round-trip: **was this a bad RESPONSE (server/proxy) or a bad STORED FILE?**
+
+The fields are shapes only — never the file's bytes. The head of a sync file
+is user data.
+
+## Decode table
+
+| Field       | Value    | Read as                                                                                                                                                                                                                                                                                       |
+| ----------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `prefixAt`  | `-1`     | Header gone entirely. Heuristic: a head that lost only its first byte also reads `-1`.                                                                                                                                                                                                        |
+| `prefixAt`  | `>= 0`   | Header present but damaged, or pushed to that offset by prepended junk.                                                                                                                                                                                                                       |
+| `headShape` | `markup` | Bad RESPONSE: proxy or captive-portal HTML, WebDAV multistatus.                                                                                                                                                                                                                               |
+| `headShape` | `base64` | Consistent with our own ciphertext/gzip body missing its header — a STORED-FILE problem. **Not proof**: any long alphanumeric body reads the same; weigh `inputLength` and the provider.                                                                                                      |
+| `headShape` | `json`   | **Ambiguous — do not read as "bad response".** Encryption and compression are both off by default, so an unencrypted stored body IS raw JSON. Resolve with the reporter's sync settings: with encryption or compression ON their body would be `base64`, so `json` then points at a response. |
+| `headShape` | `other`  | Unrecognized or too short to classify (`Unauthorized`, `nginx`). Check `inputLength`.                                                                                                                                                                                                         |
+
+`headShape` cannot separate a head-strip from a larger fragment (both read
+`base64`); nothing local knows the file's expected size.
+
+## Ownership
+
+The interface doc on `SyncFilePrefixInvalidPrefixDetails`
+(`packages/sync-core/src/sync-file-prefix.ts`) is normative; this table is a
+triage summary. The claims are pinned by executable specs: classification in
+`packages/sync-core/tests/sync-file-prefix.spec.ts`, per-config body shape
+against the real encoder in
+`src/app/op-log/encryption/encrypt-and-compress-handler.service.spec.ts`, and
+the OpLog bridge in `src/app/op-log/util/sync-file-prefix.spec.ts`.
+
+Recovery: `SyncWrapperService` surfaces the corrupted-remote snack with a
+force-overwrite action (shared with `JsonParseError`). `.bak` auto-recovery for
+this error is parked in #9682 — a head-strip is not a torn-write shape — with
+explicit merge criteria recorded there.

--- a/packages/sync-core/src/index.ts
+++ b/packages/sync-core/src/index.ts
@@ -34,6 +34,7 @@ export { classifyOpAgainstSyncImport } from './sync-import-filter';
 // Host-configured sync file prefix helpers.
 export { createSyncFilePrefixHelpers } from './sync-file-prefix';
 export type {
+  SyncFileHeadShape,
   SyncFilePrefixInvalidPrefixDetails,
   SyncFilePrefixParams,
   SyncFilePrefixParamsOutput,

--- a/packages/sync-core/src/sync-file-prefix.ts
+++ b/packages/sync-core/src/sync-file-prefix.ts
@@ -49,8 +49,14 @@ export interface SyncFilePrefixInvalidPrefixDetails {
    * What we got instead, as a coarse shape of the body's first bytes.
    *
    * `markup` points at a bad RESPONSE (WebDAV multistatus, a proxy or
-   * captive-portal page). `base64` points at our own ciphertext or gzip with
-   * its header lost, i.e. a problem with the STORED file.
+   * captive-portal page).
+   *
+   * `base64` is CONSISTENT WITH our own ciphertext or gzip having lost its
+   * header, i.e. a problem with the STORED file — but it is not proof. Any
+   * alphanumeric body of at least `MIN_BASE64_HEAD_LENGTH` reads the same
+   * (`ServiceUnavailable`, an opaque token, a bare hex digest). Weigh it
+   * against `inputLength` and the provider before concluding the stored file
+   * is at fault; a response can produce this shape too.
    *
    * `json` is AMBIGUOUS and must not be read as "bad response" on its own:
    * compression and encryption are both opt-in and off by default, and with
@@ -89,10 +95,13 @@ export class SyncFilePrefixVersionError extends Error {
 const DEFAULT_END_SEPARATOR = '__';
 const MODEL_VERSION_PATTERN = /^\d+(?:\.\d+)?$/;
 /**
- * Enough head to classify, and bounded so classification cost does not scale
- * with a multi-MB body. It is NOT what keeps the sample out of the log — that
- * holds because `head` never leaves this function; storing it would leak user
- * data at any length.
+ * Enough head to classify, and bounded so the SHAPE test does not scan a
+ * multi-MB body (the `prefixAt` lookup beside it deliberately does — measured
+ * at ~53ms on a 100MB body, on a path that is already throwing).
+ *
+ * It is NOT what keeps the sample out of the log — that holds because the
+ * slice never leaves this function; storing it would leak user data at any
+ * length.
  */
 const HEAD_SAMPLE_LENGTH = 64;
 /** Canonical base64: padding only at the end, matching what our writers emit. */
@@ -100,8 +109,10 @@ const BASE64_ONLY = /^[A-Za-z0-9+/]+={0,2}$/;
 /**
  * Below this, ordinary words are indistinguishable from base64 — a bare
  * `Unauthorized` or `nginx` body would otherwise read as our own ciphertext,
- * i.e. the exact wrong answer to "response or stored file?". Real heads are a
- * full `HEAD_SAMPLE_LENGTH`, so nothing genuine is lost.
+ * i.e. the exact wrong answer to "response or stored file?". Our real bodies
+ * are far longer (measured: 76 chars gzip-only, 108 encrypted), so nothing
+ * genuine is lost; a body short enough to fall under this is self-evidently a
+ * stub from the `inputLength` recorded beside it.
  */
 const MIN_BASE64_HEAD_LENGTH = 16;
 

--- a/packages/sync-core/src/sync-file-prefix.ts
+++ b/packages/sync-core/src/sync-file-prefix.ts
@@ -33,9 +33,11 @@ export interface SyncFilePrefixInvalidPrefixDetails {
   endSeparator: string;
   inputLength: number;
   /**
-   * Offset of `prefix` within the sampled head, or -1 when absent entirely.
-   * Separates "header damaged" (>= 0) from "header gone" (-1) — different
-   * causes, and the log could not previously tell them apart (#9627).
+   * Offset of `prefix` within the sampled head, or -1 when it does not occur
+   * there. Separates "header damaged" (>= 0) from "header gone" (-1) —
+   * different causes, and the log could not previously tell them apart
+   * (#9627). Bounded by the sample, so a prefix pushed past
+   * `HEAD_SAMPLE_LENGTH` by prepended junk also reads as -1.
    */
   prefixAt: number;
   /**
@@ -78,10 +80,13 @@ const HEAD_SAMPLE_LENGTH = 64;
 const BASE64_ONLY = /^[A-Za-z0-9+/=]+$/;
 
 const classifyHead = (head: string): SyncFileHeadShape => {
+  // One trimmed view for all three tests: checking markup/json trimmed but
+  // base64 untrimmed would classify a whitespace-prefixed ciphertext body as
+  // `other`, which reads as "unrecognized" when we do in fact recognize it.
   const trimmed = head.trimStart();
   if (trimmed.startsWith('<')) return 'markup';
   if (trimmed.startsWith('{') || trimmed.startsWith('[')) return 'json';
-  return BASE64_ONLY.test(head) ? 'base64' : 'other';
+  return BASE64_ONLY.test(trimmed) ? 'base64' : 'other';
 };
 
 const escapeRegExp = (value: string): string =>

--- a/packages/sync-core/src/sync-file-prefix.ts
+++ b/packages/sync-core/src/sync-file-prefix.ts
@@ -33,18 +33,31 @@ export interface SyncFilePrefixInvalidPrefixDetails {
   endSeparator: string;
   inputLength: number;
   /**
-   * Offset of `prefix` within the sampled head, or -1 when it does not occur
-   * there. Separates "header damaged" (>= 0) from "header gone" (-1) —
-   * different causes, and the log could not previously tell them apart
-   * (#9627). Bounded by the sample, so a prefix pushed past
-   * `HEAD_SAMPLE_LENGTH` by prepended junk also reads as -1.
+   * Offset of `prefix` anywhere in the body, or -1 when it does not occur at
+   * all. Separates "header damaged" (>= 0) from "header gone" (-1) — different
+   * causes, and the log could not previously tell them apart (#9627). Searched
+   * over the whole body rather than the head sample: the result is an integer
+   * offset either way, so the bound bought no privacy and only conflated
+   * "prefix pushed past the sample by prepended junk" with "prefix absent".
+   *
+   * A heuristic, not a proof: a head that lost only its first byte reads as -1
+   * ("gone") though it is merely damaged, and any body that happens to contain
+   * `pf_` reads >= 0.
    */
   prefixAt: number;
   /**
-   * What we got instead. `markup`/`json` point at a bad RESPONSE (proxy page,
-   * WebDAV multistatus, error envelope); `base64` points at our own ciphertext
-   * with its header lost, i.e. a problem with the STORED file. That is the
-   * distinction that decides whether a decode failure is a transport issue.
+   * What we got instead, as a coarse shape of the body's first bytes.
+   *
+   * `markup` points at a bad RESPONSE (WebDAV multistatus, a proxy or
+   * captive-portal page). `base64` points at our own ciphertext or gzip with
+   * its header lost, i.e. a problem with the STORED file.
+   *
+   * `json` is AMBIGUOUS and must not be read as "bad response" on its own:
+   * compression and encryption are both opt-in and off by default, and with
+   * neither enabled our own stored body IS `JSON.stringify(data)`. So `json`
+   * means either an error envelope OR our own plaintext file with the header
+   * lost. Resolve it with the reporter's sync settings — with encryption or
+   * compression ON, our body would be `base64`, so `json` is then a response.
    *
    * It does NOT separate a head-strip from a larger fragment — both read as
    * `base64` — since nothing local knows the file's expected size.
@@ -75,9 +88,22 @@ export class SyncFilePrefixVersionError extends Error {
 
 const DEFAULT_END_SEPARATOR = '__';
 const MODEL_VERSION_PATTERN = /^\d+(?:\.\d+)?$/;
-/** Enough head to classify; short enough that no sample is ever retained. */
+/**
+ * Enough head to classify, and bounded so classification cost does not scale
+ * with a multi-MB body. It is NOT what keeps the sample out of the log — that
+ * holds because `head` never leaves this function; storing it would leak user
+ * data at any length.
+ */
 const HEAD_SAMPLE_LENGTH = 64;
-const BASE64_ONLY = /^[A-Za-z0-9+/=]+$/;
+/** Canonical base64: padding only at the end, matching what our writers emit. */
+const BASE64_ONLY = /^[A-Za-z0-9+/]+={0,2}$/;
+/**
+ * Below this, ordinary words are indistinguishable from base64 — a bare
+ * `Unauthorized` or `nginx` body would otherwise read as our own ciphertext,
+ * i.e. the exact wrong answer to "response or stored file?". Real heads are a
+ * full `HEAD_SAMPLE_LENGTH`, so nothing genuine is lost.
+ */
+const MIN_BASE64_HEAD_LENGTH = 16;
 
 const classifyHead = (head: string): SyncFileHeadShape => {
   // One trimmed view for all three tests: checking markup/json trimmed but
@@ -86,7 +112,9 @@ const classifyHead = (head: string): SyncFileHeadShape => {
   const trimmed = head.trimStart();
   if (trimmed.startsWith('<')) return 'markup';
   if (trimmed.startsWith('{') || trimmed.startsWith('[')) return 'json';
-  return BASE64_ONLY.test(trimmed) ? 'base64' : 'other';
+  return trimmed.length >= MIN_BASE64_HEAD_LENGTH && BASE64_ONLY.test(trimmed)
+    ? 'base64'
+    : 'other';
 };
 
 const escapeRegExp = (value: string): string =>
@@ -133,13 +161,12 @@ export const createSyncFilePrefixHelpers = ({
     extractSyncFileStateFromPrefix: (dataStr: string): SyncFilePrefixParamsOutput => {
       const match = dataStr.match(prefixRegex);
       if (!match) {
-        const head = dataStr.slice(0, HEAD_SAMPLE_LENGTH);
         const details: SyncFilePrefixInvalidPrefixDetails = {
           expectedPrefix: prefix,
           endSeparator,
           inputLength: dataStr.length,
-          prefixAt: head.indexOf(prefix),
-          headShape: classifyHead(head),
+          prefixAt: dataStr.indexOf(prefix),
+          headShape: classifyHead(dataStr.slice(0, HEAD_SAMPLE_LENGTH)),
         };
         throw createInvalidPrefixError?.(details) ?? new SyncFilePrefixError(details);
       }

--- a/packages/sync-core/src/sync-file-prefix.ts
+++ b/packages/sync-core/src/sync-file-prefix.ts
@@ -22,10 +22,32 @@ export interface SyncFilePrefixConfig {
   createInvalidPrefixError?: (details: SyncFilePrefixInvalidPrefixDetails) => Error;
 }
 
+/**
+ * Coarse character class of a rejected file's head. Deliberately an enum of
+ * shapes, never the bytes themselves — the head of a sync file is user data.
+ */
+export type SyncFileHeadShape = 'base64' | 'markup' | 'json' | 'other';
+
 export interface SyncFilePrefixInvalidPrefixDetails {
   expectedPrefix: string;
   endSeparator: string;
   inputLength: number;
+  /**
+   * Offset of `prefix` within the sampled head, or -1 when absent entirely.
+   * Separates "header damaged" (>= 0) from "header gone" (-1) — different
+   * causes, and the log could not previously tell them apart (#9627).
+   */
+  prefixAt: number;
+  /**
+   * What we got instead. `markup`/`json` point at a bad RESPONSE (proxy page,
+   * WebDAV multistatus, error envelope); `base64` points at our own ciphertext
+   * with its header lost, i.e. a problem with the STORED file. That is the
+   * distinction that decides whether a decode failure is a transport issue.
+   *
+   * It does NOT separate a head-strip from a larger fragment — both read as
+   * `base64` — since nothing local knows the file's expected size.
+   */
+  headShape: SyncFileHeadShape;
 }
 
 export class SyncFilePrefixError extends Error {
@@ -51,6 +73,16 @@ export class SyncFilePrefixVersionError extends Error {
 
 const DEFAULT_END_SEPARATOR = '__';
 const MODEL_VERSION_PATTERN = /^\d+(?:\.\d+)?$/;
+/** Enough head to classify; short enough that no sample is ever retained. */
+const HEAD_SAMPLE_LENGTH = 64;
+const BASE64_ONLY = /^[A-Za-z0-9+/=]+$/;
+
+const classifyHead = (head: string): SyncFileHeadShape => {
+  const trimmed = head.trimStart();
+  if (trimmed.startsWith('<')) return 'markup';
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) return 'json';
+  return BASE64_ONLY.test(head) ? 'base64' : 'other';
+};
 
 const escapeRegExp = (value: string): string =>
   value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -96,10 +128,13 @@ export const createSyncFilePrefixHelpers = ({
     extractSyncFileStateFromPrefix: (dataStr: string): SyncFilePrefixParamsOutput => {
       const match = dataStr.match(prefixRegex);
       if (!match) {
+        const head = dataStr.slice(0, HEAD_SAMPLE_LENGTH);
         const details: SyncFilePrefixInvalidPrefixDetails = {
           expectedPrefix: prefix,
           endSeparator,
           inputLength: dataStr.length,
+          prefixAt: head.indexOf(prefix),
+          headShape: classifyHead(head),
         };
         throw createInvalidPrefixError?.(details) ?? new SyncFilePrefixError(details);
       }

--- a/packages/sync-core/tests/sync-file-prefix.spec.ts
+++ b/packages/sync-core/tests/sync-file-prefix.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createSyncFilePrefixHelpers } from '../src';
+import type { SyncFilePrefixInvalidPrefixDetails } from '../src';
 import { SyncFilePrefixError, SyncFilePrefixVersionError } from '../src/sync-file-prefix';
 
 describe('createSyncFilePrefixHelpers', () => {
@@ -93,22 +94,28 @@ describe('createSyncFilePrefixHelpers', () => {
   // RESPONSE or a bad STORED FILE. These pin the classification, which is the
   // whole point of the diagnostic.
   describe('head-shape diagnostics (#9627)', () => {
-    const detailsFor = (dataStr: string): Record<string, unknown> => {
-      let received: Record<string, unknown> = {};
+    // Synthetic stand-in for the reporter's ciphertext head. Same shape (plain
+    // base64, no padding, longer than MIN_BASE64_HEAD_LENGTH) without copying a
+    // user's bytes into source control.
+    const CIPHERTEXT_HEAD = 'QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWY';
+
+    const detailsFor = (dataStr: string): SyncFilePrefixInvalidPrefixDetails => {
+      let received: SyncFilePrefixInvalidPrefixDetails | undefined;
       const helpers = createSyncFilePrefixHelpers({
         prefix: 'pf_',
         createInvalidPrefixError: (details) => {
-          received = details as unknown as Record<string, unknown>;
+          received = details;
           return new Error('invalid');
         },
       });
       expect(() => helpers.extractSyncFileStateFromPrefix(dataStr)).toThrow();
-      return received;
+      expect(received).toBeDefined();
+      return received!;
     };
 
     it('reads our own ciphertext with a lost header as base64 + no prefix', () => {
-      // The exact #9627 shape: encrypted payload intact, `pf_...__` head gone.
-      expect(detailsFor('41J7VJwUqK/0k436aSIRL5utdxhyV6WhXWSguANW')).toMatchObject({
+      // The #9627 shape: encrypted payload intact, `pf_...__` head gone.
+      expect(detailsFor(CIPHERTEXT_HEAD)).toMatchObject({
         headShape: 'base64',
         prefixAt: -1,
       });
@@ -130,10 +137,28 @@ describe('createSyncFilePrefixHelpers', () => {
       expect(detailsFor('[1,2,3]')).toMatchObject({ headShape: 'json' });
     });
 
+    it('also reads our own PLAINTEXT body as json — the shape is ambiguous', () => {
+      // Compression and encryption are both off by default, so an unencrypted
+      // stored file is raw JSON and is indistinguishable here from an error
+      // envelope. Pinned so nobody reads `json` as "definitely a bad response";
+      // the interface doc says to resolve it with the reporter's sync settings.
+      expect(detailsFor('{"version":2,"lastUpdate":123,"ops":[]}')).toMatchObject({
+        headShape: 'json',
+      });
+    });
+
+    it('does not mistake a short plaintext error body for our ciphertext', () => {
+      // Bare alphabetic bodies are valid base64 by alphabet alone. Calling them
+      // `base64` would point the reader at the STORED file when the truth is a
+      // bad RESPONSE — the exact inversion the diagnostic exists to prevent.
+      expect(detailsFor('Unauthorized').headShape).toBe('other');
+      expect(detailsFor('nginx').headShape).toBe('other');
+    });
+
     it('still recognizes ciphertext when the body has leading whitespace', () => {
       // All three tests read the same trimmed view; classifying markup/json
       // trimmed but base64 raw would demote this to `other`.
-      expect(detailsFor('  41J7VJwUqK/0k436aSIRL5utdxhyV6WhXWSguANW')).toMatchObject({
+      expect(detailsFor(`  ${CIPHERTEXT_HEAD}`)).toMatchObject({
         headShape: 'base64',
       });
     });
@@ -144,10 +169,18 @@ describe('createSyncFilePrefixHelpers', () => {
       expect(detailsFor('pf_E2_payload')).toMatchObject({ prefixAt: 0 });
     });
 
+    it('finds a prefix pushed past the head sample by prepended junk', () => {
+      // prefixAt searches the whole body: bounding it to the 64-char sample
+      // reported -1 here, conflating "junk prepended" with "prefix absent".
+      expect(detailsFor(`${'x'.repeat(70)}pf_CE2__{}`)).toMatchObject({
+        prefixAt: 70,
+      });
+    });
+
     it('samples only the head, so a long body cannot bloat the diagnostic', () => {
       const details = detailsFor('<html>' + 'x'.repeat(5000));
-      expect(details['headShape']).toBe('markup');
-      expect(details['inputLength']).toBe(5006);
+      expect(details.headShape).toBe('markup');
+      expect(details.inputLength).toBe(5006);
       // No field carries the payload itself.
       expect(JSON.stringify(details)).not.toContain('xxxx');
     });

--- a/packages/sync-core/tests/sync-file-prefix.spec.ts
+++ b/packages/sync-core/tests/sync-file-prefix.spec.ts
@@ -82,6 +82,66 @@ describe('createSyncFilePrefixHelpers', () => {
       expectedPrefix: 'pf_',
       endSeparator: '__',
       inputLength: 'bad secret payload'.length,
+      prefixAt: -1,
+      headShape: 'other',
+    });
+  });
+
+  // #9627: the details said how long the body was and what we expected, but
+  // nothing about what we actually got — so a single field report cost five
+  // round-trips and still did not settle whether the failure was a bad
+  // RESPONSE or a bad STORED FILE. These pin the classification, which is the
+  // whole point of the diagnostic.
+  describe('head-shape diagnostics (#9627)', () => {
+    const detailsFor = (dataStr: string): Record<string, unknown> => {
+      let received: Record<string, unknown> = {};
+      const helpers = createSyncFilePrefixHelpers({
+        prefix: 'pf_',
+        createInvalidPrefixError: (details) => {
+          received = details as unknown as Record<string, unknown>;
+          return new Error('invalid');
+        },
+      });
+      expect(() => helpers.extractSyncFileStateFromPrefix(dataStr)).toThrow();
+      return received;
+    };
+
+    it('reads our own ciphertext with a lost header as base64 + no prefix', () => {
+      // The exact #9627 shape: encrypted payload intact, `pf_...__` head gone.
+      expect(detailsFor('41J7VJwUqK/0k436aSIRL5utdxhyV6WhXWSguANW')).toMatchObject({
+        headShape: 'base64',
+        prefixAt: -1,
+      });
+    });
+
+    it('reads a proxy page / WebDAV multistatus as markup', () => {
+      expect(detailsFor('<?xml version="1.0"?><d:multistatus/>')).toMatchObject({
+        headShape: 'markup',
+      });
+      expect(detailsFor('<!DOCTYPE html><html>login</html>')).toMatchObject({
+        headShape: 'markup',
+      });
+    });
+
+    it('reads an error envelope as json', () => {
+      expect(detailsFor('{"error":"unauthorized"}')).toMatchObject({
+        headShape: 'json',
+      });
+      expect(detailsFor('[1,2,3]')).toMatchObject({ headShape: 'json' });
+    });
+
+    it('reports the offset when the header is DAMAGED rather than missing', () => {
+      // `pf_` still there, separator gone. Different cause from a head-strip,
+      // and prefixAt is the only thing that tells them apart.
+      expect(detailsFor('pf_E2_payload')).toMatchObject({ prefixAt: 0 });
+    });
+
+    it('samples only the head, so a long body cannot bloat the diagnostic', () => {
+      const details = detailsFor('<html>' + 'x'.repeat(5000));
+      expect(details['headShape']).toBe('markup');
+      expect(details['inputLength']).toBe(5006);
+      // No field carries the payload itself.
+      expect(JSON.stringify(details)).not.toContain('xxxx');
     });
   });
 

--- a/packages/sync-core/tests/sync-file-prefix.spec.ts
+++ b/packages/sync-core/tests/sync-file-prefix.spec.ts
@@ -147,6 +147,12 @@ describe('createSyncFilePrefixHelpers', () => {
       });
     });
 
+    it('rejects non-canonical base64 with padding in the middle', () => {
+      // Our writers use btoa, which pads only at the end. A body with `=`
+      // mid-string is something else (`status=failedauth`), not our payload.
+      expect(detailsFor('AAAA=BBBB=CCCC=DD').headShape).toBe('other');
+    });
+
     it('does not mistake a short plaintext error body for our ciphertext', () => {
       // Bare alphabetic bodies are valid base64 by alphabet alone. Calling them
       // `base64` would point the reader at the STORED file when the truth is a

--- a/packages/sync-core/tests/sync-file-prefix.spec.ts
+++ b/packages/sync-core/tests/sync-file-prefix.spec.ts
@@ -130,6 +130,14 @@ describe('createSyncFilePrefixHelpers', () => {
       expect(detailsFor('[1,2,3]')).toMatchObject({ headShape: 'json' });
     });
 
+    it('still recognizes ciphertext when the body has leading whitespace', () => {
+      // All three tests read the same trimmed view; classifying markup/json
+      // trimmed but base64 raw would demote this to `other`.
+      expect(detailsFor('  41J7VJwUqK/0k436aSIRL5utdxhyV6WhXWSguANW')).toMatchObject({
+        headShape: 'base64',
+      });
+    });
+
     it('reports the offset when the header is DAMAGED rather than missing', () => {
       // `pf_` still there, separator gone. Different cause from a head-strip,
       // and prefixAt is the only thing that tells them apart.

--- a/src/app/imex/sync/sync-wrapper.service.spec.ts
+++ b/src/app/imex/sync/sync-wrapper.service.spec.ts
@@ -1924,6 +1924,8 @@ describe('SyncWrapperService', () => {
             expectedPrefix: 'pf_',
             endSeparator: '__',
             inputLength: 294912,
+            prefixAt: -1,
+            headShape: 'base64',
           }),
         ),
       );

--- a/src/app/imex/sync/sync-wrapper.service.spec.ts
+++ b/src/app/imex/sync/sync-wrapper.service.spec.ts
@@ -1942,6 +1942,15 @@ describe('SyncWrapperService', () => {
           actionStr: jasmine.any(String),
         }),
       );
+
+      // The branch is shared with JsonParseError, so the trigger label is the
+      // only thing distinguishing the two in the log. Invoke the action rather
+      // than asserting `jasmine.any(Function)` — otherwise a label regression
+      // (both reporting 'JsonParseError') passes silently.
+      const forceUploadSpy = spyOn(service, 'forceUpload').and.resolveTo(undefined);
+      const openedSnack = mockSnackService.open.calls.mostRecent().args[0] as SnackParams;
+      await (openedSnack.actionFn as (() => Promise<void>) | undefined)?.();
+      expect(forceUploadSpy).toHaveBeenCalledWith('InvalidFilePrefixError');
     });
 
     it('should handle SyncDataCorruptedError with version-mismatch message (no force-overwrite)', async () => {

--- a/src/app/imex/sync/sync-wrapper.service.spec.ts
+++ b/src/app/imex/sync/sync-wrapper.service.spec.ts
@@ -38,6 +38,7 @@ import {
   LocalDataConflictError,
   LockAcquisitionTimeoutError,
   MissingRefreshTokenAPIError,
+  InvalidFilePrefixError,
   JsonParseError,
   SyncDataCorruptedError,
   UploadRevToMatchMismatchAPIError,
@@ -1894,6 +1895,37 @@ describe('SyncWrapperService', () => {
     it('should handle JsonParseError with force-overwrite action and corrupted-data message (#5574, #4616)', async () => {
       mockSyncService.downloadRemoteOps.and.returnValue(
         Promise.reject(new JsonParseError(new SyntaxError('Unexpected end of JSON'), '')),
+      );
+
+      const result = await service.sync();
+
+      expect(result).toBe('HANDLED_ERROR');
+      expect(mockProviderManager.setSyncStatus).toHaveBeenCalledWith('ERROR');
+      expect(mockSnackService.open).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          msg: T.F.SYNC.S.ERROR_REMOTE_FILE_CORRUPTED,
+          type: 'ERROR',
+          actionFn: jasmine.any(Function),
+          actionStr: jasmine.any(String),
+        }),
+      );
+    });
+
+    it('should handle InvalidFilePrefixError with force-overwrite action and corrupted-data message (#9627)', async () => {
+      // The remote file's head is not `pf_...__`, so it is rejected before the
+      // decrypt/decompress/JSON stages its siblings cover. Same user-facing
+      // situation as JsonParseError and EmptyRemoteBodySPError — remote is
+      // unreadable, local data is intact — so it gets the same actionable snack
+      // instead of falling through to the generic handler, which surfaced the
+      // raw internal message that became this issue's title.
+      mockSyncService.downloadRemoteOps.and.returnValue(
+        Promise.reject(
+          new InvalidFilePrefixError({
+            expectedPrefix: 'pf_',
+            endSeparator: '__',
+            inputLength: 294912,
+          }),
+        ),
       );
 
       const result = await service.sync();

--- a/src/app/imex/sync/sync-wrapper.service.ts
+++ b/src/app/imex/sync/sync-wrapper.service.ts
@@ -941,30 +941,29 @@ export class SyncWrapperService {
         });
         return 'HANDLED_ERROR';
       } else if (
+        // InvalidFilePrefixError: the remote file's head is not `pf_[C][E]<v>__`,
+        // so it is rejected before the decrypt/decompress/JSON stages — but the
+        // user's situation is identical to JsonParseError's: remote unreadable,
+        // local intact. Without it, that error fell through to the generic
+        // handler and surfaced the raw internal message (verbatim the title of
+        // #9627) with no way forward. See PR #9682 for why .bak recovery is
+        // deliberately NOT extended to it.
         error instanceof JsonParseError ||
-        // The remote file's head is not `pf_[C][E]<v>__`, so it is rejected
-        // before the decrypt/decompress/JSON stages — but the user's situation
-        // is identical to its siblings above: remote unreadable, local intact.
-        // Without this branch it fell through to the generic handler and
-        // surfaced the raw internal message ("Invalid sync file prefix...",
-        // verbatim the title of #9627) with no way forward. Force overwrite is
-        // what actually unblocked that reporter.
         error instanceof InvalidFilePrefixError
       ) {
         // Remote JSON is unparseable (e.g. truncated write, encoding issue).
         // Force overwrite is safe: local data is intact, remote cannot be parsed.
         // Issues: #5574, #4616, #9627.
+        const forceUploadSource: ForceUploadTriggerSource =
+          error instanceof InvalidFilePrefixError
+            ? 'InvalidFilePrefixError'
+            : 'JsonParseError';
         this._providerManager.setSyncStatus('ERROR');
         this._snackService.open({
           msg: T.F.SYNC.S.ERROR_REMOTE_FILE_CORRUPTED,
           type: 'ERROR',
           config: { duration: 12000 },
-          actionFn: async () =>
-            this.forceUpload(
-              error instanceof InvalidFilePrefixError
-                ? 'InvalidFilePrefixError'
-                : 'JsonParseError',
-            ),
+          actionFn: async () => this.forceUpload(forceUploadSource),
           actionStr: T.F.SYNC.S.BTN_FORCE_OVERWRITE,
         });
         return 'HANDLED_ERROR';

--- a/src/app/imex/sync/sync-wrapper.service.ts
+++ b/src/app/imex/sync/sync-wrapper.service.ts
@@ -19,6 +19,7 @@ import {
   MissingRefreshTokenAPIError,
   HttpNotOkAPIError,
   EmptyRemoteBodySPError,
+  InvalidFilePrefixError,
   JsonParseError,
   LegacySyncFormatDetectedError,
   IncompleteRemoteOperationsError,
@@ -94,6 +95,7 @@ type CompletedUploadOutcome = Extract<UploadOutcome, { kind: 'completed' }>;
  */
 export type ForceUploadTriggerSource =
   | 'EmptyRemoteBodySPError'
+  | 'InvalidFilePrefixError'
   | 'JsonParseError'
   | 'LegacySyncFormatDetectedError'
   | 'DecryptError'
@@ -938,16 +940,31 @@ export class SyncWrapperService {
           actionStr: T.F.SYNC.S.BTN_FORCE_OVERWRITE,
         });
         return 'HANDLED_ERROR';
-      } else if (error instanceof JsonParseError) {
+      } else if (
+        error instanceof JsonParseError ||
+        // The remote file's head is not `pf_[C][E]<v>__`, so it is rejected
+        // before the decrypt/decompress/JSON stages — but the user's situation
+        // is identical to its siblings above: remote unreadable, local intact.
+        // Without this branch it fell through to the generic handler and
+        // surfaced the raw internal message ("Invalid sync file prefix...",
+        // verbatim the title of #9627) with no way forward. Force overwrite is
+        // what actually unblocked that reporter.
+        error instanceof InvalidFilePrefixError
+      ) {
         // Remote JSON is unparseable (e.g. truncated write, encoding issue).
         // Force overwrite is safe: local data is intact, remote cannot be parsed.
-        // Issues: #5574, #4616.
+        // Issues: #5574, #4616, #9627.
         this._providerManager.setSyncStatus('ERROR');
         this._snackService.open({
           msg: T.F.SYNC.S.ERROR_REMOTE_FILE_CORRUPTED,
           type: 'ERROR',
           config: { duration: 12000 },
-          actionFn: async () => this.forceUpload('JsonParseError'),
+          actionFn: async () =>
+            this.forceUpload(
+              error instanceof InvalidFilePrefixError
+                ? 'InvalidFilePrefixError'
+                : 'JsonParseError',
+            ),
           actionStr: T.F.SYNC.S.BTN_FORCE_OVERWRITE,
         });
         return 'HANDLED_ERROR';

--- a/src/app/imex/sync/sync-wrapper.service.ts
+++ b/src/app/imex/sync/sync-wrapper.service.ts
@@ -946,8 +946,15 @@ export class SyncWrapperService {
         // user's situation is identical to JsonParseError's: remote unreadable,
         // local intact. Without it, that error fell through to the generic
         // handler and surfaced the raw internal message (verbatim the title of
-        // #9627) with no way forward. See PR #9682 for why .bak recovery is
-        // deliberately NOT extended to it.
+        // #9627) with no way forward.
+        //
+        // #9682 initially excluded this branch, arguing that if a server-side
+        // transformation strips the header, force upload just recreates the
+        // broken state. Reversed because the #9627 reporter was in fact
+        // unblocked by force upload. That PR — which would have extended .bak
+        // auto-recovery here — is parked, not declined: a head-strip is not a
+        // shape a torn write produces, so .bak recovery is a poor fit, but it
+        // has explicit merge criteria. Revisit this branch alongside it.
         error instanceof JsonParseError ||
         error instanceof InvalidFilePrefixError
       ) {

--- a/src/app/op-log/core/errors/sync-errors.spec.ts
+++ b/src/app/op-log/core/errors/sync-errors.spec.ts
@@ -37,6 +37,8 @@ describe('sync errors', () => {
       expectedPrefix: 'pf_',
       endSeparator: '__',
       inputLength: 42,
+      prefixAt: -1,
+      headShape: 'base64',
     });
 
     expect((OpLog.log as jasmine.Spy).calls.count()).toBe(0);

--- a/src/app/op-log/core/errors/sync-errors.ts
+++ b/src/app/op-log/core/errors/sync-errors.ts
@@ -477,6 +477,8 @@ export class InvalidFilePrefixError extends AdditionalLogErrorBase {
       expectedPrefix: details.expectedPrefix,
       endSeparator: details.endSeparator,
       inputLength: details.inputLength,
+      prefixAt: details.prefixAt,
+      headShape: details.headShape,
     });
   }
 }

--- a/src/app/op-log/encryption/encrypt-and-compress-handler.service.spec.ts
+++ b/src/app/op-log/encryption/encrypt-and-compress-handler.service.spec.ts
@@ -4,9 +4,15 @@ import {
   DecryptNoPasswordError,
   EncryptNoPasswordError,
   extractErrorMessage,
+  InvalidFilePrefixError,
   JsonParseError,
   PlaintextWhenEncryptionExpectedError,
 } from '../core/errors/sync-errors';
+import {
+  extractSyncFileStateFromPrefix,
+  getSyncFilePrefix,
+} from '../util/sync-file-prefix';
+import { clearSessionKeyCache, setArgon2ParamsForTesting } from '@sp/sync-core';
 import { EncryptAndCompressHandlerService } from './encrypt-and-compress-handler.service';
 import { getErrorTxt } from '../../util/get-error-text';
 
@@ -377,6 +383,88 @@ describe('JsonParseError', () => {
     expect(error.position).toBe(1000);
     // dataSample should still be set but truncated to actual data length
     expect(error.dataSample).toBeDefined();
+  });
+});
+
+// #9627: `headShape` tells a maintainer reading a log export whether a decode
+// failure was a bad RESPONSE or a bad STORED FILE. Its interface doc states what
+// OUR OWN body looks like per config — a claim about this encoder. Pin it to the
+// encoder's real output rather than to hand-written fixtures, so the doc cannot
+// drift from what we actually write.
+describe('head-shape of a real encoded body with its header stripped (#9627)', () => {
+  let service: EncryptAndCompressHandlerService;
+
+  beforeEach(() => {
+    service = new EncryptAndCompressHandlerService();
+    spyOn(OpLog, 'log').and.stub();
+    spyOn(OpLog, 'normal').and.stub();
+    // Same downshift the other real-crypto specs use: this asserts a body
+    // SHAPE, not KDF strength, and production Argon2id costs ~190ms and 64MiB
+    // per encrypted case in the browser runner.
+    setArgon2ParamsForTesting({ parallelism: 1, memorySize: 8, iterations: 1 });
+  });
+
+  afterEach(() => {
+    setArgon2ParamsForTesting();
+    clearSessionKeyCache();
+  });
+
+  /** Encodes for real, drops the `pf_…__` head, and reports what we see instead. */
+  const shapeOfHeadlessBody = async (cfg: {
+    isCompress: boolean;
+    isEncrypt: boolean;
+  }): Promise<{ headShape: unknown; prefixAt: unknown }> => {
+    const modelVersion = 1;
+    const encoded = await service.compressAndEncrypt({
+      data: { version: 2, ops: [], lastUpdate: 1 },
+      modelVersion,
+      isCompress: cfg.isCompress,
+      isEncrypt: cfg.isEncrypt,
+      encryptKey: cfg.isEncrypt ? 'the-key' : undefined,
+    });
+    // Strip exactly the prefix the writer produced. Deriving the length from
+    // getSyncFilePrefix (rather than scanning for `__`) means a change to the
+    // header format breaks this loudly instead of silently asserting the shape
+    // of the wrong bytes — which is the contract this block exists to pin.
+    const prefix = getSyncFilePrefix({
+      isCompress: cfg.isCompress,
+      isEncrypt: cfg.isEncrypt,
+      modelVersion,
+    });
+    expect(encoded.startsWith(prefix)).toBe(true);
+    const body = encoded.slice(prefix.length);
+    expect(body.length).toBeGreaterThan(0);
+
+    expect(() => extractSyncFileStateFromPrefix(body)).toThrowError(
+      InvalidFilePrefixError,
+    );
+    const meta = (OpLog.log as jasmine.Spy).calls.mostRecent().args[1];
+    return { headShape: meta.headShape, prefixAt: meta.prefixAt };
+  };
+
+  it('reads an ENCRYPTED body as base64 — the #9627 reporter shape', async () => {
+    expect(await shapeOfHeadlessBody({ isCompress: false, isEncrypt: true })).toEqual({
+      headShape: 'base64',
+      prefixAt: -1,
+    });
+  });
+
+  it('reads a COMPRESSED body as base64', async () => {
+    // compressWithGzipToString base64-encodes, so compression alone is enough.
+    expect(await shapeOfHeadlessBody({ isCompress: true, isEncrypt: false })).toEqual({
+      headShape: 'base64',
+      prefixAt: -1,
+    });
+  });
+
+  it('reads a PLAINTEXT body as json — which is why `json` is ambiguous', async () => {
+    // Both flags are off by DEFAULT, so this is the common configuration: our
+    // own stored file is raw JSON and is indistinguishable here from an error
+    // envelope. Reading `json` as "bad response" would invert the answer.
+    expect(await shapeOfHeadlessBody({ isCompress: false, isEncrypt: false })).toEqual({
+      headShape: 'json',
+      prefixAt: -1,
+    });
   });
 });
 

--- a/src/app/op-log/util/sync-file-prefix.spec.ts
+++ b/src/app/op-log/util/sync-file-prefix.spec.ts
@@ -14,7 +14,10 @@ describe('sync-file-prefix app shim', () => {
       InvalidFilePrefixError,
     );
 
-    const logText = (OpLog.log as jasmine.Spy).calls.allArgs().flat().join('\n');
+    // JSON.stringify, not join(): the structured meta arg stringifies to
+    // `[object Object]` under join, so a payload leaked into it would pass
+    // unseen — and the meta is exactly where the diagnostic fields live.
+    const logText = JSON.stringify((OpLog.log as jasmine.Spy).calls.allArgs());
     expect(logText).toContain('inputLength');
     expect(logText).not.toContain('secret task');
     expect(logText).not.toContain(rawPayload);
@@ -24,12 +27,14 @@ describe('sync-file-prefix app shim', () => {
   // this shim owns is the bridge — the diagnostic is worthless if it never
   // reaches the exportable OpLog history a user actually sends us.
   it('carries the head-shape diagnostic into the OpLog history', () => {
+    // Synthetic stand-in for a ciphertext head — same shape, none of a user's
+    // bytes. Classification itself is pinned in @sp/sync-core's spec.
     expect(() =>
-      extractSyncFileStateFromPrefix('41J7VJwUqK/0k436aSIRL5utdxhyV6WhXWSguANW'),
+      extractSyncFileStateFromPrefix('QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWY'),
     ).toThrowError(InvalidFilePrefixError);
 
     const [message, meta] = (OpLog.log as jasmine.Spy).calls.mostRecent().args;
-    // Inlined in the message too, so it survives positional serialization.
+    // Also inlined in the message so the line greps as one unit in a console.
     expect(message).toContain('headShape="base64"');
     expect(message).toContain('prefixAt=-1');
     expect(meta).toEqual(jasmine.objectContaining({ headShape: 'base64', prefixAt: -1 }));

--- a/src/app/op-log/util/sync-file-prefix.spec.ts
+++ b/src/app/op-log/util/sync-file-prefix.spec.ts
@@ -19,4 +19,19 @@ describe('sync-file-prefix app shim', () => {
     expect(logText).not.toContain('secret task');
     expect(logText).not.toContain(rawPayload);
   });
+
+  // #9627: classification itself is pinned in @sp/sync-core's own spec. What
+  // this shim owns is the bridge — the diagnostic is worthless if it never
+  // reaches the exportable OpLog history a user actually sends us.
+  it('carries the head-shape diagnostic into the OpLog history', () => {
+    expect(() =>
+      extractSyncFileStateFromPrefix('41J7VJwUqK/0k436aSIRL5utdxhyV6WhXWSguANW'),
+    ).toThrowError(InvalidFilePrefixError);
+
+    const [message, meta] = (OpLog.log as jasmine.Spy).calls.mostRecent().args;
+    // Inlined in the message too, so it survives positional serialization.
+    expect(message).toContain('headShape="base64"');
+    expect(message).toContain('prefixAt=-1');
+    expect(meta).toEqual(jasmine.objectContaining({ headShape: 'base64', prefixAt: -1 }));
+  });
 });

--- a/src/app/op-log/util/sync-file-prefix.spec.ts
+++ b/src/app/op-log/util/sync-file-prefix.spec.ts
@@ -14,10 +14,16 @@ describe('sync-file-prefix app shim', () => {
       InvalidFilePrefixError,
     );
 
-    // JSON.stringify, not join(): the structured meta arg stringifies to
-    // `[object Object]` under join, so a payload leaked into it would pass
-    // unseen — and the meta is exactly where the diagnostic fields live.
-    const logText = JSON.stringify((OpLog.log as jasmine.Spy).calls.allArgs());
+    // Stringify each arg individually: a bare join() renders the structured
+    // meta as `[object Object]` (hiding a leak into the very object the
+    // diagnostic fields live in), while a single JSON.stringify over the whole
+    // array escapes the quotes in `rawPayload` so that assertion could never
+    // fail. Per-arg keeps string args verbatim and still sees inside the meta.
+    const logText = (OpLog.log as jasmine.Spy).calls
+      .allArgs()
+      .flat()
+      .map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg)))
+      .join('\n');
     expect(logText).toContain('inputLength');
     expect(logText).not.toContain('secret task');
     expect(logText).not.toContain(rawPayload);

--- a/src/app/op-log/util/sync-file-prefix.ts
+++ b/src/app/op-log/util/sync-file-prefix.ts
@@ -20,11 +20,15 @@ const syncFilePrefixHelpers = createSyncFilePrefixHelpers({
     OpLog.log(
       `InvalidFilePrefixError (inputLength=${details.inputLength}, ` +
         `expectedPrefix="${details.expectedPrefix}", ` +
-        `endSeparator="${details.endSeparator}")`,
+        `endSeparator="${details.endSeparator}", ` +
+        `prefixAt=${details.prefixAt}, ` +
+        `headShape="${details.headShape}")`,
       {
         expectedPrefix: details.expectedPrefix,
         endSeparator: details.endSeparator,
         inputLength: details.inputLength,
+        prefixAt: details.prefixAt,
+        headShape: details.headShape,
       },
     );
     return new InvalidFilePrefixError(details);

--- a/src/app/op-log/util/sync-file-prefix.ts
+++ b/src/app/op-log/util/sync-file-prefix.ts
@@ -15,8 +15,10 @@ const syncFilePrefixHelpers = createSyncFilePrefixHelpers({
     // the @sp/sync-providers privacy refactor), so the log call moved
     // here — the only site that owns the bridge between the package
     // helper's invalid-prefix detection and the app's OpLog history.
-    // The key names are inlined in the first-arg string so they survive
-    // any downstream serialization that stringifies args positionally.
+    // The key names are inlined in the first-arg string so the line reads as
+    // one greppable unit in a console. The structured meta is what the log
+    // EXPORT carries: `Log.exportLogHistory()` JSON-round-trips each arg, so
+    // the fields survive there on their own.
     OpLog.log(
       `InvalidFilePrefixError (inputLength=${details.inputLength}, ` +
         `expectedPrefix="${details.expectedPrefix}", ` +


### PR DESCRIPTION
Fixes #9627.

An unreadable sync file header (`pf_[C][E]<v>__` missing or damaged) previously fell through to the generic error handler, surfacing the raw internal message — the issue's title — with no way forward, and the log recorded nothing about what the file's head actually was, so a single field report cost multiple round-trips without settling whether the failure was a bad response or a bad stored file.

## Changes

- **Recovery:** `InvalidFilePrefixError` now joins the `JsonParseError` branch in `SyncWrapperService` — corrupted-remote snack with a **force overwrite** action. Local data is intact; remote cannot be parsed. The force-upload trigger source is labeled distinctly so the two remain separable in logs.
- **Diagnostics:** the error details (and the exportable OpLog history) now carry two shape-only fields, never the file's bytes:
  - `prefixAt` — offset of the expected prefix anywhere in the body, or `-1`: separates *header damaged* from *header gone*.
  - `headShape` — coarse class of the first bytes (`markup` | `json` | `base64` | `other`): separates a bad response (proxy page, WebDAV multistatus) from something consistent with our own stored body having lost its header. `json` is deliberately documented as ambiguous — with encryption and compression off (the defaults) our own stored body *is* raw JSON.
- **Docs:** `docs/sync-and-op-log/diagnosing-invalid-file-prefix.md` — triage decode table for reading these fields in a user's log export, indexed in the docs README.

## Tests

- `packages/sync-core` (vitest, 19): classification pinned per shape, privacy pinned (no payload bytes in details), damaged-vs-gone and prepended-junk offsets.
- `encrypt-and-compress-handler.service.spec.ts`: head shape pinned against the **real encoder** output per config (encrypted/compressed → `base64`, plaintext → `json`), so the interface doc cannot drift from what we write.
- `sync-wrapper.service.spec.ts`: handler branch + snack action invoked for real, asserting the distinct trigger label.
- `sync-file-prefix.spec.ts` (app shim): fields reach the OpLog history and the greppable log line.

## Risk notes

- Deliberately **not** added to `_isRecoverableCorruption` (.bak auto-recovery): a head-strip is not a torn-write shape. That extension is parked in #9682 with merge criteria.
- If a server/proxy persistently strips headers, force overwrite recreates the broken remote and the user loops — accepted trade-off (the reporter was unblocked by force upload in practice); revisit alongside #9682 if a cycling report appears.

https://claude.ai/code/session_01CXuRND966HFXxhvLbjm7i6