### PR TITLE
fix(task-repeat): give inherited subtasks deterministic ids (#9728)

### DIFF
--- a/e2e/tests/recurring/repeat-inherited-subtasks-9728.spec.ts
+++ b/e2e/tests/recurring/repeat-inherited-subtasks-9728.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from '../../fixtures/test.fixture';
+import { openRecurDialog, saveRecurDialog } from '../../utils/recurring-task-helpers';
+import type { Page } from '@playwright/test';
+
+/**
+ * Bug: https://github.com/super-productivity/super-productivity/issues/9728
+ *
+ * Single-client half of the #9728 coverage: a daily repeat with inherited
+ * subtasks must materialise each template EXACTLY once on the next day's
+ * instance. The cross-device duplication that actually triggered the report
+ * needs two clients and lives in
+ * e2e/tests/sync/supersync-repeat-subtask-duplication-9728.spec.ts; this one
+ * needs no sync server and guards the everyday path — including that the
+ * deterministic subtask ids (getRepeatableSubTaskId) did not break ordinary
+ * day-to-day instance creation.
+ *
+ * Clock strategy per #6230: setSystemTime, never setFixedTime — the day-change
+ * effect chain's debounceTime(1000) needs Date.now() to keep advancing.
+ */
+
+const addSubtask = async (
+  page: Page,
+  parentTaskName: string,
+  subtaskTitle: string,
+): Promise<void> => {
+  const parentTask = page.locator(`task:has-text("${parentTaskName}")`).first();
+  await parentTask.waitFor({ state: 'visible', timeout: 10000 });
+  await parentTask.focus();
+  await parentTask.press('a');
+
+  const draftInput = page.locator('.e2e-add-subtask-input');
+  await draftInput.waitFor({ state: 'visible', timeout: 5000 });
+  await draftInput.fill(subtaskTitle);
+  await page.keyboard.press('Enter');
+  await page.keyboard.press('Escape');
+  await draftInput.waitFor({ state: 'detached', timeout: 5000 });
+  await expect(page.locator(`task:has-text("${subtaskTitle}")`).first()).toBeVisible({
+    timeout: 10000,
+  });
+};
+
+/** Open the detail panel from the hover toolbar (mirrors TaskPage.openTaskDetail). */
+const openTaskDetail = async (page: Page, taskName: string): Promise<void> => {
+  const task = page.locator(`task:not(.hasNoSubTasks):has-text("${taskName}")`).first();
+  await task.waitFor({ state: 'visible', timeout: 10000 });
+  // Hover the parent's OWN row: subtasks render inside the parent element, so
+  // hovering the element centre lands on a subtask and opens ITS detail panel —
+  // which has no repeat button (canRepeat requires !task.parentId).
+  await task.locator('.first-line').first().hover();
+  const showDetailBtn = page.getByRole('button', { name: 'Show/hide task panel' });
+  await showDetailBtn.waitFor({ state: 'visible', timeout: 5000 });
+  await showDetailBtn.click();
+};
+
+test.describe('Recurring task inherited subtasks (#9728)', () => {
+  test('creates each inherited subtask exactly once on the next day instance', async ({
+    page,
+    workViewPage,
+    testPrefix,
+  }) => {
+    const parentName = `${testPrefix}-Routine9728`;
+    const sub1 = `${testPrefix}-Step1`;
+    const sub2 = `${testPrefix}-Step2`;
+
+    await page.clock.setSystemTime(new Date('2026-06-15T23:55:00'));
+    await page.reload();
+    await workViewPage.waitForTaskList();
+
+    // 1. A parent with two subtasks.
+    await workViewPage.addTask(parentName);
+    await addSubtask(page, parentName, sub1);
+    await addSubtask(page, parentName, sub2);
+
+    // 2. Make it a daily repeat. shouldInheritSubtasks defaults to true when the
+    //    task already has subtasks (dialog-edit-task-repeat-cfg.component.ts).
+    await openTaskDetail(page, parentName);
+    await openRecurDialog(page);
+    await saveRecurDialog(page);
+    await page.keyboard.press('Escape');
+
+    // 3. Finish day 15's instance so day 16's is unambiguous.
+    const day15 = page
+      .locator(`task:not(.hasNoSubTasks):not(.ng-animating):has-text("${parentName}")`)
+      .first();
+    await day15.focus();
+    await day15.press('d');
+    const confirmBtn = page.locator('dialog-confirm button[mat-flat-button]');
+    if (await confirmBtn.isVisible().catch(() => false)) {
+      await confirmBtn.click();
+    }
+    await expect(day15).toHaveClass(/isDone/, { timeout: 10000 });
+
+    // 4. Cross midnight; the day-change effect creates day 16's instance.
+    await page.clock.setSystemTime(new Date('2026-06-16T00:05:00'));
+    await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+
+    const day16 = page
+      .locator(
+        `task:not(.hasNoSubTasks):not(.isDone):not(.ng-animating):has-text("${parentName}")`,
+      )
+      .first();
+    await expect(day16).toBeVisible({ timeout: 60000 });
+
+    // 5. Each template must appear ONCE on the new instance. Scoped to the new
+    //    parent on purpose: a global count would also see day 15's instance.
+    //    Before the fix a second creation run made this 4 / 2 / 2 (#9728).
+    await expect(day16.locator('.sub-tasks task')).toHaveCount(2, { timeout: 15000 });
+    await expect(day16.locator(`.sub-tasks task:has-text("${sub1}")`)).toHaveCount(1);
+    await expect(day16.locator(`.sub-tasks task:has-text("${sub2}")`)).toHaveCount(1);
+  });
+});

--- a/e2e/tests/sync/supersync-repeat-subtask-duplication-9728.spec.ts
+++ b/e2e/tests/sync/supersync-repeat-subtask-duplication-9728.spec.ts
@@ -105,13 +105,23 @@ const advancePastMidnight = async (
   // Finish the current instance first, so the one created after midnight is
   // unambiguous and the wait below cannot match the old one.
   const prev = currentInstance(client.page, parentName);
+  const prevId = await prev.getAttribute('data-task-id');
   await prev.locator('.first-line').first().focus();
   await prev.press('d');
   const confirmBtn = client.page.locator('dialog-confirm button[mat-flat-button]');
   if (await confirmBtn.isVisible().catch(() => false)) {
     await confirmBtn.click();
   }
-  await expect(prev).toHaveClass(/isDone/, { timeout: 10000 });
+  // Assert via the id, not `prev`: that locator excludes .isDone, so it stops
+  // matching the instant the task is done and could never satisfy the check.
+  // Poll for a done copy rather than asserting on the single element: while the
+  // list animates, the same task id is rendered twice — once animating out of
+  // the undone list, once already .isDone in the done list.
+  await expect
+    .poll(() => client.page.locator(`task[data-task-id="${prevId}"].isDone`).count(), {
+      timeout: 10000,
+    })
+    .toBeGreaterThan(0);
 
   await client.page.clock.setSystemTime(new Date('2026-06-16T00:05:00'));
   await client.page.evaluate(() => window.dispatchEvent(new Event('focus')));
@@ -140,9 +150,13 @@ test.describe('@supersync Recurring subtask duplication (#9728)', () => {
       clientA = await createSimulatedClient(browser, baseURL!, 'A', testRunId);
       clientB = await createSimulatedClient(browser, baseURL!, 'B', testRunId);
 
-      // Both devices start on the same day, shortly before midnight.
+      // Both devices start mid-afternoon on day 15. Deliberately NOT close to
+      // midnight: sync setup plus encryption takes minutes of real time, and
+      // setSystemTime lets the clock keep ticking, so a 23:55 start crosses
+      // midnight mid-setup and re-triggers the day-change machinery on top of
+      // the encryption dialog. advancePastMidnight() jumps to day 16 later.
       for (const client of [clientA, clientB]) {
-        await client.page.clock.setSystemTime(new Date('2026-06-15T23:55:00'));
+        await client.page.clock.setSystemTime(new Date('2026-06-15T15:00:00'));
         await client.page.reload();
         await client.workView.waitForTaskList();
       }

--- a/e2e/tests/sync/supersync-repeat-subtask-duplication-9728.spec.ts
+++ b/e2e/tests/sync/supersync-repeat-subtask-duplication-9728.spec.ts
@@ -1,0 +1,163 @@
+import { test, expect } from '../../fixtures/supersync.fixture';
+import {
+  createTestUser,
+  getSuperSyncConfig,
+  createSimulatedClient,
+  closeClient,
+  waitForTask,
+  type SimulatedE2EClient,
+} from '../../utils/supersync-helpers';
+import { openRecurDialog, saveRecurDialog } from '../../utils/recurring-task-helpers';
+
+/**
+ * Bug: https://github.com/super-productivity/super-productivity/issues/9728
+ *
+ * A daily recurring task with inherited subtasks shows every subtask twice
+ * after the instance is created on more than one device.
+ *
+ * Why it happens: the repeat INSTANCE has a deterministic id
+ * (getRepeatableTaskId -> `rpt_<cfgId>_<dueDay>`), so two devices creating the
+ * same day's instance collide on one entity and conflict resolution keeps one.
+ * Its SUBTASKS used to get fresh nanoid ids, so the two devices produced
+ * DISJOINT entity ids. Conflict detection keys on `ENTITY_TYPE:entityId`
+ * (sync-core entity-key.util.ts), so those never form a conflict group and all
+ * of them apply — one parent, 2x the subtasks.
+ *
+ * Fix: getRepeatableSubTaskId() makes subtask ids deterministic too, so the
+ * second device's creation is a no-op for the whole instance.
+ *
+ * NOTE: no client goes offline here. Both simply reach the day change before
+ * the other has synced, which is the ordinary case when two devices are open
+ * around midnight.
+ */
+
+/** Add a subtask via the 'a' keyboard shortcut (mirrors supersync-archive-subtasks). */
+const addSubtask = async (
+  page: SimulatedE2EClient['page'],
+  parentTaskName: string,
+  subtaskTitle: string,
+): Promise<void> => {
+  const parentTask = page.locator(`task:has-text("${parentTaskName}")`).first();
+  await parentTask.waitFor({ state: 'visible', timeout: 10000 });
+  await parentTask.focus();
+  await page.waitForTimeout(100);
+  await parentTask.press('a');
+
+  const draftInput = page.locator('.e2e-add-subtask-input');
+  await draftInput.waitFor({ state: 'visible', timeout: 5000 });
+  await draftInput.fill(subtaskTitle);
+  await page.keyboard.press('Enter');
+  await page.keyboard.press('Escape');
+  await draftInput.waitFor({ state: 'detached', timeout: 5000 });
+
+  await waitForTask(page, subtaskTitle);
+  await page.waitForTimeout(200);
+};
+
+/**
+ * Count rendered SUBTASK rows with the given title.
+ * `.hasNoSubTasks` excludes the parent, whose DOM subtree also contains the text.
+ */
+const countSubtaskRows = async (
+  page: SimulatedE2EClient['page'],
+  title: string,
+): Promise<number> =>
+  page.locator(`task.hasNoSubTasks:not(.ng-animating):has-text("${title}")`).count();
+
+/**
+ * Move a client past midnight and wait for the fresh instance to appear.
+ * setSystemTime (not setFixedTime) so Date.now() keeps advancing — the
+ * day-change effect chain's debounceTime(1000) needs a moving clock (#6230).
+ */
+const advancePastMidnight = async (
+  client: SimulatedE2EClient,
+  parentName: string,
+): Promise<void> => {
+  await client.page.clock.setSystemTime(new Date('2026-06-16T00:05:00'));
+  await client.page.evaluate(() => window.dispatchEvent(new Event('focus')));
+  await expect(
+    client.page
+      .locator(`task:not(.hasNoSubTasks):not(.isDone):has-text("${parentName}")`)
+      .first(),
+  ).toBeVisible({ timeout: 60000 });
+};
+
+test.describe('@supersync Recurring subtask duplication (#9728)', () => {
+  test('creates each inherited subtask once when two devices reach the day change', async ({
+    browser,
+    baseURL,
+    testRunId,
+  }) => {
+    let clientA: SimulatedE2EClient | null = null;
+    let clientB: SimulatedE2EClient | null = null;
+
+    try {
+      const user = await createTestUser(testRunId);
+      const syncConfig = getSuperSyncConfig(user);
+
+      const parentName = `Routine-${testRunId}`;
+      const sub1 = `Step1-${testRunId}`;
+      const sub2 = `Step2-${testRunId}`;
+
+      clientA = await createSimulatedClient(browser, baseURL!, 'A', testRunId);
+      clientB = await createSimulatedClient(browser, baseURL!, 'B', testRunId);
+
+      // Both devices start on the same day, shortly before midnight.
+      for (const client of [clientA, clientB]) {
+        await client.page.clock.setSystemTime(new Date('2026-06-15T23:55:00'));
+        await client.page.reload();
+        await client.workView.waitForTaskList();
+      }
+
+      await clientA.sync.setupSuperSync(syncConfig);
+      await clientB.sync.setupSuperSync(syncConfig);
+
+      // 1. Device A builds the routine: a parent with two subtasks...
+      await clientA.workView.addTask(parentName);
+      await waitForTask(clientA.page, parentName);
+      await addSubtask(clientA.page, parentName, sub1);
+      await addSubtask(clientA.page, parentName, sub2);
+
+      // 2. ...and makes it a daily repeat. shouldInheritSubtasks defaults to true
+      //    when the task already has subtasks (dialog-edit-task-repeat-cfg.component.ts).
+      await clientA.page.locator(`task:has-text("${parentName}")`).first().click();
+      await openRecurDialog(clientA.page);
+      await saveRecurDialog(clientA.page);
+      await clientA.page.keyboard.press('Escape');
+
+      // 3. Both devices agree on the config and day-15 instance.
+      await clientA.sync.syncAndWait();
+      await clientB.sync.syncAndWait();
+      await waitForTask(clientB.page, parentName);
+
+      // 4. THE SCENARIO: both devices cross midnight before either syncs, so both
+      //    independently create the day-16 instance and its inherited subtasks.
+      await advancePastMidnight(clientA, parentName);
+      await advancePastMidnight(clientB, parentName);
+
+      // 5. Converge.
+      await clientA.sync.syncAndWait();
+      await clientB.sync.syncAndWait();
+      await clientA.sync.syncAndWait();
+
+      // 6. Each inherited subtask must exist exactly once on BOTH devices.
+      //    Before the fix this is 2 per device (#9728).
+      for (const [name, client] of [
+        ['A', clientA],
+        ['B', clientB],
+      ] as const) {
+        expect(
+          await countSubtaskRows(client.page, sub1),
+          `client ${name}: "${sub1}" should render once`,
+        ).toBe(1);
+        expect(
+          await countSubtaskRows(client.page, sub2),
+          `client ${name}: "${sub2}" should render once`,
+        ).toBe(1);
+      }
+    } finally {
+      if (clientA) await closeClient(clientA);
+      if (clientB) await closeClient(clientB);
+    }
+  });
+});

--- a/e2e/tests/sync/supersync-repeat-subtask-duplication-9728.spec.ts
+++ b/e2e/tests/sync/supersync-repeat-subtask-duplication-9728.spec.ts
@@ -31,6 +31,30 @@ import { openRecurDialog, saveRecurDialog } from '../../utils/recurring-task-hel
  * around midnight.
  */
 
+/**
+ * Open a task's detail panel (mirrors TaskPage.openTaskDetail, which the
+ * SuperSync harness does not expose — SimulatedE2EClient carries only
+ * workView and sync). The panel is opened from the hover toolbar, not by
+ * clicking the row.
+ */
+const openTaskDetail = async (
+  page: SimulatedE2EClient['page'],
+  taskName: string,
+): Promise<void> => {
+  // `:not(.hasNoSubTasks)` pins this to the parent — its subtask rows are
+  // nested inside it and match :has-text() too.
+  const task = page.locator(`task:not(.hasNoSubTasks):has-text("${taskName}")`).first();
+  await task.waitFor({ state: 'visible', timeout: 10000 });
+  // Hover the parent's OWN row: subtasks render inside the parent element, so
+  // hovering the element centre lands on a subtask and opens ITS detail panel —
+  // which has no repeat button (canRepeat requires !task.parentId).
+  await task.locator('.first-line').first().hover();
+  const showDetailBtn = page.getByRole('button', { name: 'Show/hide task panel' });
+  await showDetailBtn.waitFor({ state: 'visible', timeout: 5000 });
+  await showDetailBtn.click();
+  await page.waitForTimeout(300);
+};
+
 /** Add a subtask via the 'a' keyboard shortcut (mirrors supersync-archive-subtasks). */
 const addSubtask = async (
   page: SimulatedE2EClient['page'],
@@ -55,14 +79,19 @@ const addSubtask = async (
 };
 
 /**
- * Count rendered SUBTASK rows with the given title.
- * `.hasNoSubTasks` excludes the parent, whose DOM subtree also contains the text.
+ * Locate the CURRENT (undone) instance of the recurring parent.
+ * Scoping subtask counts to it is load-bearing: the previous day's instance is
+ * still in state after the day change, so a global count sees both instances.
  */
-const countSubtaskRows = async (
+const currentInstance = (
   page: SimulatedE2EClient['page'],
-  title: string,
-): Promise<number> =>
-  page.locator(`task.hasNoSubTasks:not(.ng-animating):has-text("${title}")`).count();
+  parentName: string,
+): ReturnType<SimulatedE2EClient['page']['locator']> =>
+  page
+    .locator(
+      `task:not(.hasNoSubTasks):not(.isDone):not(.ng-animating):has-text("${parentName}")`,
+    )
+    .first();
 
 /**
  * Move a client past midnight and wait for the fresh instance to appear.
@@ -73,13 +102,22 @@ const advancePastMidnight = async (
   client: SimulatedE2EClient,
   parentName: string,
 ): Promise<void> => {
+  // Finish the current instance first, so the one created after midnight is
+  // unambiguous and the wait below cannot match the old one.
+  const prev = currentInstance(client.page, parentName);
+  await prev.locator('.first-line').first().focus();
+  await prev.press('d');
+  const confirmBtn = client.page.locator('dialog-confirm button[mat-flat-button]');
+  if (await confirmBtn.isVisible().catch(() => false)) {
+    await confirmBtn.click();
+  }
+  await expect(prev).toHaveClass(/isDone/, { timeout: 10000 });
+
   await client.page.clock.setSystemTime(new Date('2026-06-16T00:05:00'));
   await client.page.evaluate(() => window.dispatchEvent(new Event('focus')));
-  await expect(
-    client.page
-      .locator(`task:not(.hasNoSubTasks):not(.isDone):has-text("${parentName}")`)
-      .first(),
-  ).toBeVisible({ timeout: 60000 });
+  await expect(currentInstance(client.page, parentName)).toBeVisible({
+    timeout: 60000,
+  });
 };
 
 test.describe('@supersync Recurring subtask duplication (#9728)', () => {
@@ -120,7 +158,7 @@ test.describe('@supersync Recurring subtask duplication (#9728)', () => {
 
       // 2. ...and makes it a daily repeat. shouldInheritSubtasks defaults to true
       //    when the task already has subtasks (dialog-edit-task-repeat-cfg.component.ts).
-      await clientA.page.locator(`task:has-text("${parentName}")`).first().click();
+      await openTaskDetail(clientA.page, parentName);
       await openRecurDialog(clientA.page);
       await saveRecurDialog(clientA.page);
       await clientA.page.keyboard.press('Escape');
@@ -146,14 +184,19 @@ test.describe('@supersync Recurring subtask duplication (#9728)', () => {
         ['A', clientA],
         ['B', clientB],
       ] as const) {
-        expect(
-          await countSubtaskRows(client.page, sub1),
-          `client ${name}: "${sub1}" should render once`,
-        ).toBe(1);
-        expect(
-          await countSubtaskRows(client.page, sub2),
-          `client ${name}: "${sub2}" should render once`,
-        ).toBe(1);
+        const instance = currentInstance(client.page, parentName);
+        await expect(
+          instance.locator('.sub-tasks task'),
+          `client ${name}: the new instance should carry exactly 2 subtasks`,
+        ).toHaveCount(2, { timeout: 15000 });
+        await expect(
+          instance.locator(`.sub-tasks task:has-text("${sub1}")`),
+          `client ${name}: "${sub1}" should appear once`,
+        ).toHaveCount(1);
+        await expect(
+          instance.locator(`.sub-tasks task:has-text("${sub2}")`),
+          `client ${name}: "${sub2}" should appear once`,
+        ).toHaveCount(1);
       }
     } finally {
       if (clientA) await closeClient(clientA);

--- a/src/app/features/task-repeat-cfg/get-repeatable-task-id.util.ts
+++ b/src/app/features/task-repeat-cfg/get-repeatable-task-id.util.ts
@@ -31,3 +31,25 @@ export const getRepeatableTaskId = (repeatCfgId: string, dueDay: string): string
   }
   return `rpt_${repeatCfgId}_${dueDay}`;
 };
+
+/**
+ * Generates a deterministic ID for a subtask of a repeatable task instance.
+ *
+ * Same reasoning as getRepeatableTaskId, applied one level down: instance
+ * creation must be idempotent for the WHOLE instance, not just its parent.
+ * With random IDs, any second run for the same (cfg, day) — a local race
+ * between the day-change and wait-for-completion creation paths, or two
+ * devices creating the instance before syncing — appends a second full set of
+ * subtasks to the one deduped parent (#9728). Subtask Creates carry disjoint
+ * entity IDs, so conflict resolution cannot collapse them after the fact.
+ *
+ * The index is the template's position in `taskRepeatCfg.subTaskTemplates`,
+ * which both devices read from the same synced config. Concurrent edits to the
+ * template list can briefly make the orders disagree; that is a far narrower
+ * window than the unconditional duplication it replaces.
+ *
+ * @param parentTaskId - The instance's parent task ID (from getRepeatableTaskId)
+ * @param index - The subtask template's index in subTaskTemplates
+ */
+export const getRepeatableSubTaskId = (parentTaskId: string, index: number): string =>
+  `${parentTaskId}_sub_${index}`;

--- a/src/app/features/task-repeat-cfg/repeat-subtask-duplication.9728.spec.ts
+++ b/src/app/features/task-repeat-cfg/repeat-subtask-duplication.9728.spec.ts
@@ -1,0 +1,298 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/**
+ * Reproduction for #9728 — a recurring task duplicates all of its subtasks.
+ *
+ * Repeat-instance creation is idempotent for the PARENT (deterministic id via
+ * getRepeatableTaskId + taskAdapter.addOne, which is a no-op on an existing id)
+ * but NOT for its SUBTASKS: every run mints fresh nanoid ids, and addSubTask
+ * only dedupes by task id. So any second execution of
+ * _getActionsForTaskRepeatCfg for the same (cfg, day) leaves 1 parent with 2x
+ * the subtasks.
+ *
+ * The two callers that can both reach the create path for the same day are
+ * TaskDueEffects.createRepeatableTasksAndAddDueToday$ (day change) and
+ * TaskRepeatCfgEffects.updateStartDateOnComplete$ (waitForCompletion), which
+ * awaits a full task-archive load between the "does it exist?" check and the
+ * dispatch.
+ *
+ * Actions are applied through the REAL meta-reducer chain + task reducer, so
+ * this asserts observable state, not a mocked seam.
+ */
+import { TestBed } from '@angular/core/testing';
+import { Action, ActionReducer } from '@ngrx/store';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { of } from 'rxjs';
+import { TaskRepeatCfgService } from './task-repeat-cfg.service';
+import { DEFAULT_TASK_REPEAT_CFG, TaskRepeatCfg } from './task-repeat-cfg.model';
+import { getRepeatableTaskId } from './get-repeatable-task-id.util';
+import { TaskService } from '../tasks/task.service';
+import { WorkContextService } from '../work-context/work-context.service';
+import { WorkContextType } from '../work-context/work-context.model';
+import { DEFAULT_TASK, Task } from '../tasks/task.model';
+import { DateService } from '../../core/date/date.service';
+import { getDbDateStr } from '../../util/get-db-date-str';
+import { RootState } from '../../root-store/root-state';
+import { createCombinedTaskSharedMetaReducer } from '../../root-store/meta/task-shared-meta-reducers/test-helpers';
+import { createBaseState } from '../../root-store/meta/task-shared-meta-reducers/test-utils';
+import { TASK_FEATURE_NAME, taskReducer } from '../tasks/store/task.reducer';
+import { appStateFeatureKey } from '../../root-store/app-state/app-state.reducer';
+import { toEntityKey } from '@sp/sync-core';
+import { addSubTask } from '../tasks/store/task.actions';
+import { TaskSharedActions } from '../../root-store/meta/task-shared.actions';
+
+describe('Recurring task subtask duplication (#9728)', () => {
+  let service: TaskRepeatCfgService;
+  let reducer: ActionReducer<any, Action>;
+  let baseState: RootState;
+  let nextTaskNr: number;
+
+  const CFG_ID = 'morning-routine-cfg';
+  const DAY = new Date(2026, 7, 25, 8, 5, 0, 0);
+  const dayStr = '2026-08-25';
+  const parentId = getRepeatableTaskId(CFG_ID, dayStr);
+
+  // 15 subtasks, as in the reported "morning routine".
+  const cfg: TaskRepeatCfg = {
+    ...DEFAULT_TASK_REPEAT_CFG,
+    id: CFG_ID,
+    title: 'Morning Routine',
+    projectId: 'project1',
+    repeatCycle: 'DAILY',
+    repeatEvery: 1,
+    startDate: '2026-08-01',
+    lastTaskCreationDay: '2026-08-24',
+    tagIds: [],
+    shouldInheritSubtasks: true,
+    waitForCompletion: true,
+    skipOverdue: true,
+    subTaskTemplates: Array.from({ length: 15 }, (_, i) => ({
+      title: `Step ${i + 1}`,
+      notes: '',
+      timeEstimate: 0,
+    })),
+  };
+
+  beforeEach(() => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate(DAY);
+    nextTaskNr = 0;
+
+    const taskServiceSpy = jasmine.createSpyObj('TaskService', [
+      'createNewTaskWithDefaults',
+      'getTasksWithSubTasksByRepeatCfgId$',
+      'getTasksByRepeatCfgId$',
+      'getArchiveTasksForRepeatCfgId',
+    ]);
+
+    // Mirrors the real TaskService.createNewTaskWithDefaults (task.service.ts):
+    // `id: id || nanoid()` — callers that pass no id get a fresh random one.
+    taskServiceSpy.createNewTaskWithDefaults.and.callFake((args: any): Task => {
+      nextTaskNr++;
+      return {
+        ...DEFAULT_TASK,
+        ...args.additional,
+        id: args.id || `rnd-${nextTaskNr}`,
+        title: args.title,
+        created: Date.now(),
+      } as Task;
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        TaskRepeatCfgService,
+        provideMockStore({ initialState: { taskRepeatCfg: { ids: [], entities: {} } } }),
+        { provide: MatDialog, useValue: jasmine.createSpyObj('MatDialog', ['open']) },
+        { provide: TaskService, useValue: taskServiceSpy },
+        {
+          provide: WorkContextService,
+          useValue: jasmine.createSpyObj('WorkContextService', [], {
+            activeWorkContextType: WorkContextType.PROJECT,
+            activeWorkContextId: 'project1',
+          }),
+        },
+        {
+          provide: DateService,
+          useValue: {
+            todayStr: () => getDbDateStr(),
+            isToday: (d: number | Date) => getDbDateStr(d) === getDbDateStr(),
+            getStartOfNextDayDiffMs: () => 0,
+          },
+        },
+      ],
+    });
+
+    service = TestBed.inject(TaskRepeatCfgService);
+    spyOn(TestBed.inject(MockStore), 'dispatch');
+
+    // Real meta-reducer chain on top of the real task reducer.
+    reducer = createCombinedTaskSharedMetaReducer((state: any, action: Action) => ({
+      ...state,
+      [TASK_FEATURE_NAME]: taskReducer(state[TASK_FEATURE_NAME], action),
+    }));
+    baseState = {
+      ...createBaseState(),
+      [appStateFeatureKey]: {
+        ...(createBaseState()[appStateFeatureKey] as any),
+        todayStr: dayStr,
+      },
+    } as RootState;
+  });
+
+  afterEach(() => jasmine.clock().uninstall());
+
+  const applyAll = (state: RootState, actions: readonly Action[]): RootState =>
+    actions.reduce((acc, action) => reducer(acc, action), state);
+
+  const subTaskIdsOf = (state: RootState, id: string): string[] =>
+    (state[TASK_FEATURE_NAME].entities[id] as Task)?.subTaskIds ?? [];
+
+  it('creates the parent once with 15 subtasks on a single run', async () => {
+    const taskService = TestBed.inject(TaskService) as jasmine.SpyObj<TaskService>;
+    taskService.getTasksWithSubTasksByRepeatCfgId$.and.returnValue(of([]) as any);
+    taskService.getArchiveTasksForRepeatCfgId.and.resolveTo([]);
+
+    const state = applyAll(
+      baseState,
+      await service._getActionsForTaskRepeatCfg(cfg, DAY.getTime()),
+    );
+
+    expect(state[TASK_FEATURE_NAME].entities[parentId]).toBeDefined();
+    expect(subTaskIdsOf(state, parentId).length).toBe(15);
+  });
+
+  it('does NOT duplicate subtasks when two callers both create the same instance', async () => {
+    const taskService = TestBed.inject(TaskService) as jasmine.SpyObj<TaskService>;
+    // Both callers read state BEFORE either has dispatched — the window that
+    // updateStartDateOnComplete$ holds open across its task-archive load.
+    taskService.getTasksWithSubTasksByRepeatCfgId$.and.returnValue(of([]) as any);
+    taskService.getArchiveTasksForRepeatCfgId.and.resolveTo([]);
+
+    const [actionsA, actionsB] = await Promise.all([
+      service._getActionsForTaskRepeatCfg(cfg, DAY.getTime()),
+      service._getActionsForTaskRepeatCfg(cfg, DAY.getTime()),
+    ]);
+
+    const state = applyAll(applyAll(baseState, actionsA), actionsB);
+    const subTaskIds = subTaskIdsOf(state, parentId);
+
+    // The parent is deduped by its deterministic id...
+    expect(
+      Object.values(state[TASK_FEATURE_NAME].entities).filter(
+        (t) => (t as Task).repeatCfgId === CFG_ID,
+      ).length,
+    ).toBe(1);
+
+    // ...but the subtasks are not: this is #9728.
+    expect(new Set(subTaskIds).size).toBe(subTaskIds.length);
+    expect(subTaskIds.length).toBe(15);
+  });
+
+  /**
+   * Cross-client path: two devices each create the same instance before syncing
+   * (e.g. both open around the day rollover).
+   *
+   * Conflict detection is keyed by `ENTITY_TYPE:entityId` (sync-core
+   * entity-key.util.ts), so the two parent Creates collide and are resolved to
+   * one winner — which is exactly what getRepeatableTaskId was introduced for.
+   * The subtask Creates carry 30 DISJOINT entity ids, so they never form a
+   * conflict group and nothing in the sync layer can dedupe them.
+   *
+   * repeat-task-sync.integration.spec.ts asserts the parent half of this
+   * ("because IDs match, there's no duplicate task") and stops there.
+   */
+  describe('cross-client creation (both devices create the same instance)', () => {
+    it('gives the two clients ONE parent entity key but 30 disjoint subtask keys', async () => {
+      const taskService = TestBed.inject(TaskService) as jasmine.SpyObj<TaskService>;
+      taskService.getTasksWithSubTasksByRepeatCfgId$.and.returnValue(of([]) as any);
+      taskService.getArchiveTasksForRepeatCfgId.and.resolveTo([]);
+
+      // Device 1 (e.g. Windows) and device 2 (e.g. Mac), each unaware of the other.
+      const deviceA = await service._getActionsForTaskRepeatCfg(cfg, DAY.getTime());
+      const deviceB = await service._getActionsForTaskRepeatCfg(cfg, DAY.getTime());
+
+      const entityIdsOf = (actions: readonly Action[], type: string): string[] =>
+        actions.filter((a) => a.type === type).map((a) => ((a as any).task as Task).id);
+
+      const parentKeys = new Set(
+        [
+          ...entityIdsOf(deviceA, TaskSharedActions.addTask.type),
+          ...entityIdsOf(deviceB, TaskSharedActions.addTask.type),
+        ].map((id) => toEntityKey('TASK', id)),
+      );
+      const subTaskKeys = new Set(
+        [
+          ...entityIdsOf(deviceA, addSubTask.type),
+          ...entityIdsOf(deviceB, addSubTask.type),
+        ].map((id) => toEntityKey('TASK', id)),
+      );
+
+      // One conflict group -> LWW picks a winner, no duplicate parent.
+      expect(parentKeys.size).toBe(1);
+      // 30 separate entities -> no conflict group exists, so all 30 apply.
+      expect(subTaskKeys.size).toBe(15);
+    });
+
+    it('does NOT leave 30 subtasks after merging both devices op sets', async () => {
+      const taskService = TestBed.inject(TaskService) as jasmine.SpyObj<TaskService>;
+      taskService.getTasksWithSubTasksByRepeatCfgId$.and.returnValue(of([]) as any);
+      taskService.getArchiveTasksForRepeatCfgId.and.resolveTo([]);
+
+      const deviceA = await service._getActionsForTaskRepeatCfg(cfg, DAY.getTime());
+      const deviceB = await service._getActionsForTaskRepeatCfg(cfg, DAY.getTime());
+
+      // Merge order on the receiving client: own ops, then the remote ones.
+      const state = applyAll(applyAll(baseState, deviceA), deviceB);
+
+      expect(subTaskIdsOf(state, parentId).length).toBe(15);
+    });
+  });
+
+  /**
+   * Generalized invariant (#9728 follow-up).
+   *
+   * The property that actually matters is not "subtasks have ids" but: two
+   * independent creation runs for the same (cfg, day) must produce byte-identical
+   * task ids for EVERY task they create. That is what makes the second run a
+   * no-op, whether it comes from a local re-entry or another device.
+   *
+   * This guards anything added to the instance later — a third nesting level,
+   * a template-derived attachment, a note task — which would otherwise
+   * reintroduce #9728 silently.
+   */
+  describe('instance-creation id determinism', () => {
+    const taskIdsOf = (actions: readonly Action[]): string[] =>
+      actions
+        .filter((a) => 'task' in (a as any) && !!(a as any).task?.id)
+        .map((a) => ((a as any).task as Task).id);
+
+    it('produces identical task ids across two independent runs', async () => {
+      const taskService = TestBed.inject(TaskService) as jasmine.SpyObj<TaskService>;
+      taskService.getTasksWithSubTasksByRepeatCfgId$.and.returnValue(of([]) as any);
+      taskService.getArchiveTasksForRepeatCfgId.and.resolveTo([]);
+
+      const runA = await service._getActionsForTaskRepeatCfg(cfg, DAY.getTime());
+      const runB = await service._getActionsForTaskRepeatCfg(cfg, DAY.getTime());
+
+      expect(taskIdsOf(runA).length).toBeGreaterThan(0);
+      expect(taskIdsOf(runB)).toEqual(taskIdsOf(runA));
+    });
+
+    it('derives every created task id from the repeat cfg and its due day', async () => {
+      const taskService = TestBed.inject(TaskService) as jasmine.SpyObj<TaskService>;
+      taskService.getTasksWithSubTasksByRepeatCfgId$.and.returnValue(of([]) as any);
+      taskService.getArchiveTasksForRepeatCfgId.and.resolveTo([]);
+
+      const ids = taskIdsOf(
+        await service._getActionsForTaskRepeatCfg(cfg, DAY.getTime()),
+      );
+
+      expect(ids.length).toBe(16); // 1 parent + 15 subtasks
+      ids.forEach((id) =>
+        expect(id.startsWith(parentId))
+          .withContext(`task id "${id}" is not derived from "${parentId}"`)
+          .toBe(true),
+      );
+    });
+  });
+});

--- a/src/app/features/task-repeat-cfg/task-repeat-cfg.service.ts
+++ b/src/app/features/task-repeat-cfg/task-repeat-cfg.service.ts
@@ -39,7 +39,10 @@ import {
   selectAllUnprocessedTaskRepeatCfgs,
   selectTaskRepeatCfgsForExactDay,
 } from './store/task-repeat-cfg.selectors';
-import { getRepeatableTaskId } from './get-repeatable-task-id.util';
+import {
+  getRepeatableSubTaskId,
+  getRepeatableTaskId,
+} from './get-repeatable-task-id.util';
 import { getDeadlineAutoPlanFields } from '../tasks/util/get-deadline-auto-plan-fields';
 
 @Injectable({
@@ -352,9 +355,12 @@ export class TaskRepeatCfgService {
       taskRepeatCfg.subTaskTemplates &&
       taskRepeatCfg.subTaskTemplates.length > 0
     ) {
-      for (const subTask of taskRepeatCfg.subTaskTemplates) {
+      taskRepeatCfg.subTaskTemplates.forEach((subTask, i) => {
         const newSubTask = this._taskService.createNewTaskWithDefaults({
           title: subTask.title,
+          // Deterministic, so a second creation run for the same day is a
+          // no-op instead of a second set of subtasks (#9728).
+          id: getRepeatableSubTaskId(task.id, i),
           additional: {
             notes: subTask.notes ?? '',
             timeEstimate: subTask.timeEstimate ?? 0,
@@ -370,7 +376,7 @@ export class TaskRepeatCfgService {
             parentId: task.id,
           }),
         );
-      }
+      });
     }
 
     return createNewActions;


### PR DESCRIPTION
Fixes #9728.

## The bug

Repeat-instance creation is idempotent for the parent task but was not for its
inherited subtasks.

The parent gets a deterministic id (`rpt_<cfgId>_<dueDay>`), so a second
creation run for the same day is a no-op — `taskAdapter.addOne` ignores an id
that already exists. The subtasks were created with fresh nanoids, and
`addSubTask` dedupes only by task id, so a second run appended a *second
complete set*: one parent, two copies of every subtask.

The sync layer cannot repair this after the fact. Conflict detection keys on
`ENTITY_TYPE:entityId` (`packages/sync-core/src/entity-key.util.ts`), so two
sets of subtasks with disjoint ids never form a conflict group — they are just
two batches of legitimately created tasks.

## The fix

`getRepeatableSubTaskId(parentTaskId, index)` → `<parentId>_sub_<index>`, applied
in `_getActionsForTaskRepeatCfg`. Same reasoning as `getRepeatableTaskId`, one
level down: a repeat run for a day that already has its instance becomes a no-op
all the way through.

I audited the rest of the action batch — it was already idempotent
(`addTaskToList` dedupes by id, `remindAt` has an unchanged-value early-out).
Subtask ids were the only non-idempotent part.

## Verification

| | without the fix | with the fix |
|---|---|---|
| unit (`repeat-subtask-duplication.9728.spec.ts`) | 30 subtasks vs 15; 5 of 6 tests fail | 6 passed |
| two-client E2E vs a real SuperSync server | client B: **4** subtasks where 2 are correct | passed |

Both were run in both directions locally — the failing direction is what
establishes these as reproductions rather than assertions.

CI on this branch: [run 33104506370](https://github.com/super-productivity/super-productivity/actions/runs/33104506370)
— all jobs green, with the two-client repro executing in SuperSync shard 2/6
(1 passed, 1.0m) and the single-client guard in shard 1/6.

## Notes for review

- **`e2e/tests/recurring/repeat-inherited-subtasks-9728.spec.ts` is a regression
  guard, not a repro** — it passes with and without the fix, and says so in its
  header. `addAllDueToday()` runs exactly once per day change because
  `afterCurrentSyncDoneOrSyncDisabled$` ends in `first()`
  (`sync-wrapper.service.ts:285`), so a single client cannot trigger the double
  run. The live path is cross-device, which is what the SuperSync spec covers.
- **No schema bump** (sync rule 10). Subtask ids are opaque strings; an older
  client receiving these ops applies them normally.
- **Mixed-version fleets get partial relief only.** A client on the current
  release still mints random subtask ids and can contribute a duplicate set that
  syncs onward. The reporter needs every device updated.
- **No healing of existing duplicates.** The condition is self-clearing as daily
  instances archive, and a deletion heuristic risks removing real subtasks. There
  is also no reproducible failure driving such a change, which the repo's
  sync rules require before touching this area.
- **Index stability:** the index comes from `subTaskTemplates` on the same synced
  config, so two devices creating the same day's instance agree. Concurrently
  editing the template while a day change lands on another device is a far
  narrower window than the unconditional duplication being fixed.

https://claude.ai/code/session_01S58DbtcphBvvR2pKy6M5ZN
