### PR TITLE
fix(task): keep narrow task rows from spilling off the left edge

### DIFF
--- a/e2e/tests/task-list-basic/parent-title-overflow-9750.spec.ts
+++ b/e2e/tests/task-list-basic/parent-title-overflow-9750.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '../../fixtures/test.fixture';
+
+/**
+ * Issue #9750: on a phone "the beginning of the name is cut off on the screen".
+ * The reporter narrowed it down themselves — it needs a sub-task shown in the
+ * Today view whose parent has no date, so the task row carries the `.parent-title`
+ * line with the (long) parent name.
+ *
+ * Cause: `.parent-title .title` is `white-space: nowrap`, so the min-content width
+ * it contributes upwards is the whole untruncated parent name. With
+ * `.title-and-left-btns-wrapper` at `min-width: auto` that intrinsic size became a
+ * floor the wrapper could not shrink below, so on a narrow screen it outgrew
+ * `.first-line` — and since the wrapper centers its content, the overflow was split
+ * evenly to both sides, pushing the start of both titles (and the done-toggle) off
+ * the left edge. `min-width: 0` lets it shrink so the parent name ellipsizes instead.
+ *
+ * Run: npm run e2e:file e2e/tests/task-list-basic/parent-title-overflow-9750.spec.ts -- --retries=0
+ */
+
+const PHONE = { width: 360, height: 780 };
+
+const LONG_PARENT =
+  'Call the insurance company about the damaged roof claim and get the reference number';
+const SUB_TASK = 'Find the policy number first';
+
+test.describe('Task title overflow with parent title', () => {
+  test('should keep a sub-task row inside the viewport on a narrow screen', async ({
+    page,
+    workViewPage,
+    taskPage,
+  }) => {
+    await workViewPage.waitForTaskList();
+
+    // The parent must stay undated, so create it in the project view rather than
+    // in Today (adding from Today would set dueDay and nest the sub-task under it).
+    await page.goto('/#/project/INBOX_PROJECT/tasks');
+    await workViewPage.waitForTaskList();
+    await workViewPage.addTask(LONG_PARENT);
+
+    const parentTask = taskPage.getTaskByText(LONG_PARENT).first();
+    await parentTask.waitFor({ state: 'visible' });
+    await workViewPage.addSubTask(parentTask, SUB_TASK);
+
+    // Shift+T === taskScheduleToday: the sub-task moves into Today on its own,
+    // which is what makes it render flat with a `.parent-title` line.
+    const subTask = taskPage.getTaskByText(SUB_TASK).last();
+    await subTask.focus();
+    await subTask.press('Shift+T');
+
+    await page.goto('/#/tag/TODAY/tasks');
+    await workViewPage.waitForTaskList();
+    await page.setViewportSize(PHONE);
+
+    const parentTitle = page.locator('task .parent-title .title').first();
+    await expect(parentTitle).toBeVisible();
+    // The move-to-Today animation leaves a transient clone of the row behind;
+    // measuring while it is still in flight reads the animated position.
+    await expect(page.locator('task')).toHaveCount(1);
+
+    const geometry = await page.evaluate(() => {
+      const task = document.querySelector('task') as HTMLElement;
+      const rect = (sel: string): { left: number; right: number } | null => {
+        const el = task.querySelector(sel);
+        if (!el) return null;
+        const { left, right } = el.getBoundingClientRect();
+        return { left, right };
+      };
+      const title = task.querySelector('.parent-title .title') as HTMLElement;
+      return {
+        viewportWidth: window.innerWidth,
+        row: rect('.title-and-left-btns-wrapper'),
+        parentTitle: rect('.parent-title .title'),
+        taskTitle: rect('task-title'),
+        // the long parent name should be ellipsized, not spilling out of its box
+        isParentTitleTruncated: title.scrollWidth > title.clientWidth,
+      };
+    });
+
+    expect(geometry.row).not.toBeNull();
+    expect(geometry.parentTitle).not.toBeNull();
+    expect(geometry.taskTitle).not.toBeNull();
+
+    // Nothing may start left of the viewport — that is the reported symptom.
+    expect(geometry.row!.left).toBeGreaterThanOrEqual(0);
+    expect(geometry.parentTitle!.left).toBeGreaterThanOrEqual(0);
+    expect(geometry.taskTitle!.left).toBeGreaterThanOrEqual(0);
+
+    // ...and the row must fit, so the end is not lost either.
+    expect(geometry.row!.right).toBeLessThanOrEqual(geometry.viewportWidth);
+
+    expect(geometry.isParentTitleTruncated).toBe(true);
+  });
+});

--- a/src/app/features/tasks/task/_task-base.scss
+++ b/src/app/features/tasks/task/_task-base.scss
@@ -219,6 +219,12 @@
   flex-grow: 1;
   flex-shrink: 1;
   flex-basis: 70%;
+  // Without this the automatic minimum size keeps the wrapper at its min-content
+  // width, which the nowrap .parent-title carries as the full untruncated parent
+  // name. On narrow screens the wrapper then outgrows .first-line and, because we
+  // center here, the overflow is split evenly left and right — pushing the start
+  // of the title off the left edge (#9750).
+  min-width: 0;
   // we cannot do this since this cuts of the box shadow of the task edit
   //overflow: hidden;
   -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
Fixes the first item of #9750: on a phone, "the beginning of the name is cut off on the screen".

## Reproduction

The reporter narrowed it down themselves, and their guess was right — it needs a **sub-task shown in Today whose parent has no date**, so the row carries the `.parent-title` line with the (long) parent name. Measured at a 360px viewport before the fix:

| element | left | width |
| --- | --- | --- |
| `.first-line` (available) | 8 | 344 |
| `.title-and-left-btns-wrapper` | **−200** | 552 |
| `.parent-title .title` | **−144** | 496 |
| `task-title` | **−151** | 503 |

The whole row sits 200px off the left edge: the done-toggle is gone, the parent name starts mid-word and the sub-task title renders as "…er first".

## Cause

`.parent-title .title` is `white-space: nowrap`, so the min-content width it contributes upwards is the entire untruncated parent name. `.title-and-left-btns-wrapper` was at `min-width: auto` with visible overflow, which turns that intrinsic size into a floor it cannot shrink below — so on narrow screens it outgrows `.first-line`. Because that wrapper is `justify-content: center`, the overflow is split evenly to both sides, which is why the *beginning* is cut off rather than the end.

Note `truncateText()`'s `overflow: hidden` already zeroes the *item's* automatic minimum, so `min-width: 0` on `.title` or `.parent-title` changes nothing (I probed both) — the container's min-content still carries the nowrap text. The floor has to come off the wrapper.

## Fix

`min-width: 0` on `.title-and-left-btns-wrapper`, so it can shrink and the parent name ellipsizes instead. Not Android-specific — any narrow window hits it. Present since 40d04f4a08 (2025-08-01) and shipped in v18.20.1, the reporter's version.

## Test

`e2e/tests/task-list-basic/parent-title-overflow-9750.spec.ts` walks the real path (undated parent in Inbox → sub-task → `Shift+T` into Today → Today view at 360×780) and asserts the row, parent title and task title all start at x ≥ 0, that the row fits the viewport, and that the parent name is genuinely ellipsized.

- With the fix: passes. With the fix reverted: fails at `left: -240` — so it pins the reported symptom, not something adjacent.
- No regressions: `task-list-basic` + `task-basic` (26 passed), `work-view` + `task-dragdrop` + `task-detail` (38 passed).

## Not addressed here

The issue bundles three more items, all deliberately left out of this PR:

- **Upper vs lower case (item 2)** — not an app bug. There is no `autocapitalize` anywhere in the codebase, so Android's default (`sentences`) applies and desktop keyboards don't capitalize. Which direction is correct is a product call.
- **No autocorrect / dictionary (item 3)** — real and code-level: `spellcheck="false"` is hard-coded on all three task-name inputs (`task-title.component.html:31`, `add-task-bar.component.html:56`, `add-subtask-input.component.html:12`), and Gboard keys autocorrect off that attribute. But #751, #2874 and #4040 are users asking for spellcheck *off*, so a blanket flip regresses them; scoping it to touch devices would need its own decision.
- **Line breaks in task titles (item 4)** — Enter submits and Ctrl/Cmd+Enter already adds a sub-task, so there is no free key for a newline, and titles are single-line across list, planner, schedule, focus mode, plugin API and exports.

https://claude.ai/code/session_01B7ktLsRMzz7JVLicNM3QWn