### PR TITLE
build(android): enable R8 and fix credential handling on device migration

### DIFF
--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -49,7 +49,7 @@ jobs:
           # packages/sync-core is included because the Kotlin op-payload
           # decryptor must stay wire-compatible with its encrypt() — the live
           # round-trip test below is what catches drift on sync-core PRs.
-          ANDROID_PATTERN='^(android/|packages/sync-core/|tools/generate-android-crypto-fixtures\.mjs$|capacitor\.config\.ts$|package(-lock)?\.json$|\.github/workflows/android-tests\.yml$)'
+          ANDROID_PATTERN='^(android/|packages/sync-core/|tools/(generate-android-crypto-fixtures|verify-r8-mapping)\.mjs$|capacitor\.config\.ts$|package(-lock)?\.json$|\.github/workflows/android-tests\.yml$)'
           if grep -Eq "${ANDROID_PATTERN}" <<< "${CHANGED_FILES}"; then android=true; fi
 
           echo "→ android=${android}"
@@ -109,6 +109,17 @@ jobs:
         env:
           LIVE_CRYPTO_FIXTURES: ${{ github.workspace }}/android/app/build/live-crypto-fixtures.tsv
         run: ./gradlew :app:testPlayDebugUnitTest :app:testFdroidDebugUnitTest
+
+      # Release builds are minified, and both keep-rule failures are silent: a
+      # stripped @JavascriptInterface method or WorkManager worker builds and
+      # installs fine, it just never runs. Nothing else here exercises R8 — the
+      # emulator tests below run the debug build — so check the mapping instead.
+      - name: Verify R8 keep rules survive minification
+        if: steps.changes.outputs.android == 'true'
+        run: |
+          (cd android && ./gradlew :app:minifyFdroidReleaseWithR8)
+          node tools/verify-r8-mapping.mjs \
+            android/app/build/outputs/mapping/fdroidRelease/mapping.txt
 
       - name: Enable KVM
         if: steps.changes.outputs.android == 'true'

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -124,7 +124,11 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sup-android-release
-          path: android/app/build/outputs/apk/**/*.apk
+          # The R8 mapping travels with the APKs: release builds are minified, so
+          # without it a release stack trace cannot be retraced.
+          path: |
+            android/app/build/outputs/apk/**/*.apk
+            android/app/build/outputs/mapping/**/mapping.txt
 
       # Ship the dev-versioned APK to the Play `internal` track (non-tag master
       # pushes only, and only when the versionCode was actually applied). This is
@@ -145,6 +149,7 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.superproductivity.superproductivity
           releaseFiles: android/app/build/outputs/apk/play/release/*.apk
+          mappingFile: android/app/build/outputs/mapping/playRelease/mapping.txt
           releaseName: 'dev ${{ steps.devvc.outputs.code }} (${{ steps.devvc.outputs.sha }})'
           tracks: internal
           status: completed
@@ -193,6 +198,7 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.superproductivity.superproductivity
           releaseFiles: android/app/build/outputs/apk/play/release/*.apk
+          mappingFile: android/app/build/outputs/mapping/playRelease/mapping.txt
           tracks: internal
           status: completed
           inAppUpdatePriority: 2

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -56,8 +56,13 @@ android {
             }
 
             signingConfig signingConfigs.release
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            // Google Play requires a minimum level of DEX shrinking, obfuscation
+            // and optimization for app uploads from February 2027. The plain
+            // "proguard-android.txt" is not enough on its own: it sets
+            // -dontoptimize, so it would satisfy neither half of that.
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,24 +1,35 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
+# R8 rules for the release build.
 #
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Release builds are minified (see build.gradle) because Google Play requires a
+# minimum level of DEX shrinking, obfuscation and optimization from February 2027.
+# Everything R8 cannot see statically has to be kept here — reflection and the
+# WebView bridge both look like dead code to it.
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# --- WebView JS bridge ------------------------------------------------------
+# The Angular app calls these methods by name off the injected window property,
+# so R8 must neither rename nor drop them. Redundant today: the default
+# proguard-android-optimize.txt keeps @JavascriptInterface members globally.
+# Kept because it names the one class we actually depend on, and because the
+# failure is silent — a stripped bridge method builds and installs fine, the JS
+# call just goes nowhere. tools/verify-r8-mapping.mjs is what enforces it.
+-keepclassmembers class com.superproductivity.superproductivity.webview.JavaScriptInterface {
+    @android.webkit.JavascriptInterface <methods>;
+}
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# --- WorkManager ------------------------------------------------------------
+# Workers are instantiated reflectively from the class name persisted in the
+# WorkManager database. Redundant today, and measurably so — dropping this rule
+# still leaves SyncReminderWorker un-renamed, because SyncReminderScheduler
+# names the class through PeriodicWorkRequestBuilder<SyncReminderWorker>, so R8
+# keeps it and work-runtime's own -keepnames preserves the name. It stops being
+# redundant as soon as a worker is only ever referenced as a string: -keepnames
+# permits shrinking, so R8 would drop it. Same silent failure as above.
+-keep class * extends androidx.work.ListenableWorker {
+    public <init>(android.content.Context, androidx.work.WorkerParameters);
+}
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
-
-# Keep WorkManager worker classes (used for background sync reminder cancellation)
--keepnames class * extends androidx.work.CoroutineWorker
+# --- Tink (via androidx.security-crypto) ------------------------------------
+# Tink is annotated with Error Prone annotations that are compile-only and are
+# deliberately absent at runtime, so R8 reports them as missing classes. They
+# carry no runtime behaviour — suppressing the warning is the documented fix.
+-dontwarn com.google.errorprone.annotations.**

--- a/android/app/src/androidTest/java/com/superproductivity/superproductivity/service/BackgroundSyncCredentialStoreInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/superproductivity/superproductivity/service/BackgroundSyncCredentialStoreInstrumentedTest.kt
@@ -1,0 +1,134 @@
+package com.superproductivity.superproductivity.service
+
+import android.content.Context
+import androidx.security.crypto.MasterKey
+import androidx.test.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnit4
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.security.KeyStore
+
+/**
+ * Instrumented test for [BackgroundSyncCredentialStore].
+ *
+ * MUST run on an emulator/device, not Robolectric: the whole point is the real
+ * Android Keystore, which is what does not survive a device migration.
+ *
+ * Regression for the migration data-exposure bug. The EncryptedSharedPreferences
+ * master key is device-bound; cloud backup and device-to-device transfer carry
+ * the prefs file but never the key. On the new device Tink then throws out of
+ * `EncryptedSharedPreferences.create()`, and the catch in `createPrefs()` used to
+ * fall straight through to a plaintext SharedPreferences over that same file — so
+ * the SuperSync access token and the E2EE password were written to disk in the
+ * clear from the first launch onward, and never re-encrypted, because create()
+ * keeps failing on the stale keyset on every later process start.
+ *
+ * Run: ./gradlew :app:connectedPlayDebugAndroidTest (emulator/device required).
+ */
+@RunWith(AndroidJUnit4::class)
+class BackgroundSyncCredentialStoreInstrumentedTest {
+
+    private val context: Context
+        get() = InstrumentationRegistry.getTargetContext().applicationContext
+
+    private val prefsFile: File
+        get() = File(context.applicationInfo.dataDir, "shared_prefs/$PREFS_FILE_NAME")
+
+    @Before
+    fun reset() = wipe()
+
+    @After
+    fun cleanUp() = wipe()
+
+    private fun wipe() {
+        BackgroundSyncCredentialStore.clear(context)
+        context.deleteSharedPreferences(PREFS_NAME)
+        forgetCachedPrefs()
+    }
+
+    /** Drops the process-lifetime `prefs` cache so the next call re-opens the store. */
+    private fun forgetCachedPrefs() {
+        BackgroundSyncCredentialStore::class.java.getDeclaredField("prefs").apply {
+            isAccessible = true
+            set(BackgroundSyncCredentialStore, null)
+        }
+    }
+
+    /**
+     * What a restore onto a new device leaves behind: the prefs file is still
+     * there, the Keystore key that wrapped its keyset is not. Dropping the cached
+     * instance stands in for the fresh process on the new device.
+     */
+    private fun simulateDeviceMigration() {
+        KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+            .deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+        forgetCachedPrefs()
+    }
+
+    @Test
+    fun credentialsRoundTripAndAreNotStoredInCleartext() {
+        BackgroundSyncCredentialStore.save(context, BASE_URL, TOKEN)
+        BackgroundSyncCredentialStore.setEncryptionPassword(context, PASSWORD)
+
+        val credentials = BackgroundSyncCredentialStore.get(context)
+        assertNotNull(credentials)
+        assertEquals(BASE_URL, credentials!!.baseUrl)
+        assertEquals(TOKEN, credentials.accessToken)
+        assertNoSecretsOnDisk()
+    }
+
+    /**
+     * After a migration the inherited credentials are unreadable, which must read
+     * as "not signed in" rather than as a crash — the WebView re-supplies them.
+     */
+    @Test
+    fun migratedInstallReportsNoCredentials() {
+        BackgroundSyncCredentialStore.save(context, BASE_URL, TOKEN)
+        simulateDeviceMigration()
+
+        assertNull(BackgroundSyncCredentialStore.get(context))
+    }
+
+    /**
+     * Core regression. Pre-fix the store silently degraded to plaintext for the
+     * rest of the install's life, so this write landed on disk unencrypted.
+     */
+    @Test
+    fun migratedInstallReEncryptsInsteadOfFallingBackToCleartext() {
+        BackgroundSyncCredentialStore.save(context, BASE_URL, TOKEN)
+        BackgroundSyncCredentialStore.setEncryptionPassword(context, PASSWORD)
+        simulateDeviceMigration()
+
+        // Whatever the WebView supplies after the migration must still be encrypted.
+        BackgroundSyncCredentialStore.save(context, BASE_URL, TOKEN)
+        BackgroundSyncCredentialStore.setEncryptionPassword(context, PASSWORD)
+
+        assertEquals(TOKEN, BackgroundSyncCredentialStore.get(context)?.accessToken)
+        assertEquals(PASSWORD, BackgroundSyncCredentialStore.getEncryptionPassword(context))
+        assertNoSecretsOnDisk()
+    }
+
+    private fun assertNoSecretsOnDisk() {
+        val raw = prefsFile.takeIf { it.exists() }?.readText().orEmpty()
+        assertFalse("access token found in cleartext in $PREFS_FILE_NAME", raw.contains(TOKEN))
+        assertFalse("E2EE password found in cleartext in $PREFS_FILE_NAME", raw.contains(PASSWORD))
+        assertFalse("base url found in cleartext in $PREFS_FILE_NAME", raw.contains(BASE_URL))
+    }
+
+    private companion object {
+        const val PREFS_NAME = "SuperProductivitySync"
+        const val PREFS_FILE_NAME = "$PREFS_NAME.xml"
+
+        // Distinctive values so a cleartext hit cannot be a coincidental substring.
+        const val BASE_URL = "https://instr-test-sync.example.invalid"
+        const val TOKEN = "instr-test-token-6f3a9c2e1b7d"
+        const val PASSWORD = "instr-test-password-4e8b1d0a5c9f"
+    }
+}

--- a/android/app/src/main/java/com/superproductivity/superproductivity/service/BackgroundSyncCredentialStore.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/service/BackgroundSyncCredentialStore.kt
@@ -44,21 +44,40 @@ object BackgroundSyncCredentialStore {
 
     private fun createPrefs(context: Context): SharedPreferences {
         return try {
-            val masterKey = MasterKey.Builder(context.applicationContext)
-                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                .build()
-            EncryptedSharedPreferences.create(
-                context.applicationContext,
-                PREFS_NAME,
-                masterKey,
-                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-            )
+            createEncryptedPrefs(context)
         } catch (e: Exception) {
-            // Fallback to standard SharedPreferences if KeyStore is broken
-            Log.w(TAG, "EncryptedSharedPreferences unavailable, falling back to standard", e)
-            context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            // The master key is device-bound and lives in the Android Keystore,
+            // which neither cloud backup nor device-to-device transfer carries
+            // over. A migrated install therefore holds a keyset it can never
+            // unwrap, and Tink throws out of create() rather than returning
+            // empty. Falling straight through to the plaintext store below
+            // would then write the access token and the E2EE password to disk
+            // in the clear, on every device the user migrates to — so discard
+            // the unreadable file and mint a fresh encrypted store first. The
+            // WebView re-supplies the credentials on the next foreground sync.
+            Log.w(TAG, "Encrypted store unreadable, discarding it", e)
+            context.applicationContext.deleteSharedPreferences(PREFS_NAME)
+            try {
+                createEncryptedPrefs(context)
+            } catch (e2: Exception) {
+                // Fallback to standard SharedPreferences if KeyStore is broken
+                Log.w(TAG, "EncryptedSharedPreferences unavailable, falling back to standard", e2)
+                context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            }
         }
+    }
+
+    private fun createEncryptedPrefs(context: Context): SharedPreferences {
+        val masterKey = MasterKey.Builder(context.applicationContext)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        return EncryptedSharedPreferences.create(
+            context.applicationContext,
+            PREFS_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
     }
 
     @Synchronized

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -4,4 +4,13 @@
   <exclude
     domain="sharedpref"
     path="com.superproductivity.superproductivity_preferences.xml" />
+  <!--
+    BackgroundSyncCredentialStore is EncryptedSharedPreferences. Its master key
+    lives in the device-bound Android Keystore, which backup never carries over,
+    so a restored file is undecryptable ciphertext that makes every read throw.
+    Keep it device-local; the WebView re-supplies the credentials on next sync.
+  -->
+  <exclude
+    domain="sharedpref"
+    path="SuperProductivitySync.xml" />
 </full-backup-content>

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -13,4 +13,14 @@
   <exclude
     domain="sharedpref"
     path="SuperProductivitySync.xml" />
+  <!--
+    Per-device WebView verdict. block_override is the user's decision to bypass
+    the block screen on THIS device; restoring it elsewhere silently disarms a
+    guard that exists because users otherwise uninstall their WebView updates,
+    which resets the Chromium profile and takes the app's local data with it.
+    last_known_good_major_version is device-specific for the same reason.
+  -->
+  <exclude
+    domain="sharedpref"
+    path="webview_compatibility.xml" />
 </full-backup-content>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -5,11 +5,19 @@
     <exclude
       domain="sharedpref"
       path="com.superproductivity.superproductivity_preferences.xml" />
+    <!-- Keystore-bound ciphertext; see backup_rules.xml. -->
+    <exclude
+      domain="sharedpref"
+      path="SuperProductivitySync.xml" />
   </cloud-backup>
   <device-transfer>
     <!-- A transferred fresh install should select launch mode from current state. -->
     <exclude
       domain="sharedpref"
       path="com.superproductivity.superproductivity_preferences.xml" />
+    <!-- Keystore-bound ciphertext; see backup_rules.xml. -->
+    <exclude
+      domain="sharedpref"
+      path="SuperProductivitySync.xml" />
   </device-transfer>
 </data-extraction-rules>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -9,6 +9,10 @@
     <exclude
       domain="sharedpref"
       path="SuperProductivitySync.xml" />
+    <!-- Per-device WebView verdict; see backup_rules.xml. -->
+    <exclude
+      domain="sharedpref"
+      path="webview_compatibility.xml" />
   </cloud-backup>
   <device-transfer>
     <!-- A transferred fresh install should select launch mode from current state. -->
@@ -19,5 +23,9 @@
     <exclude
       domain="sharedpref"
       path="SuperProductivitySync.xml" />
+    <!-- Per-device WebView verdict; see backup_rules.xml. -->
+    <exclude
+      domain="sharedpref"
+      path="webview_compatibility.xml" />
   </device-transfer>
 </data-extraction-rules>

--- a/tools/verify-r8-mapping.mjs
+++ b/tools/verify-r8-mapping.mjs
@@ -42,7 +42,7 @@ const bridge = sources.find((s) => s.path.endsWith('JavaScriptInterface.kt'));
 if (!bridge) throw new Error('JavaScriptInterface.kt not found under ' + srcRoot);
 const bridgeClass = fqcn(bridge.text, 'JavaScriptInterface');
 const bridgeMethods = [
-  ...bridge.text.matchAll(/@JavascriptInterface\s+(?:[^\n]*\n\s*)*?fun\s+(\w+)/g),
+  ...bridge.text.matchAll(/@JavascriptInterface\s+(?:[^\n]*\n[ \t]*)*?fun\s+(\w+)/g),
 ].map((m) => m[1]);
 
 const workers = sources.flatMap(({ text }) =>

--- a/tools/verify-r8-mapping.mjs
+++ b/tools/verify-r8-mapping.mjs
@@ -42,7 +42,7 @@ const bridge = sources.find((s) => s.path.endsWith('JavaScriptInterface.kt'));
 if (!bridge) throw new Error('JavaScriptInterface.kt not found under ' + srcRoot);
 const bridgeClass = fqcn(bridge.text, 'JavaScriptInterface');
 const bridgeMethods = [
-  ...bridge.text.matchAll(/@JavascriptInterface\s+(?:[^\n]*\n[ \t]*)*?fun\s+(\w+)/g),
+  ...bridge.text.matchAll(/@JavascriptInterface[\s\S]*?\bfun\s+(\w+)/g),
 ].map((m) => m[1]);
 
 const workers = sources.flatMap(({ text }) =>

--- a/tools/verify-r8-mapping.mjs
+++ b/tools/verify-r8-mapping.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Guards the two R8 keep rules whose failure is invisible at build time.
+ *
+ * A minified release that drops a @JavascriptInterface method or a WorkManager
+ * worker builds and installs fine — the bridge call just goes nowhere and the
+ * worker never runs. Both only surface on a device, and release builds ship to
+ * the Play internal track straight off master, so this reads the mapping R8
+ * already produces and fails the build instead.
+ *
+ * Expectations come from the Kotlin sources, not a hardcoded list, so adding a
+ * bridge method or a worker keeps the check honest without touching this file.
+ *
+ * Usage: node tools/verify-r8-mapping.mjs <mapping.txt> [androidSrcRoot]
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const [mappingPath, srcRoot = 'android/app/src/main/java'] = process.argv.slice(2);
+if (!mappingPath) {
+  console.error('usage: node tools/verify-r8-mapping.mjs <mapping.txt> [androidSrcRoot]');
+  process.exit(2);
+}
+
+const kotlinFiles = (dir) =>
+  readdirSync(dir).flatMap((entry) => {
+    const p = join(dir, entry);
+    return statSync(p).isDirectory() ? kotlinFiles(p) : p.endsWith('.kt') ? [p] : [];
+  });
+
+const sources = kotlinFiles(srcRoot).map((path) => ({
+  path,
+  text: readFileSync(path, 'utf8'),
+}));
+
+/** `com.example` + `class Foo` -> `com.example.Foo`, for the mapping's left-hand side. */
+const fqcn = (text, name) => `${/^package\s+([\w.]+)/m.exec(text)?.[1] ?? ''}.${name}`;
+
+// --- expectations from source ------------------------------------------------
+
+const bridge = sources.find((s) => s.path.endsWith('JavaScriptInterface.kt'));
+if (!bridge) throw new Error('JavaScriptInterface.kt not found under ' + srcRoot);
+const bridgeClass = fqcn(bridge.text, 'JavaScriptInterface');
+const bridgeMethods = [
+  ...bridge.text.matchAll(/@JavascriptInterface\s+(?:[^\n]*\n\s*)*?fun\s+(\w+)/g),
+].map((m) => m[1]);
+
+const workers = sources.flatMap(({ text }) =>
+  [
+    ...text.matchAll(
+      /class\s+(\w+)\s*\([^)]*\)\s*:\s*(?:CoroutineWorker|ListenableWorker|Worker)\b/gs,
+    ),
+  ].map((m) => fqcn(text, m[1])),
+);
+
+// --- what R8 actually emitted ------------------------------------------------
+
+const mapping = readFileSync(mappingPath, 'utf8').split('\n');
+const classLine = (name) => mapping.find((l) => l.startsWith(`${name} ->`));
+
+const bodyOf = (name) => {
+  const i = mapping.findIndex((l) => l.startsWith(`${name} ->`));
+  if (i < 0) return null;
+  const out = [];
+  for (const line of mapping.slice(i + 1)) {
+    if (!line || line.trimStart().startsWith('#')) continue;
+    if (!/^\s/.test(line)) break;
+    out.push(line);
+  }
+  return out;
+};
+
+const errors = [];
+
+const bridgeBody = bodyOf(bridgeClass);
+if (!bridgeBody) {
+  errors.push(
+    `${bridgeClass} is absent from the mapping — R8 removed the WebView bridge entirely.`,
+  );
+} else {
+  const unrenamed = new Set(
+    bridgeBody
+      .map((l) =>
+        /^\s+(?:\d+:\d+:)?[\w.$[\]<>]+ ([\w<>$]+)\([^)]*\)(?::\d+)*\s*->\s*(\S+)$/.exec(
+          l,
+        ),
+      )
+      .filter((m) => m && m[1] === m[2])
+      .map((m) => m[1]),
+  );
+  for (const name of bridgeMethods) {
+    if (!unrenamed.has(name)) {
+      errors.push(
+        `@JavascriptInterface ${name}() was renamed or stripped — the JS call would go nowhere.`,
+      );
+    }
+  }
+}
+
+for (const worker of workers) {
+  const line = classLine(worker);
+  if (!line)
+    errors.push(
+      `${worker} was stripped — WorkManager instantiates it reflectively by name.`,
+    );
+  else if (!line.startsWith(`${worker} -> ${worker}:`))
+    errors.push(`${worker} was renamed to ${line.split('-> ')[1]}.`);
+}
+
+// --- report ------------------------------------------------------------------
+
+if (errors.length) {
+  console.error('R8 mapping check FAILED:\n' + errors.map((e) => `  - ${e}`).join('\n'));
+  console.error('\nFix the keep rules in android/app/proguard-rules.pro.');
+  process.exit(1);
+}
+
+if (!bridgeMethods.length || !workers.length) {
+  console.error(
+    `R8 mapping check FAILED: parsed ${bridgeMethods.length} bridge methods and ${workers.length} workers ` +
+      'from source. Zero means this check is silently passing — fix the source parsing.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `R8 mapping OK: ${bridgeMethods.length} bridge methods un-renamed, ${workers.length} worker(s) kept.`,
+);


### PR DESCRIPTION
Google Play announced two new technical quality requirements. This PR implements the two that apply now; the third is tracked separately.

## 1. Safe device migration (fix)

`BackgroundSyncCredentialStore` keeps the SuperSync access token and the E2EE password in `EncryptedSharedPreferences`. The master key is device-bound and lives in the Android Keystore, which **neither cloud backup nor device-to-device transfer carries over** — but `SuperProductivitySync.xml` *was* backed up. A migrated install therefore held a keyset it can never unwrap, Tink threw out of `EncryptedSharedPreferences.create()`, and the pre-existing `catch` fell straight through to plain `getSharedPreferences()`. The next `save()` then wrote **the access token and the E2EE password to disk in cleartext**, on every device the user migrates to.

`createPrefs()` now discards an unreadable store and mints a fresh encrypted one, falling back to plaintext only if the Keystore itself is broken. The WebView re-supplies the credentials on the next foreground sync. Additionally `SuperProductivitySync.xml` and `webview_compatibility.xml` (a per-device WebView verdict) are excluded from `backup_rules.xml` and `data_extraction_rules.xml`, in both `<cloud-backup>` and `<device-transfer>`.

**Verified on an API 35 emulator, with a negative control.** `BackgroundSyncCredentialStoreInstrumentedTest.migratedInstallReEncryptsInsteadOfFallingBackToCleartext` deletes the Keystore alias underneath a surviving prefs file — the migration, reproduced. With the fix: 3/3 green. With `createPrefs()` reverted to its pre-fix body: `AssertionError: access token found in cleartext in SuperProductivitySync.xml`.

## 2. DEX shrinking, obfuscation and optimization (build)

From February 2027 Play requires a minimum level of DEX reduction for apps above 10 MB DEX. This app was at **14.82 MB** unminified — over the threshold and doing none of it.

Enables `minifyEnabled` + `shrinkResources` with **`proguard-android-optimize.txt`**. The plain `proguard-android.txt` would not be enough on its own: it sets `-dontoptimize`, so it satisfies neither half of the requirement. Measured reduction: **84.7%**.

Of the rules in `proguard-rules.pro` only `-dontwarn com.google.errorprone.annotations.**` (Tink) is load-bearing. The keep rules for the `@JavascriptInterface` bridge and the WorkManager worker are **redundant today** — verified by removing each and re-running R8; the default config already carries a global `@JavascriptInterface` rule, and `SyncReminderScheduler` references the worker statically. They stay as guards, with comments saying exactly that.

Both keep-rule failures are silent: a stripped bridge method or worker builds and installs fine, it just never runs. Nothing else exercises R8 (the instrumentation suite runs the debug build), so `tools/verify-r8-mapping.mjs` derives the expected bridge methods and worker classes from the Kotlin sources — not a hardcoded list — and checks them against `mapping.txt`. It exits non-zero if it parses zero expectations, so it cannot pass vacuously. CI runs it against `minifyFdroidReleaseWithR8`. Current run: `R8 mapping OK: 33 bridge methods un-renamed, 1 worker(s) kept.`

Release crash reports stay retraceable: `mappingFile:` on both Play uploads, and `mapping.txt` added to the artifact upload.

## 3. Zero-Tap Sign-In — not in this PR

The Restore Credentials API requirement lands April 2027 and is tracked in #9757. Backup-quota measurement is #9762 (measure with `bmgr` / `dumpsys backup` first — excluding the wrong component could remove the only working recovery path). `SuperProductivityAlarms` deliberately stays in backup: `BootReceiver` rebuilds alarms exclusively from it.

## Risks

- **R8 is the real risk here.** Reflective use that neither the keep rules nor the mapping check covers fails silently at runtime rather than at build time. A smoke test of the release APK from the internal track is still worth doing before this reaches production.
- Merging publishes to the Play internal track automatically, i.e. onto testers' real data.

https://claude.ai/code/session_018GiPapudvgQjkCuqNdfAoF
