### PR TITLE
fix(mentions): flip short-syntax dropdown up when it runs off-screen

### DIFF
--- a/e2e/tests/add-task-bar/mention-dropdown-offscreen-5146.spec.ts
+++ b/e2e/tests/add-task-bar/mention-dropdown-offscreen-5146.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '../../fixtures/test.fixture';
+
+/**
+ * Issue #5146: on a phone the short-syntax autocomplete "gets stuck outside the
+ * screen by the lower side" — the reporter sees a blank strip over the add-task
+ * bar's action-chip row and none of the entries.
+ *
+ * Cause: `:host-context(.isTouchPrimary).global` pins the global add-task bar to
+ * the bottom of the screen, but the mention list only ever opened *downwards*
+ * from the caret, so the list rendered past the bottom edge. The mat-autocomplete
+ * panel next to it already has a touch rule that flips it above the input
+ * (`.isTouchPrimary .add-task-bar-panel`); the mention list had no equivalent.
+ *
+ * Headless Chromium reports a fine pointer, so `InputIntentService` classifies
+ * it as `mouseOnly` and never sets the body class — the test sets it directly,
+ * which is stable precisely because the service bails out on such devices.
+ *
+ * Run: npm run e2e:file e2e/tests/add-task-bar/mention-dropdown-offscreen-5146.spec.ts -- --retries=0
+ */
+
+// A phone with the on-screen keyboard up: the layout viewport shrinks and the
+// bar floats just above the keyboard, leaving almost no room below it.
+const PHONE_WITH_KEYBOARD = { width: 390, height: 330 };
+
+test.describe('Add-task-bar mention dropdown', () => {
+  test('should stay inside the viewport when the bar is pinned to the bottom', async ({
+    page,
+    workViewPage,
+    projectPage,
+  }) => {
+    await workViewPage.waitForTaskList();
+
+    // Enough projects that the `+` list cannot fit in the strip below the bar
+    for (const name of ['Alpha', 'Beta', 'Gamma']) {
+      await projectPage.createProject(name);
+    }
+
+    await page.goto('/#/tag/TODAY/tasks');
+    await workViewPage.waitForTaskList();
+
+    await page.evaluate(() => document.body.classList.add('isTouchPrimary'));
+
+    const addBtn = page.locator('.tour-addBtn');
+    await addBtn.waitFor({ state: 'visible', timeout: 20000 });
+    await addBtn.click();
+
+    const input = page.locator('add-task-bar.global .main-input').first();
+    await input.waitFor({ state: 'visible' });
+
+    await page.setViewportSize(PHONE_WITH_KEYBOARD);
+    await input.click();
+    await page.keyboard.type('test task +');
+
+    const list = page.locator('mention-list ul');
+    await expect(list).toBeVisible();
+
+    const geometry = await page.evaluate(() => {
+      const ul = document.querySelector('mention-list ul') as HTMLElement;
+      const bar = document.querySelector('add-task-bar.global') as HTMLElement;
+      const items = Array.from(ul.querySelectorAll('li')).map(
+        (li) => li.getBoundingClientRect().top,
+      );
+      return {
+        viewportHeight: window.innerHeight,
+        barTop: bar.getBoundingClientRect().top,
+        listBottom: ul.getBoundingClientRect().bottom,
+        itemCount: items.length,
+        itemsBelowFold: items.filter((top) => top >= window.innerHeight).length,
+      };
+    });
+
+    // guard the premise: the bar really is pinned to the bottom half
+    expect(geometry.barTop).toBeGreaterThan(geometry.viewportHeight / 2);
+    expect(geometry.itemCount).toBeGreaterThan(1);
+
+    expect(geometry.itemsBelowFold).toBe(0);
+    expect(geometry.listBottom).toBeLessThanOrEqual(geometry.viewportHeight);
+  });
+});

--- a/src/app/ui/mentions/mention-list.component.spec.ts
+++ b/src/app/ui/mentions/mention-list.component.spec.ts
@@ -230,4 +230,133 @@ describe('MentionListComponent', () => {
       expect(component.activeIndex).toBe(0); // should stay at first item
     });
   });
+
+  /**
+   * Issue #5146: on touch devices the global add-task bar is pinned to the
+   * bottom of the screen (`:host-context(.isTouchPrimary).global`), yet the
+   * mention list always opened downwards from the caret — so the whole
+   * `#tag` / `@due` / `+project` list rendered past the bottom edge and the
+   * user saw a blank strip over the action-chip row with no entries in it.
+   */
+  describe('drop direction', () => {
+    const stubList = (opts: {
+      top: number;
+      height: number;
+      viewportHeight: number;
+      /** Defaults to `viewportHeight` — the two only differ once an IME is up. */
+      visualViewportHeight?: number;
+    }): void => {
+      spyOnProperty(window, 'innerHeight', 'get').and.returnValue(opts.viewportHeight);
+      spyOnProperty(window, 'visualViewport', 'get').and.returnValue({
+        height: opts.visualViewportHeight ?? opts.viewportHeight,
+      } as VisualViewport);
+      spyOn(component.list.nativeElement, 'getBoundingClientRect').and.returnValue({
+        top: opts.top,
+        bottom: opts.top + opts.height,
+        left: 48,
+        right: 202,
+        width: 154,
+        height: opts.height,
+        x: 48,
+        y: opts.top,
+        toJSON: () => ({}),
+      } as DOMRect);
+    };
+
+    const hasDropUpClass = (): boolean =>
+      (component.list.nativeElement as HTMLElement).classList.contains(
+        'mention-dropdown',
+      );
+
+    beforeEach(() => {
+      component.items = Array.from({ length: 8 }, (_, i) => ({
+        label: `item${i}`,
+      })) as any;
+      // `checkNoChanges` trips on the `@for` views created by this first pass
+      fixture.detectChanges(false);
+    });
+
+    it('should flip above the caret when the list would run past the bottom edge', () => {
+      // bar pinned to the bottom: a 292px list starting at y=579 ends at 871
+      stubList({ top: 579, height: 292, viewportHeight: 640 });
+
+      component.reset();
+      fixture.detectChanges(false);
+
+      expect(component.dropUp).toBe(true);
+      expect(hasDropUpClass()).toBe(true);
+    });
+
+    it('should keep dropping down when the list fits below the caret', () => {
+      stubList({ top: 80, height: 292, viewportHeight: 640 });
+
+      component.reset();
+      fixture.detectChanges(false);
+
+      expect(component.dropUp).toBe(false);
+      expect(hasDropUpClass()).toBe(false);
+    });
+
+    it('should keep dropping down when it overflows but there is more room below', () => {
+      // bar near the top: a 560px list from y=120 overflows the bottom, but
+      // flipping it would leave only 120px above vs 520px below
+      stubList({ top: 120, height: 560, viewportHeight: 640 });
+
+      component.reset();
+      fixture.detectChanges(false);
+
+      expect(component.dropUp).toBe(false);
+    });
+
+    it('should measure against the visual viewport when the layout one does not shrink', () => {
+      // Android's WebView does not always apply adjustResize, so `innerHeight`
+      // stays at the full screen while the IME covers the bottom — only
+      // `visualViewport` sees the area that is actually visible. The bar has
+      // already moved up via `--keyboard-height`, so a list that looks like it
+      // fits below is really rendering into the keyboard.
+      stubList({
+        top: 460,
+        height: 292,
+        viewportHeight: 800,
+        visualViewportHeight: 500,
+      });
+
+      component.reset();
+      fixture.detectChanges(false);
+
+      expect(component.dropUp).toBe(true);
+      expect(hasDropUpClass()).toBe(true);
+    });
+
+    it('should measure a reused list at its natural height, not the previous cap', () => {
+      // a first `#` search capped the list; the following `+` search must not be
+      // measured against that leftover cap
+      const listEl = component.list.nativeElement as HTMLElement;
+      listEl.style.maxHeight = '120px';
+      stubList({ top: 579, height: 292, viewportHeight: 640 });
+      let capAtMeasureTime = 'not-measured';
+      (listEl.getBoundingClientRect as jasmine.Spy).and.callFake(() => {
+        capAtMeasureTime = listEl.style.maxHeight;
+        return { top: 579, bottom: 871, height: 292, left: 48, width: 154 } as DOMRect;
+      });
+
+      component.reset();
+
+      expect(capAtMeasureTime).toBe('');
+    });
+
+    it('should cap the height when the flipped list does not fit above either', () => {
+      // on-screen keyboard open: 330px of viewport, bar at the bottom
+      stubList({ top: 269, height: 292, viewportHeight: 330 });
+
+      component.reset();
+
+      expect(component.dropUp).toBe(true);
+      const maxHeight = parseFloat(
+        (component.list.nativeElement as HTMLElement).style.maxHeight,
+      );
+      expect(maxHeight).toBeGreaterThan(0);
+      expect(maxHeight).toBeLessThanOrEqual(269);
+    });
+  });
 });

--- a/src/app/ui/mentions/mention-list.component.ts
+++ b/src/app/ui/mentions/mention-list.component.ts
@@ -23,6 +23,10 @@ import { MatIcon } from '@angular/material/icon';
  *
  * Copyright (c) 2016 Dan MacFarlane
  */
+
+/** Breathing room kept between the list and the viewport edge when capping it. */
+const VIEWPORT_MARGIN = 8;
+
 @Component({
   selector: 'mention-list',
   styleUrls: ['./mention-list.component.scss'],
@@ -217,19 +221,43 @@ export class MentionListComponent implements AfterContentChecked {
     let left = this.coords.left;
     const top = this.coords.top;
     let dropUp = this.dropUp;
-    const bounds: ClientRect = this.list.nativeElement.getBoundingClientRect();
+    const listEl: HTMLElement = this.list.nativeElement;
+    // The component instance is reused across searches, so drop the cap left by
+    // the previous one — otherwise the list is measured at that height and both
+    // decisions below are made against a stale, too-small box.
+    listEl.style.maxHeight = '';
+    const bounds: ClientRect = listEl.getBoundingClientRect();
     // if off right of page, align right
     if (bounds.left + bounds.width > window.innerWidth) {
       left -= bounds.left + bounds.width - window.innerWidth + 10;
     }
-    // if more than half off the bottom of the page, force dropUp
-    // if ((bounds.top+bounds.height/2)>window.innerHeight) {
-    //   dropUp = true;
-    // }
+    // Not `innerHeight`: Android's WebView does not always apply adjustResize,
+    // so the layout viewport can stay at the full screen while the IME covers
+    // the bottom of it — see GlobalThemeService's visualViewport keyboard
+    // tracking. VisualViewport is the area that is really visible, and matches
+    // innerHeight wherever the layout viewport does shrink.
+    const visibleHeight = window.visualViewport?.height ?? window.innerHeight;
+    // Room on either side of the caret line the list was measured against.
+    const spaceBelow = visibleHeight - bounds.top;
+    const spaceAbove = bounds.top - this.offset;
+    // The global add-task bar is pinned to the bottom of the screen on touch
+    // devices, so a list that only ever drops down renders past the lower edge
+    // and reads as an empty strip with no entries in it (#5146). Flip it above
+    // the caret when it does not fit below and there is more room above.
+    if (bounds.bottom > visibleHeight && spaceAbove > spaceBelow) {
+      dropUp = true;
+    }
     // if top is off page, disable dropUp
     if (bounds.top < 0) {
       dropUp = false;
     }
+    // On a phone with the keyboard up neither side is necessarily tall enough,
+    // so cap the list to what is actually on screen — `.scrollable-menu` then
+    // scrolls it instead of letting the overflow be clipped away.
+    const available = Math.max(0, (dropUp ? spaceAbove : spaceBelow) - VIEWPORT_MARGIN);
+    listEl.style.maxHeight = bounds.height > available ? `${available}px` : '';
+
+    this.dropUp = dropUp;
     // set the revised/final position
     this.positionElement(left, top, dropUp);
   }
@@ -245,6 +273,14 @@ export class MentionListComponent implements AfterContentChecked {
     el.style.position = 'absolute';
     el.style.left = left + 'px';
     el.style.top = top + 'px';
+    // The app runs zoneless and this is called from a requestAnimationFrame, so
+    // nothing schedules a change detection pass for the template's
+    // `[class.mention-dropdown]` binding — apply it here. `this.dropUp` is kept
+    // in sync above, so a later pass agrees rather than fighting this.
+    this.list.nativeElement.classList.toggle(
+      'mention-dropdown',
+      dropUp && !this.styleOff,
+    );
   }
 
   private getBlockCursorDimensions(nativeParentElement: HTMLInputElement): {


### PR DESCRIPTION
Closes #5146

## The bug

On touch devices the global add-task bar is pinned to the bottom of the screen (`:host-context(.isTouchPrimary).global`), but the mention list only ever opened *downwards* from the caret. The `#tag` / `@due` / `+project` list therefore rendered past the lower edge and read as a blank strip over the action-chip row with no entries in it.

Two things had to line up for this:

- The mat-autocomplete panel beside it already has a touch rule that flips it above the input (`.isTouchPrimary .add-task-bar-panel`); the mention list had no equivalent.
- The vendored angular-mentions auto-flip in `checkBounds()` was commented out, and no `MentionConfig` ever sets `dropUp` — so the flip was doubly dead.

## The fix

`MentionListComponent.checkBounds()`:

- **Restore the flip**, gated on *overflows the bottom* **and** *more room above* — so a bar near the top still drops downwards.
- **Measure against `visualViewport`, not `innerHeight`.** Android's WebView does not always apply `adjustResize`, so the layout viewport can stay at full screen height while the IME covers the bottom of it (same reasoning as `GlobalThemeService`'s keyboard tracking, `global-theme.service.ts:860-873`). On that path `innerHeight` counts pixels hidden behind the keyboard as free space and the list never flips at all — i.e. exactly the reporter's platform.
- **Cap the list height** to the space actually on screen, so `.scrollable-menu` scrolls it instead of the overflow being clipped, for the case where neither side is tall enough.
- **Clear that cap before measuring** — the component is reused across searches, so the next one would otherwise be measured against a stale, too-small box.
- **Toggle `mention-dropdown` imperatively.** The app is zoneless and this runs from a `requestAnimationFrame`, so nothing schedules change detection for the `[class.mention-dropdown]` binding. `this.dropUp` is kept in sync so a later pass agrees rather than fighting it.

## Verification

Reproduced first, then fixed. Measured at 360×640 @2x with 8 projects:

| | before | after |
|---|---|---|
| keyboard open (h=330) | panel 269→561, 2 of 4 below fold | panel 4→243, 0 below fold |
| no keyboard (h=640) | panel 579→871, 6 of 8 below fold | panel 314→553, 0 below fold |

- 6 unit tests in `mention-list.component.spec.ts` covering flip / no-flip / more-room-below / visualViewport / stale-cap / height-cap. Each was confirmed red before the corresponding line existed.
- E2E repro `e2e/tests/add-task-bar/mention-dropdown-offscreen-5146.spec.ts` — `itemsBelowFold` 2 → 0.
- Full unit suite green; add-task-bar, short-syntax and autocomplete E2E green.

## Known gap

The `visualViewport` branch is **unit-tested only**. Playwright's `setViewportSize` always keeps the layout and visual viewports equal, so the two can only diverge with a real IME on a real Android runtime — which the E2E suite cannot produce. The unit test covers the decision given those inputs; it does not prove a real WebView produces them. #9761 tracks building a reusable local Android harness so this class of bug is verifiable rather than argued.

The iOS Capacitor path (`--keyboard-overlay-offset`) is unverified for the same reason.

https://claude.ai/code/session_01PRrsYwoAtW83ibUFEvf3b1
