### PR TITLE
fix(op-log): defer an incoming causal REPAIR instead of prompting (#9773)

### DIFF
--- a/ARCHITECTURE-DECISIONS.md
+++ b/ARCHITECTURE-DECISIONS.md
@@ -177,6 +177,12 @@ latency or transaction lock-hold time becomes a measured production problem.
   to reject an upload behind the latest `SYNC_IMPORT` or `BACKUP_IMPORT` before
   insertion. The durable replacement marker is reconciled lazily from retained
   operations for rows created before the marker existed.
+- The marker carries **import** semantics — it forces a stale client to download
+  a replacement whose concurrent ops the client then drops. Only an import
+  advances it. The lazy reconcile falls back to the newest causal `REPAIR` purely
+  as a stand-in for an import row that pruning already deleted; a repair is not a
+  fence in its own right, and the client replays concurrent work on top of one
+  rather than dropping it
 - Markerless legacy repairs are compatibility records, not causal boundaries:
   they cannot drive download fast-forward, snapshot trust, history pruning, or
   server-generated restore points; snapshot replay across one fails closed

--- a/e2e/tests/sync/supersync-repair-lifecycle.spec.ts
+++ b/e2e/tests/sync/supersync-repair-lifecycle.spec.ts
@@ -511,28 +511,23 @@ test.describe('@supersync REPAIR lifecycle', () => {
 
 test.describe('@supersync REPAIR with an offline client', () => {
   /**
-   * A causal REPAIR is automatic, so its client contract is meant to be
-   * narrower than an import's: `SyncImportFilterService` drops only the ops the
-   * repair snapshot already covers, concurrent work replays on top instead of
-   * being discarded, and its own doc states that an automatic REPAIR "never
-   * opens the explicit import/restore conflict dialog".
+   * A causal REPAIR is automatic, so it must never reach the explicit
+   * import/restore conflict dialog. It used to: `SyncImportConflictGateService`
+   * matched on `FULL_STATE_OP_TYPES`, which includes REPAIR, so a device
+   * returning with pending work after another device's background repair was
+   * prompted with "replaces this device's data with the server's and discards N
+   * local change(s)" — and every answer lost something. Traced: the returning
+   * device issued no ops upload at all, so its work reached neither the server
+   * nor its own repaired state (#9773).
    *
-   * KNOWN FAILING — it does. `SyncImportConflictGateService` matches on
-   * `FULL_STATE_OP_TYPES`, which includes REPAIR, so a device returning with
-   * pending work after another device's background repair is prompted with the
-   * import conflict dialog ("replaces this device's data with the server's and
-   * discards N local change(s)") and loses that work if it accepts. Verified
-   * from the trace: the returning device issues no ops upload at all, so the
-   * work reaches neither the server nor the repaired state.
-   *
-   * Note the gate is currently the ONLY thing protecting those ops: applying a
-   * full-state op replaces the whole store, and nothing replays local unsynced
-   * ops afterwards. Simply exempting REPAIR from the gate would trade the
-   * prompt for silent divergence. Making this pass means replaying the pending
-   * ops on top of the applied repair, which is what SyncImportFilterService
-   * already promises for concurrent work. Filed as #9773.
+   * Exempting REPAIR from the gate would have been worse than the prompt:
+   * applying a full-state op replaces the whole store and nothing replays local
+   * unsynced ops afterwards, so it would trade the dialog for silent
+   * divergence. The fix defers instead — a device holding pending work skips
+   * the incoming snapshot and heals its own copy of the same corruption, which
+   * is why a second REPAIR here is expected rather than a regression.
    */
-  test.fixme('keeps an offline client’s pending work and does not resurrect what the REPAIR removed', async ({
+  test('keeps an offline client’s pending work and does not resurrect what the REPAIR removed', async ({
     browser,
     baseURL,
     testRunId,
@@ -604,11 +599,24 @@ test.describe('@supersync REPAIR with an offline client', () => {
       await waitForTask(clientA.page, offlineTaskTitle);
       await expectConvergedTask(clientA, sharedTaskTitle, ghostTagId);
 
-      // Still exactly one repair: B's return did not trigger a second one.
+      // One more round each so B's own repair — if it uploaded one after
+      // healing itself — is on the server and applied by A.
+      await clientB.sync.syncAndWait({ timeout: 60000 });
+      await clientA.sync.syncAndWait({ timeout: 60000 });
+      await expectConvergedTask(clientA, sharedTaskTitle, ghostTagId);
+      await expectConvergedTask(clientB, sharedTaskTitle, ghostTagId);
+      await waitForTask(clientA.page, offlineTaskTitle);
+      await waitForTask(clientB.page, offlineTaskTitle);
+      await waitForTask(clientA.page, sharedTaskTitle);
+      await waitForTask(clientB.page, sharedTaskTitle);
+
+      // A's repair, plus at most B's own after it healed its local copy.
+      // Anything beyond that is the two clients trading repairs.
       const repairOperations = (await getServerOperations(user.userId)).filter(
         ({ opType }) => opType === 'REPAIR',
       );
-      expect(repairOperations).toHaveLength(1);
+      expect(repairOperations.length).toBeGreaterThanOrEqual(1);
+      expect(repairOperations.length).toBeLessThanOrEqual(2);
     } finally {
       if (clientA) await closeClient(clientA);
       if (clientB) await closeClient(clientB);

--- a/e2e/tests/sync/supersync-repair-lifecycle.spec.ts
+++ b/e2e/tests/sync/supersync-repair-lifecycle.spec.ts
@@ -508,3 +508,110 @@ test.describe('@supersync REPAIR lifecycle', () => {
     }
   });
 });
+
+test.describe('@supersync REPAIR with an offline client', () => {
+  /**
+   * A causal REPAIR is automatic, so its client contract is meant to be
+   * narrower than an import's: `SyncImportFilterService` drops only the ops the
+   * repair snapshot already covers, concurrent work replays on top instead of
+   * being discarded, and its own doc states that an automatic REPAIR "never
+   * opens the explicit import/restore conflict dialog".
+   *
+   * KNOWN FAILING — it does. `SyncImportConflictGateService` matches on
+   * `FULL_STATE_OP_TYPES`, which includes REPAIR, so a device returning with
+   * pending work after another device's background repair is prompted with the
+   * import conflict dialog ("replaces this device's data with the server's and
+   * discards N local change(s)") and loses that work if it accepts. Verified
+   * from the trace: the returning device issues no ops upload at all, so the
+   * work reaches neither the server nor the repaired state.
+   *
+   * Note the gate is currently the ONLY thing protecting those ops: applying a
+   * full-state op replaces the whole store, and nothing replays local unsynced
+   * ops afterwards. Simply exempting REPAIR from the gate would trade the
+   * prompt for silent divergence. Making this pass means replaying the pending
+   * ops on top of the applied repair, which is what SyncImportFilterService
+   * already promises for concurrent work. Filed as #9773.
+   */
+  test.fixme('keeps an offline client’s pending work and does not resurrect what the REPAIR removed', async ({
+    browser,
+    baseURL,
+    testRunId,
+  }) => {
+    test.setTimeout(240000);
+
+    const appUrl = baseURL || 'http://localhost:4242';
+    const sharedTaskTitle = `A-${testRunId}-RepairOfflineShared`;
+    const offlineTaskTitle = `A-${testRunId}-RepairOfflineWork`;
+    const ghostTagId = `ghost-tag-offline-${testRunId}`;
+    let clientA: SimulatedE2EClient | null = null;
+    let clientB: SimulatedE2EClient | null = null;
+
+    try {
+      const user = await createTestUser(testRunId);
+      const syncConfig = getSuperSyncConfig(user);
+
+      clientA = await createSimulatedClient(browser, appUrl, 'A', testRunId);
+      await clientA.workView.waitForTaskList();
+      await clientA.sync.setupSuperSync(syncConfig);
+
+      clientB = await createSimulatedClient(browser, appUrl, 'B', testRunId);
+      await clientB.workView.waitForTaskList();
+      await clientB.sync.setupSuperSync(syncConfig);
+
+      await clientA.workView.addTask(sharedTaskTitle);
+      await clientA.sync.syncAndWait();
+      await clientB.sync.syncAndWait();
+      await waitForTask(clientB.page, sharedTaskTitle);
+
+      // B seeds the corruption that A will repair, then stops syncing. Both
+      // clients only ever sync through syncAndWait(), so B is simply offline
+      // from here on.
+      await addGhostTagReference(clientB.page, sharedTaskTitle, ghostTagId);
+      await clientB.sync.syncAndWait();
+      const corruptionServerSeq = await getLatestServerSeq(user.userId);
+
+      // Offline work A's repair snapshot cannot know about.
+      await clientB.workView.addTask(offlineTaskTitle);
+
+      // A downloads the corruption, auto-repairs, and uploads a causal REPAIR.
+      await clientA.sync.syncAndWait({ timeout: 60000 });
+      await clientA.sync.syncAndWait({ timeout: 60000 });
+      await expect
+        .poll(
+          async () =>
+            (await getServerOperations(user.userId)).filter(
+              ({ opType }) => opType === 'REPAIR',
+            ).length,
+          { message: 'client A never uploaded a causal REPAIR', timeout: 60000 },
+        )
+        .toBe(1);
+      const repairOperation = (await getServerOperations(user.userId)).find(
+        ({ opType }) => opType === 'REPAIR',
+      );
+      expect(repairOperation?.serverSeq).toBeGreaterThan(corruptionServerSeq);
+      await expectConvergedTask(clientA, sharedTaskTitle, ghostTagId);
+
+      // B comes back with a cursor below the REPAIR and pending local work.
+      await clientB.sync.syncAndWait({ timeout: 60000 });
+
+      // B keeps both its own offline task and the repaired shared task.
+      await waitForTask(clientB.page, offlineTaskTitle);
+      await expectConvergedTask(clientB, sharedTaskTitle, ghostTagId);
+
+      // The offline work reached the server and replays on top of the repair
+      // for everyone else, and the repair's removal is not undone by it.
+      await clientA.sync.syncAndWait({ timeout: 60000 });
+      await waitForTask(clientA.page, offlineTaskTitle);
+      await expectConvergedTask(clientA, sharedTaskTitle, ghostTagId);
+
+      // Still exactly one repair: B's return did not trigger a second one.
+      const repairOperations = (await getServerOperations(user.userId)).filter(
+        ({ opType }) => opType === 'REPAIR',
+      );
+      expect(repairOperations).toHaveLength(1);
+    } finally {
+      if (clientA) await closeClient(clientA);
+      if (clientB) await closeClient(clientB);
+    }
+  });
+});

--- a/packages/super-sync-server/src/sync/sync.service.ts
+++ b/packages/super-sync-server/src/sync/sync.service.ts
@@ -44,6 +44,20 @@ import type { ValidationResult } from './services/validation.service';
  *
  * The second query only runs for the rare account holding no import at all, so
  * the ordinary upload path still costs a single indexed lookup.
+ *
+ * The REPAIR is a STAND-IN for a pruned import, not a boundary in its own
+ * right. The fence enforces IMPORT semantics: a client below a SYNC_IMPORT /
+ * BACKUP_IMPORT must download it so `SyncImportFilterService` drops its
+ * concurrent ops. A causal REPAIR is borrowed only as the nearest higher seq
+ * that still forces that download once the import row itself is gone. Its own
+ * client contract is the opposite — a REPAIR is automatic, and concurrent work
+ * replays on top of it instead of being dropped.
+ *
+ * That is why the accepted-op write in `uploadOps` records SYNC_IMPORT /
+ * BACKUP_IMPORT and NOT an accepted REPAIR: at that moment no import row has
+ * been pruned yet, so there is no missing fence to reconstruct. Writer and
+ * resolver answering differently is the design, not an asymmetry to close
+ * (#9703, #9755).
  */
 const resolveRetainedReplacementSeq = async (
   db: Prisma.TransactionClient,
@@ -394,6 +408,13 @@ export class SyncService {
             }
           }
 
+          // Only an import moves the fence. An accepted causal REPAIR is
+          // deliberately NOT recorded here: the fence carries import semantics
+          // (the client drops concurrent ops at one), while a repair replays
+          // concurrent work on top. `resolveRetainedReplacementSeq` treats a
+          // REPAIR as a boundary only as a stand-in for an import row that
+          // pruning already deleted — a case that cannot exist at this point in
+          // an upload. See that resolver's comment before widening this (#9703).
           let latestAcceptedStateReplacementSeq: number | undefined;
           for (let index = 0; index < ops.length; index++) {
             const op = ops[index];

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -86,6 +86,12 @@ type RemoteOpsProcessingResult = Awaited<
 
 type GuardedRemoteOpsProcessingResult = RemoteOpsProcessingResult & {
   preApplyFullStateConflict?: IncomingFullStateConflictGateResult;
+  /**
+   * Pending work appeared between the gate check and the apply, and the
+   * incoming full-state op was a causal REPAIR. Nothing was applied; the
+   * caller must leave the cursor behind the batch and retry (#9773).
+   */
+  preApplyRepairDeferred?: boolean;
 };
 
 /**
@@ -321,7 +327,8 @@ export class OperationLogSyncService {
           },
         );
       if (piggybackedConflict.fullStateOp) {
-        const { fullStateOp, pendingOps, dialogData } = piggybackedConflict;
+        const { fullStateOp, pendingOps, dialogData, deferredRepairOpId } =
+          piggybackedConflict;
 
         // Existing synced store data is not a conflict here. Prompt only when
         // local pending user changes would be discarded; otherwise an old client
@@ -355,6 +362,12 @@ export class OperationLogSyncService {
             hasMorePiggyback: false,
             rejectedOps: [],
           };
+        } else if (deferredRepairOpId) {
+          OpLog.normal(
+            `OperationLogSyncService: Deferring piggybacked REPAIR from client ` +
+              `${fullStateOp.clientId}; ${pendingOps.length} pending local op(s) ` +
+              `keep their place and this client repairs its own state instead.`,
+          );
         } else {
           // Known limitation (#7985, upload→piggyback path): example-task ops accepted earlier in
           // THIS same upload round were already marked synced, so they have left
@@ -384,6 +397,9 @@ export class OperationLogSyncService {
             preCapturedPendingOps: result.selectedPendingOps ?? [],
           },
           fenceEpoch: options?.fenceEpoch,
+          ...(piggybackedConflict.deferredRepairOpId
+            ? { deferredRepairOpId: piggybackedConflict.deferredRepairOpId }
+            : {}),
         },
       );
       localWinOpsCreated = processResult.localWinOpsCreated;
@@ -404,6 +420,24 @@ export class OperationLogSyncService {
         if (conflictResult === 'CANCEL') {
           return { kind: 'cancelled' };
         }
+        return {
+          kind: 'completed',
+          uploadedCount: result.uploadedCount,
+          piggybackedOpsCount: result.piggybackedOps.length,
+          localWinOpsCreated: 0,
+          permanentRejectionCount: 0,
+          hasMorePiggyback: false,
+          rejectedOps: [],
+        };
+      }
+
+      if (processResult.preApplyRepairDeferred) {
+        // Cursor stays behind the repair (the persist below is skipped), so the
+        // batch comes back next cycle and the gate defers the repair up front.
+        OpLog.normal(
+          'OperationLogSyncService: Pending work appeared before the piggybacked REPAIR apply; ' +
+            'retrying the batch next cycle.',
+        );
         return {
           kind: 'completed',
           uploadedCount: result.uploadedCount,
@@ -1095,7 +1129,8 @@ export class OperationLogSyncService {
     let startupOpIdsToDiscard: string[] = [];
     let startupCleanupFullStateOpId: string | undefined;
     if (incomingConflict.fullStateOp) {
-      const { fullStateOp, pendingOps, dialogData } = incomingConflict;
+      const { fullStateOp, pendingOps, dialogData, deferredRepairOpId } =
+        incomingConflict;
       // Existing synced store data is not a conflict here. Prompt only when
       // local pending user changes would be discarded; otherwise an old client
       // can accidentally force-upload stale state over the remote import.
@@ -1119,6 +1154,12 @@ export class OperationLogSyncService {
         // Validation failure (if any during USE_REMOTE force-download) is on
         // the session-validation latch — wrapper reads it. (#7330)
         return { kind: 'no_new_ops' };
+      } else if (deferredRepairOpId) {
+        OpLog.normal(
+          `OperationLogSyncService: Deferring incoming REPAIR from client ` +
+            `${fullStateOp.clientId}; ${pendingOps.length} pending local op(s) ` +
+            `keep their place and this client repairs its own state instead.`,
+        );
       } else {
         startupOpIdsToDiscard = incomingConflict.discardablePendingOpIds;
         startupCleanupFullStateOpId = fullStateOp.id;
@@ -1139,8 +1180,21 @@ export class OperationLogSyncService {
         ignoredLocalFullStateOpIds: options?.ignoredLocalFullStateOpIds,
         conflictRecheck: { isNeverSynced: options?.isNeverSynced },
         fenceEpoch: options?.fenceEpoch,
+        ...(incomingConflict.deferredRepairOpId
+          ? { deferredRepairOpId: incomingConflict.deferredRepairOpId }
+          : {}),
       },
     );
+
+    if (processResult.preApplyRepairDeferred) {
+      // Cursor stays behind the repair (the persist below is skipped), so the
+      // batch comes back next cycle and the gate defers the repair up front.
+      OpLog.normal(
+        'OperationLogSyncService: Pending work appeared before the incoming REPAIR apply; ' +
+          'retrying the batch next cycle.',
+      );
+      return { kind: 'no_new_ops' };
+    }
 
     if (processResult.preApplyFullStateConflict?.dialogData) {
       const { fullStateOp, pendingOps, dialogData } =
@@ -1255,10 +1309,20 @@ export class OperationLogSyncService {
       };
       /** Sync epoch captured at cycle start (#9074); fences the apply. */
       fenceEpoch?: number;
+      /** Causal REPAIR the gate deferred; dropped from this batch (#9773). */
+      deferredRepairOpId?: string;
     },
   ): Promise<GuardedRemoteOpsProcessingResult> {
     const startupOpIdsToDiscard = new Set(startupOpIds);
     let preApplyFullStateConflict: IncomingFullStateConflictGateResult | undefined;
+    let preApplyRepairDeferred = false;
+    // Drop the deferred repair, then treat the rest of the batch as ordinary
+    // remote ops. The snapshot is not lost work: this client already applies
+    // every op the repair was built from, so only the correction itself is
+    // skipped — and the post-apply validation below recomputes that locally.
+    const opsToProcess = options?.deferredRepairOpId
+      ? remoteOps.filter((op) => op.id !== options.deferredRepairOpId)
+      : remoteOps;
     try {
       const conflictRecheck = options?.conflictRecheck;
       const beforeFullStateApply = conflictRecheck
@@ -1274,6 +1338,14 @@ export class OperationLogSyncService {
             for (const opId of conflict.discardablePendingOpIds) {
               startupOpIdsToDiscard.add(opId);
             }
+            if (conflict.deferredRepairOpId) {
+              // Too late to drop the repair from this batch — it is already
+              // partitioned for a wholesale apply. Block the apply and leave
+              // the cursor behind it; the next cycle's gate check runs before
+              // partitioning and defers it properly (#9773).
+              preApplyRepairDeferred = true;
+              return false;
+            }
             if (conflict.dialogData) {
               preApplyFullStateConflict = conflict;
               return false;
@@ -1283,22 +1355,37 @@ export class OperationLogSyncService {
         : undefined;
       const result = await this.repairSyncContext.runWithBaseServerSeq(
         options?.repairBaseServerSeq,
-        () =>
-          this.remoteOpsProcessingService.processRemoteOps(remoteOps, {
-            ...(options?.ignoredLocalFullStateOpIds?.length
-              ? {
-                  ignoredLocalFullStateOpIds: options.ignoredLocalFullStateOpIds,
-                }
-              : {}),
-            ...(beforeFullStateApply ? { beforeFullStateApply } : {}),
-            ...(options?.fenceEpoch !== undefined
-              ? { fenceEpoch: options.fenceEpoch }
-              : {}),
-          }),
+        async () => {
+          const processed = await this.remoteOpsProcessingService.processRemoteOps(
+            opsToProcess,
+            {
+              ...(options?.ignoredLocalFullStateOpIds?.length
+                ? {
+                    ignoredLocalFullStateOpIds: options.ignoredLocalFullStateOpIds,
+                  }
+                : {}),
+              ...(beforeFullStateApply ? { beforeFullStateApply } : {}),
+              ...(options?.fenceEpoch !== undefined
+                ? { fenceEpoch: options.fenceEpoch }
+                : {}),
+            },
+          );
+          if (options?.deferredRepairOpId && !preApplyRepairDeferred) {
+            // The skipped snapshot carried the fix for corruption this client
+            // most likely shares (it applied the same ops). Heal it here:
+            // processRemoteOps only validates when it applied something, and a
+            // batch holding just the repair applies nothing. Inside
+            // runWithBaseServerSeq so any repair this produces is causal — a
+            // legacy one would make receivers drop concurrent ops.
+            await this.remoteOpsProcessingService.validateAfterSync();
+          }
+          return processed;
+        },
       );
       if (
         result.fullStateApplyBlockedByLocalConflict &&
-        !preApplyFullStateConflict?.dialogData
+        !preApplyFullStateConflict?.dialogData &&
+        !preApplyRepairDeferred
       ) {
         throw new Error(
           'Full-state apply was blocked without conflict data for resolution.',
@@ -1312,6 +1399,7 @@ export class OperationLogSyncService {
       return {
         ...result,
         ...(preApplyFullStateConflict ? { preApplyFullStateConflict } : {}),
+        ...(preApplyRepairDeferred ? { preApplyRepairDeferred } : {}),
       };
     } catch (error) {
       try {

--- a/src/app/op-log/sync/sync-import-conflict-gate.service.spec.ts
+++ b/src/app/op-log/sync/sync-import-conflict-gate.service.spec.ts
@@ -94,6 +94,88 @@ describe('SyncImportConflictGateService', () => {
     });
   });
 
+  describe('incoming causal REPAIR', () => {
+    const createPendingTaskEntry = (): OperationLogEntry =>
+      createEntry(
+        createOperation({
+          id: 'local-task-update',
+          actionType: 'test' as ActionType,
+          opType: OpType.Update,
+          entityType: 'TASK',
+          entityId: 'task-1',
+          payload: { title: 'Local title' },
+          clientId: 'client-A',
+          vectorClock: { clientA: 1 },
+        }),
+      );
+
+    /**
+     * A REPAIR is automatic. Prompting for it offers the user three wrong
+     * answers — force-upload (destroys every other device's work), force-download
+     * (destroys this device's pending work), or cancel (re-prompts next cycle).
+     * Defer it instead: this device keeps its work and its own repair pass fixes
+     * the same shared corruption locally. (#9773)
+     */
+    it('defers an incoming causal REPAIR instead of prompting', async () => {
+      const incomingRepair = createOperation({
+        id: 'remote-causal-repair',
+        actionType: ActionType.REPAIR_AUTO,
+        opType: OpType.Repair,
+        syncImportReason: 'REPAIR',
+        repairBaseServerSeq: 4,
+      });
+      opLogStoreSpy.getUnsynced.and.resolveTo([createPendingTaskEntry()]);
+
+      const result = await service.checkIncomingFullStateConflict([incomingRepair]);
+
+      expect(result.fullStateOp).toBe(incomingRepair);
+      expect(result.hasMeaningfulPending).toBeTrue();
+      expect(result.dialogData).toBeUndefined();
+      expect(result.deferredRepairOpId).toBe('remote-causal-repair');
+    });
+
+    it('still prompts for an incoming SYNC_IMPORT', async () => {
+      const incomingImport = createOperation({ syncImportReason: 'SERVER_MIGRATION' });
+      opLogStoreSpy.getUnsynced.and.resolveTo([createPendingTaskEntry()]);
+
+      const result = await service.checkIncomingFullStateConflict([incomingImport]);
+
+      expect(result.dialogData).toBeDefined();
+      expect(result.deferredRepairOpId).toBeUndefined();
+    });
+
+    it('does not defer a REPAIR when there is no meaningful pending work', async () => {
+      const incomingRepair = createOperation({
+        id: 'remote-causal-repair',
+        actionType: ActionType.REPAIR_AUTO,
+        opType: OpType.Repair,
+        syncImportReason: 'REPAIR',
+        repairBaseServerSeq: 4,
+      });
+      opLogStoreSpy.getUnsynced.and.resolveTo([]);
+
+      const result = await service.checkIncomingFullStateConflict([incomingRepair]);
+
+      expect(result.hasMeaningfulPending).toBeFalse();
+      expect(result.deferredRepairOpId).toBeUndefined();
+    });
+
+    it('does not defer a legacy REPAIR that carries no causal base', async () => {
+      const legacyRepair = createOperation({
+        id: 'remote-legacy-repair',
+        actionType: ActionType.REPAIR_AUTO,
+        opType: OpType.Repair,
+        syncImportReason: 'REPAIR',
+      });
+      opLogStoreSpy.getUnsynced.and.resolveTo([createPendingTaskEntry()]);
+
+      const result = await service.checkIncomingFullStateConflict([legacyRepair]);
+
+      expect(result.deferredRepairOpId).toBeUndefined();
+      expect(result.dialogData).toBeDefined();
+    });
+  });
+
   const createPendingConfigEntry = (sectionKey = 'sync'): OperationLogEntry =>
     createEntry(
       createOperation({

--- a/src/app/op-log/sync/sync-import-conflict-gate.service.ts
+++ b/src/app/op-log/sync/sync-import-conflict-gate.service.ts
@@ -10,6 +10,7 @@ import {
 import { OperationWriteFlushService } from './operation-write-flush.service';
 import { SyncImportConflictData } from './dialog-sync-import-conflict/dialog-sync-import-conflict.component';
 import { isExampleTaskCreateOp } from '../validation/is-example-task-op.util';
+import { OpLog } from '../../core/log';
 
 /**
  * Enabling/configuring sync on a never-synced client necessarily writes the
@@ -32,7 +33,19 @@ export interface IncomingFullStateConflictGateResult {
   hasMeaningfulPending: boolean;
   discardablePendingOpIds: string[];
   dialogData?: SyncImportConflictData;
+  /**
+   * Incoming causal REPAIR to skip this cycle rather than prompt for (#9773).
+   * Set only when this device holds meaningful pending work.
+   */
+  deferredRepairOpId?: string;
 }
+
+/**
+ * A causal REPAIR proves its snapshot covered the whole server prefix; a legacy
+ * one carries no base cursor and proves nothing, so it keeps import handling.
+ */
+const isCausalRepair = (op: Operation): boolean =>
+  op.opType === OpType.Repair && op.repairBaseServerSeq !== undefined;
 
 /**
  * Decides whether an incoming full-state operation would discard meaningful local work.
@@ -171,6 +184,22 @@ export class SyncImportConflictGateService {
 
     if (!hasMeaningfulPending) {
       return result;
+    }
+
+    // An automatic repair must not put the user in front of the import dialog:
+    // every answer it offers is wrong here. Force-upload would replace remote
+    // state with this device's (destroying the repair and every other device's
+    // concurrent work), force-download would discard this device's pending work,
+    // and cancel just re-prompts next cycle. Defer the repair instead — this
+    // device keeps its work, and its own post-sync repair pass fixes the same
+    // shared corruption locally. (#9773)
+    if (isCausalRepair(fullStateOp)) {
+      OpLog.normal(
+        `SyncImportConflictGateService: Deferring incoming causal REPAIR ` +
+          `${fullStateOp.id} from client ${fullStateOp.clientId}; ` +
+          `${pendingOps.length} pending local op(s) stay put.`,
+      );
+      return { ...result, deferredRepairOpId: fullStateOp.id };
     }
 
     return {


### PR DESCRIPTION
Fixes #9773.

## The bug

An automatic `REPAIR` uploaded by one device opened the **import/restore conflict dialog** on any other device holding unsynced work — `SyncImportConflictGateService` matches on `FULL_STATE_OP_TYPES`, and `REPAIR` is one of them. Every answer the dialog offers loses something:

- **USE_LOCAL** force-uploads a `SYNC_IMPORT` over every other device's concurrent work
- **USE_REMOTE** discards this device's pending work
- **CANCEL** re-prompts next cycle — and, traced from the e2e run, aborts the cycle *before* the ops upload, so the device's local change reached neither the server nor its own repaired state

A repair is automatic and unattended; it must never surface an explicit restore prompt.

## Why not just exempt REPAIR from the gate

That was my first instinct and it is wrong — it would be worse than the prompt. Applying a full-state op replaces the whole store and **nothing replays local unsynced ops afterwards**, so exempting it trades a bad dialog for silent divergence. The gate is currently the only thing protecting those ops.

## The fix

Defer instead. When the incoming full-state op is a **causal** `REPAIR` (`repairBaseServerSeq` present) and the device holds meaningful pending work:

- the gate returns `deferredRepairOpId` and **no** `dialogData`
- `_processRemoteOpsWithStartupCleanup` drops that op from the batch and applies the rest through normal conflict detection
- the device then runs its own `validateAfterSync()` to heal its copy of the same corruption, **inside `runWithBaseServerSeq`** so any repair it emits is causal, not legacy (a legacy repair would make receivers drop concurrent ops)

Nothing is lost by skipping the snapshot: the device already applies every op the repair was built from, so only the correction itself is skipped — and it recomputes that locally. Its pending work uploads as usual.

A **legacy** `REPAIR` (no causal base) proves nothing about its coverage and keeps the existing import handling.

If pending work appears *after* the gate check but *before* the apply, the pre-apply recheck blocks the batch and leaves the cursor behind it, so the next cycle's gate defers it up front rather than applying a snapshot older than that work.

### Design note: "defer and retry later" is wrong

Keeping the cursor below the repair and re-applying it on a later cycle looks tempting but is unsafe: once the pending ops upload they stop being pending, the gate passes next cycle, and the device applies a snapshot older than its own just-uploaded op — reverting it locally while it lives on the server. Skipping permanently is the correct semantics.

### Expected consequence

The returning device emits a **second** `REPAIR` after healing itself. This terminates (once healed, validation passes), and the e2e asserts 1–2 repairs plus an extra sync round on each side to prove there is no repair ping-pong.

## Tests

- `e2e/tests/sync/supersync-repair-lifecycle.spec.ts` — new two-client reproduction: B seeds corruption and goes offline with pending work, A auto-repairs and uploads a causal REPAIR, B returns. Written failing first (it hit the dialog and lost the work), now passing. Enabled in this PR.
- 4 new `SyncImportConflictGateService` unit tests covering defer-vs-prompt, `SYNC_IMPORT` unaffected, no-pending-work unaffected, and legacy REPAIR unaffected.
- Full unit suite green (14434).

## Also in this branch

`26a48dd76` is a docs/comment-only commit from the review of #9755 (the #9703 fence question): it records *why* the accepted-op fence writer records `SYNC_IMPORT`/`BACKUP_IMPORT` but not an accepted causal `REPAIR` — the fence carries **import** semantics, and the lazy resolver treats a REPAIR as a boundary only as a stand-in for an import row that pruning already deleted. Happy to split it out if you'd rather keep it separate.
