### PR TITLE
fix(sync): gate .bak adoption on a confirming re-read for decode failures (#9683)

### DIFF
--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.spec.ts
@@ -2795,6 +2795,75 @@ describe('FileBasedSyncAdapterService', () => {
       expect(mainRevToMatch).not.toContain('bak-rev-heal');
     });
 
+    it('(#9683a) a TRANSIENT decode failure of a HEALTHY primary must not adopt .bak and heal-overwrite it', async () => {
+      // Reproduces the asymmetric-transport shape from #9683 (a) end-to-end,
+      // through the REAL decode path — no injected error:
+      //
+      //   1. The primary on the server is HEALTHY (generation N).
+      //   2. One GET returns a TRUNCATED body as a success (prefix intact, JSON
+      //      tail cut). The prefix stage passes; JSON.parse fails →
+      //      real JsonParseError, which _isRecoverableCorruption() enrolls.
+      //   3. .bak is adopted with NO confirming re-read.
+      //   4. Because the download SUCCEEDED we hold the primary's REAL rev, so
+      //      the follow-up conditional upload MATCHES and overwrites the intact
+      //      primary with generation N-1 content — one generation of ops lost.
+      //
+      // Contrast with the empty-body transport failure (EmptyRemoteBodySPError),
+      // which degrades safely: `downloadFile` itself throws, no primary rev is
+      // annotated, so the heal upload uses the .bak rev and loses the conditional
+      // write instead of clobbering. The rev we hold is what makes this class
+      // destructive.
+      const healthyPrimary = createMockSyncData({
+        syncVersion: 9,
+        recentOps: [compactOp('gen-N-op') as never],
+      });
+      const staleBak = createMockSyncData({
+        syncVersion: 8,
+        recentOps: [compactOp('gen-N-minus-1-op') as never],
+      });
+      const healthyBody = addPrefix(healthyPrimary);
+      // Prefix intact, JSON tail cut — exactly what a silently truncated 200 gives.
+      const truncatedBody = healthyBody.slice(0, healthyBody.length - 30);
+
+      let primaryGets = 0;
+      mockProvider.downloadFile.and.callFake((path: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE) {
+          return Promise.resolve({
+            dataStr: addPrefix(staleBak),
+            rev: 'stale-bak-rev',
+          });
+        }
+        primaryGets++;
+        // Transient: only the FIRST read is mangled. A confirming re-read (the
+        // fix this test drives) would see the intact file and refuse recovery.
+        return Promise.resolve({
+          dataStr: primaryGets === 1 ? truncatedBody : healthyBody,
+          rev: 'healthy-primary-rev',
+        });
+      });
+
+      const mainUploads: string[] = [];
+      mockProvider.uploadFile.and.callFake((path: string, dataStr: string) => {
+        if (path === FILE_BASED_SYNC_CONSTANTS.SYNC_FILE) {
+          mainUploads.push(dataStr);
+        }
+        return Promise.resolve({ rev: 'healed-rev' });
+      });
+
+      const result = await adapter.downloadOps(0);
+
+      // The healthy primary's ops must survive a transient mangled read.
+      expect(result.ops.map((o) => o.op.id)).toContain('gen-N-op');
+      expect(mockSnackService.open).not.toHaveBeenCalled();
+
+      await adapter.uploadOps([createMockSyncOp()], 'client1');
+
+      // ...and the follow-up upload must not overwrite the intact primary with
+      // the previous generation.
+      const uploaded = parseWithPrefix(mainUploads[mainUploads.length - 1]);
+      expect(uploaded.recentOps.map((o) => o.id)).toContain('gen-N-op');
+    });
+
     it('(c) never issues isForceOverwrite=true on the rev-mismatch retry path', async () => {
       const syncData = createMockSyncData({ syncVersion: 1 });
       mockProvider.downloadFile.and.returnValue(

--- a/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
+++ b/src/app/op-log/sync-providers/file-based/file-based-sync-adapter.service.ts
@@ -1116,33 +1116,42 @@ export class FileBasedSyncAdapterService {
       }
       if (this._isRecoverableCorruption(e)) {
         // Primary sync-data.json is corrupt/empty/unparseable (e.g. interrupted
-        // write). Try to recover from the .bak artifact before failing.
-        const recovered = await this._readBakFile<FileBasedSyncData>(
-          provider,
-          cfg,
-          encryptKey,
-          FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
-          FILE_BASED_SYNC_CONSTANTS.FILE_VERSION,
+        // write). Confirm it is REALLY corrupt (#9683) before adopting .bak.
+        const confirmed = await this._reDownloadOrNull(() =>
+          this._downloadSyncFile(provider, cfg, encryptKey),
         );
-        if (recovered) {
-          recoveredFromBackup = true;
-          OpLog.warn(
-            'FileBasedSyncAdapter: Primary sync file unreadable; recovered from backup',
-          );
-          syncData = recovered.data;
-          // Seed the cache with the CORRUPT PRIMARY file's rev (annotated onto the
-          // error in _downloadSyncFile), not the .bak rev. The next conditional
-          // upload then matches sync-data.json and OVERWRITES (heals) it. Using the
-          // .bak rev would mismatch the primary on every upload, leaving sync stuck
-          // in a re-recover/re-fail loop. Fall back to the .bak rev if the primary
-          // rev is unavailable (a later mismatch just re-recovers — no data loss).
-          const primaryRev =
-            (e as { primaryRev?: string } | null)?.primaryRev ?? recovered.rev;
-          rev = primaryRev;
+        if (confirmed) {
+          syncData = confirmed.data;
+          rev = confirmed.rev;
           this._setCachedSyncData(providerKey, syncData, rev);
-          this._notifyRecoveredCorruptPrimaryOnce(providerKey, primaryRev);
         } else {
-          throw e;
+          const recovered = await this._readBakFile<FileBasedSyncData>(
+            provider,
+            cfg,
+            encryptKey,
+            FILE_BASED_SYNC_CONSTANTS.BACKUP_FILE,
+            FILE_BASED_SYNC_CONSTANTS.FILE_VERSION,
+          );
+          if (recovered) {
+            recoveredFromBackup = true;
+            OpLog.warn(
+              'FileBasedSyncAdapter: Primary sync file unreadable; recovered from backup',
+            );
+            syncData = recovered.data;
+            // Seed the cache with the CORRUPT PRIMARY file's rev (annotated onto the
+            // error in _downloadSyncFile), not the .bak rev. The next conditional
+            // upload then matches sync-data.json and OVERWRITES (heals) it. Using the
+            // .bak rev would mismatch the primary on every upload, leaving sync stuck
+            // in a re-recover/re-fail loop. Fall back to the .bak rev if the primary
+            // rev is unavailable (a later mismatch just re-recovers — no data loss).
+            const primaryRev =
+              (e as { primaryRev?: string } | null)?.primaryRev ?? recovered.rev;
+            rev = primaryRev;
+            this._setCachedSyncData(providerKey, syncData, rev);
+            this._notifyRecoveredCorruptPrimaryOnce(providerKey, primaryRev);
+          } else {
+            throw e;
+          }
         }
       } else {
         throw e;
@@ -2629,23 +2638,34 @@ export class FileBasedSyncAdapterService {
         // Corrupt/torn sync-ops.json (the hot file, rewritten every op-bearing
         // sync): recover from .bak — same SPAP-8 semantics as the single-file
         // path, including seeding the heal cache with the CORRUPT primary's rev
-        // so this cycle's upload conditionally matches and heals it.
-        const recovered = await this._readBakFile<FileBasedOpsFile>(
-          provider,
-          cfg,
-          encryptKey,
-          FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
-          FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+        // so this cycle's upload conditionally matches and heals it. Gated on a
+        // confirming re-read (#9683) so a one-off mangled response cannot
+        // heal-overwrite an intact primary with a stale .bak.
+        const confirmed = await this._reDownloadOrNull(() =>
+          this._downloadOpsFile(provider, cfg, encryptKey),
         );
-        if (!recovered) throw e;
-        recoveredFromBackup = true;
-        OpLog.warn(
-          'FileBasedSyncAdapter: Primary ops file unreadable; recovered from backup',
-        );
-        opsFile = recovered.data;
-        opsRev = (e as { primaryRev?: string } | null)?.primaryRev ?? recovered.rev;
-        this._setCachedOpsData(providerKey, opsFile, opsRev, true);
-        this._notifyRecoveredCorruptPrimaryOnce(providerKey, opsRev);
+        if (confirmed) {
+          opsFile = confirmed.data;
+          opsRev = confirmed.rev;
+          this._setCachedOpsData(providerKey, opsFile, opsRev);
+        } else {
+          const recovered = await this._readBakFile<FileBasedOpsFile>(
+            provider,
+            cfg,
+            encryptKey,
+            FILE_BASED_SYNC_CONSTANTS.OPS_BACKUP_FILE,
+            FILE_BASED_SYNC_CONSTANTS.SPLIT_FILE_VERSION,
+          );
+          if (!recovered) throw e;
+          recoveredFromBackup = true;
+          OpLog.warn(
+            'FileBasedSyncAdapter: Primary ops file unreadable; recovered from backup',
+          );
+          opsFile = recovered.data;
+          opsRev = (e as { primaryRev?: string } | null)?.primaryRev ?? recovered.rev;
+          this._setCachedOpsData(providerKey, opsFile, opsRev, true);
+          this._notifyRecoveredCorruptPrimaryOnce(providerKey, opsRev);
+        }
       } else {
         throw e;
       }
@@ -3160,6 +3180,40 @@ export class FileBasedSyncAdapterService {
       (e as { primaryRev?: string }).primaryRev = rev;
     }
     return e;
+  }
+
+  /**
+   * #9683(a): confirming re-read before `.bak` adoption.
+   *
+   * `_isRecoverableCorruption()` classifies the FIRST response, so any transport
+   * that hands back a mangled body as a success (a silently truncated 200 —
+   * prefix intact, tail cut) makes a HEALTHY primary look corrupt. Adopting the
+   * stale `.bak` then heal-overwrites the intact primary at its real rev, losing
+   * one generation of ops. Re-running the FULL download+decode once distinguishes
+   * the two: genuine corruption fails again (→ null, recover as before), a one-off
+   * mangled read succeeds (→ use the good data, no recovery, no heal-overwrite).
+   *
+   * Cost: one extra GET, only on cycles that already failed to decode. Residual:
+   * a deterministic mangler (same corrupt bytes on every read) is indistinguishable
+   * from real corruption — the acknowledged limit of any re-read gate (#9682).
+   */
+  private async _reDownloadOrNull<T>(
+    download: () => Promise<{ data: T; rev: string }>,
+  ): Promise<{ data: T; rev: string } | null> {
+    try {
+      const res = await download();
+      OpLog.warn(
+        'FileBasedSyncAdapter: primary decoded fine on re-read — treating the first ' +
+          'failure as a transient transport fault; skipping .bak recovery.',
+      );
+      return res;
+    } catch (e) {
+      OpLog.normal(
+        'FileBasedSyncAdapter: primary still unreadable on re-read; proceeding with .bak recovery.',
+        e,
+      );
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION
Addresses shape (a) of #9683.

## The bug

`_isRecoverableCorruption()` classifies only the **first** response. So any transport that hands back a mangled body as a success — a silently truncated 200, prefix intact, JSON tail cut — makes a **healthy** primary look corrupt:

1. The prefix stage passes (the file really is ours).
2. Decode fails → `JsonParseError`.
3. `.bak` is adopted with no confirming re-read.
4. Because the download *succeeded*, we hold the primary's **real** rev — so the next conditional upload matches and heal-**overwrites** the intact primary with the stale backup.

One generation of ops lost, silently, with no error surfaced to the user.

#9683 filed this as "reasoned, not observed". It reproduces.

## Reproduction

`(#9683a) a TRANSIENT decode failure of a HEALTHY primary must not adopt .bak and heal-overwrite it` drives the **real** decode path — a genuinely truncated body, no injected error object.

Red on unmodified `file-based-sync-adapter.service.ts`:

```
✗ (#9683a) a TRANSIENT decode failure of a HEALTHY primary must not adopt .bak and heal-overwrite it
TOTAL: 1 FAILED, 140 SUCCESS
```

It fails three ways: the recovered ops are the previous generation, no corruption snack is shown, and the follow-up upload writes that older generation back over the intact primary.

Green with the fix: `TOTAL: 141 SUCCESS`.

## The fix

Before adopting `.bak`, re-run the full download+decode **once**.

- Genuine corruption fails again → recovery proceeds exactly as before, byte for byte.
- A one-off mangled read decodes fine → use it, skip recovery, never heal-overwrite.

Applied at **both** heal-overwrite sites — the single-file `_downloadOps` path and the split `_downloadOpsSplit` ops-file path — since both route through `_isRecoverableCorruption()`.

Cost: one extra GET, and only on cycles that already failed to decode.

## Notes for review

- **#9682 has not landed on `master`.** There is no `InvalidFilePrefixError` and no `_isPrefixFailurePersistent()` in this tree, so there was nothing to reuse and the re-read is implemented directly. If #9682 lands, the two gates should collapse into one helper.
- Shapes **(b)** and **(c)** from #9683 are about that same not-yet-existing prefix gate, so they are not actionable yet and are deliberately untouched.
- `_recoverStateFromBackup` (`sync-state.json.bak`) is deliberately skipped: it does not heal-overwrite, so it lacks the destructive half of the shape.
- **Acknowledged limit:** a *deterministic* mangler — same corrupt bytes on every read — is indistinguishable from real corruption. That is the inherent ceiling of any re-read gate, and the same one #9682 accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
