### PR TITLE
fix(super-sync): arm the state-replacement fence on an accepted causal REPAIR (#9703)

### DIFF
--- a/ARCHITECTURE-DECISIONS.md
+++ b/ARCHITECTURE-DECISIONS.md
@@ -153,9 +153,12 @@ from PostgreSQL RepeatableRead snapshot isolation alone.
   handler rejects an obviously stale base before quota cleanup, and the upload
   transaction repeats the check under `SELECT ... FOR UPDATE` before insertion
 - Regular uploads carrying `lastKnownServerSeq` use the same per-user row lock
-  to reject a batch behind the latest `SYNC_IMPORT` or `BACKUP_IMPORT` before
-  insertion. The durable replacement marker is reconciled lazily from retained
-  operations for rows created before the marker existed.
+  to reject a batch behind the latest `SYNC_IMPORT`, `BACKUP_IMPORT` or causal
+  `REPAIR` before insertion. The durable replacement marker is reconciled lazily
+  from retained operations for rows created before the marker existed, and is
+  advanced by every accepted state replacement — the lazy resolve runs only
+  while the marker is unset, so the accepted-op write is the sole way the fence
+  moves on an account whose marker is already resolved.
 - Markerless legacy repairs are compatibility records, not causal boundaries:
   they cannot drive download fast-forward, snapshot trust, history pruning, or
   server-generated restore points; snapshot replay across one fails closed

--- a/packages/super-sync-server/src/sync/sync.service.ts
+++ b/packages/super-sync-server/src/sync/sync.service.ts
@@ -450,10 +450,25 @@ export class SyncService {
           for (let index = 0; index < ops.length; index++) {
             const op = ops[index];
             const result = results[index];
+            // A causal REPAIR is a proven full-state boundary — the same one
+            // `resolveRetainedReplacementSeq` falls back to. Recording it here
+            // is what keeps writer and resolver agreeing: the resolver only
+            // runs while the column is NULL, and the first ordinary upload that
+            // takes the row lock resolves it (to 0 for every account that never
+            // imported). So on an already-resolved account the accepted-op
+            // write is the ONLY thing that can arm the guard, and skipping
+            // REPAIR left the boundary at the stale 0 — a device returning with
+            // a pre-repair cursor then appends superseded deltas above the
+            // repair (#9703). A legacy REPAIR carries no base cursor and is not
+            // a proven boundary, so it stays excluded here as everywhere else.
+            const isStateReplacement =
+              op.opType === 'SYNC_IMPORT' ||
+              op.opType === 'BACKUP_IMPORT' ||
+              (op.opType === 'REPAIR' && !isLegacyRepairUpload);
             if (
               result?.accepted &&
               result.serverSeq !== undefined &&
-              (op.opType === 'SYNC_IMPORT' || op.opType === 'BACKUP_IMPORT')
+              isStateReplacement
             ) {
               latestAcceptedStateReplacementSeq = Math.max(
                 latestAcceptedStateReplacementSeq ?? 0,

--- a/packages/super-sync-server/tests/sync.service.spec.ts
+++ b/packages/super-sync-server/tests/sync.service.spec.ts
@@ -1093,6 +1093,93 @@ describe('SyncService', () => {
       expect(testState.userSyncStates.get(userId)?.latestStateReplacementSeq).toBe(0);
     });
 
+    /**
+     * The resolver treats a causal REPAIR as a full-state boundary, but it only
+     * ever runs while the column is NULL — and the very first ordinary upload
+     * that takes the row lock resolves it, to 0 for the many accounts that have
+     * never imported. So on the common account the accepted-op write is the ONLY
+     * thing that can arm the guard, and it used to ignore REPAIR entirely:
+     * a causal REPAIR left the boundary at the stale 0 and a device returning
+     * with a pre-repair cursor appended its superseded deltas above the repair
+     * (#9703). No pruning and no upgrade window needed — just a resolved column.
+     */
+    it('arms the guard on an accepted causal REPAIR', async () => {
+      const service = getSyncService();
+      testState.userSyncStates.set(userId, {
+        userId,
+        lastSeq: 4,
+        latestStateReplacementSeq: 0,
+      });
+      const repair = makeOp({
+        id: 'causal-repair-boundary',
+        actionType: '[Repair] Auto Repair',
+        opType: 'REPAIR',
+        entityType: 'ALL',
+        entityId: undefined,
+        payload: { repaired: true },
+      });
+
+      const repairResults = await service.uploadOps(
+        userId,
+        clientId,
+        [repair],
+        undefined,
+        undefined,
+        4,
+        false,
+        4,
+      );
+
+      expect(repairResults[0].accepted).toBe(true);
+      expect(repairResults[0].serverSeq).toBe(5);
+      expect(testState.userSyncStates.get(userId)?.latestStateReplacementSeq).toBe(5);
+
+      const preRepairDelta = makeOp({ id: 'pre-repair-delta' });
+      const staleResults = await service.uploadOps(
+        userId,
+        clientId,
+        [preRepairDelta],
+        undefined,
+        undefined,
+        undefined,
+        false,
+        3,
+      );
+
+      expect(staleResults[0].accepted).toBe(false);
+      expect(testState.operations.has(preRepairDelta.id)).toBe(false);
+    });
+
+    it('leaves the boundary alone for a legacy REPAIR with no causal base', async () => {
+      const service = getSyncService();
+      testState.userSyncStates.set(userId, {
+        userId,
+        lastSeq: 4,
+        latestStateReplacementSeq: 0,
+      });
+      const legacyRepair = makeOp({
+        id: 'legacy-repair-boundary',
+        actionType: '[Repair] Auto Repair',
+        opType: 'REPAIR',
+        entityType: 'ALL',
+        entityId: undefined,
+        payload: { repaired: true },
+      });
+
+      const results = await service.uploadOps(
+        userId,
+        clientId,
+        [legacyRepair],
+        undefined,
+        undefined,
+        undefined,
+        true,
+      );
+
+      expect(results[0].accepted).toBe(true);
+      expect(testState.userSyncStates.get(userId)?.latestStateReplacementSeq).toBe(0);
+    });
+
     it('should correctly upload operations', async () => {
       const service = getSyncService();
       const op: Operation = makeOp();


### PR DESCRIPTION
Closes #9703.

## What #9703 filed, and what is actually broken

#9703 reported that `resolveRetainedReplacementSeq` never considered `REPAIR`, so the old-ops sweep could prune the newest import out from under it and silently disarm the stale-cursor upload guard.

**That half already shipped.** `26fbe93d8` (2026-08-23) taught the resolver to fall back to a causal `REPAIR`. It is on `master` and in no tag, so it is not in any release yet, but it is there.

The **writer** was never fixed, and it is the wider half:

- `latestStateReplacementSeq` is resolved lazily *and persisted* — the resolver only runs while the column is `NULL`.
- The first ordinary upload that takes the per-user row lock resolves it, to `0` for every account that has never imported (i.e. most of them).
- From then on, the accepted-op write at `sync.service.ts:449-470` is the only thing that can move the fence — and it counted `SYNC_IMPORT` / `BACKUP_IMPORT` only.

So a causal `REPAIR` on an already-resolved account leaves the boundary at a stale `0`, and the stale-cursor guard silently stays disarmed. A device returning with a pre-repair cursor gets its superseded deltas appended **above** the repair instead of being fenced into downloading the replacement first — resurrecting exactly what the repair removed.

This needs **no pruning and no upgrade window**, only a resolved column. It is live on `ghcr.io/super-productivity/supersync:latest`, which self-hosters run by default via the checked-in `docker-compose.yml`.

## The fix

Count an accepted causal `REPAIR` as a state replacement in the accepted-op write, so writer and resolver agree on what a boundary is. A legacy `REPAIR` carries no base cursor and is not a proven boundary, so it stays excluded here exactly as it is everywhere else.

## Test evidence

`tests/sync.service.spec.ts` — `arms the guard on an accepted causal REPAIR`.

Red on unmodified `sync.service.ts`:

```
× arms the guard on an accepted causal REPAIR
AssertionError: expected +0 to be 5
Tests  1 failed | 120 passed (121)
```

`+0` is the stale fence; `5` is the serverSeq of the accepted REPAIR. Green with the fix: `121 passed (121)`.

A second test pins the legacy-`REPAIR` exclusion so it cannot regress.

`ARCHITECTURE-DECISIONS.md` still described the fence as "SYNC_IMPORT or BACKUP_IMPORT"; `26fbe93d8` had already outgrown that, so it is corrected here.

## Risk

No migration, no schema bump, no API change. Accounts already resolved to `0` are **not** healed by this — they re-arm on their next state replacement. Healing them is a one-off `UPDATE` a maintainer can decide on separately; I deliberately did not ship it as a Prisma migration, because `migrate deploy` runs while the old process is still serving and would race it straight back to `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
