### PR TITLE
fix(sync): preserve cleared fields dropped by JSON serialization (#9776)

### DIFF
--- a/docs/sync-and-op-log/contributor-sync-model.md
+++ b/docs/sync-and-op-log/contributor-sync-model.md
@@ -143,6 +143,36 @@ blessed pattern is a `task-shared-meta-reducers/` reducer.
 
 ---
 
+## Clearing a field — `undefined` does not survive the wire (#9776)
+
+**Never rely on `changes: { someField: undefined }` reaching another device.**
+`JSON.stringify` drops undefined-valued keys from the op payload (SuperSync
+HTTP/E2EE, file-based providers, the SQLite op-log — everything except the
+IndexedDB structured clone), so a reducer that applies `changes` verbatim
+replays the clear as a no-op remotely. The local device looks correct, which is
+exactly why this class of bug survives testing.
+
+Safe patterns, in order of preference:
+
+1. **Set the `undefined` inside a reducer/meta-reducer** keyed off a dedicated
+   action whose payload carries only ids (e.g.
+   `TaskSharedActions.dismissReminderOnly` → `remindAt: undefined` in the
+   reducer). Deterministic on replay; nothing to serialize.
+2. **Rebuild `changes` from destructured payload fields** — a dropped key
+   destructures back to `undefined` identically (e.g. `scheduleTaskWithTime`).
+3. For generic `Update<T>` actions, **list cleared keys out-of-band**: the
+   action creator adds `clearedFields` via `clearedFieldsProps()` and the
+   reducer restores them with `applyClearedFields()`
+   (`src/app/util/cleared-update-fields.ts`; used by `updateTaskUi` and
+   `updateTaskRepeatCfg`). Old clients ignore the extra prop, so the clear
+   degrades to a no-op there instead of corrupting state — no schema bump.
+
+Do **not** invent in-band sentinels (`null`, `0`, marker strings): remote
+reducers apply payload values verbatim, so released clients would persist the
+sentinel and fail typia state validation.
+
+---
+
 ## Decision table — "I'm writing an effect"
 
 | Question                                                        | Answer                                                                                                    | Linter                                           |

--- a/e2e/tests/sync/supersync-clear-field-9776.spec.ts
+++ b/e2e/tests/sync/supersync-clear-field-9776.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from '../../fixtures/supersync.fixture';
+import {
+  createTestUser,
+  getSuperSyncConfig,
+  createSimulatedClient,
+  closeClient,
+  waitForTask,
+  type SimulatedE2EClient,
+} from '../../utils/supersync-helpers';
+
+/**
+ * Issue #9776 — clearing a field with `undefined` was dropped by
+ * JSON.stringify on the sync wire, so the change never replayed on other
+ * devices.
+ *
+ * Reproducible one-click case: the subtask collapse state
+ * (`_hideSubTasksMode`). Collapsing writes a real enum value (HideAll = 2)
+ * and always synced. Expanding writes `undefined`, whose key was dropped
+ * from the op payload — so the remote device stayed collapsed forever
+ * ("my subtasks disappeared on my phone").
+ *
+ * The fix carries cleared keys out-of-band in `clearedFields`
+ * (src/app/util/cleared-update-fields.ts); this test proves the full
+ * two-client round trip through a real SuperSync server:
+ *
+ * 1. Client A creates a parent with one subtask; both clients sync.
+ * 2. A collapses (chevron) -> sync -> B is collapsed too (control:
+ *    proves collapse state syncs at all).
+ * 3. A expands (chevron) -> sync -> B MUST show the subtask again
+ *    (the direction that was broken).
+ */
+
+const addSubtask = async (
+  page: SimulatedE2EClient['page'],
+  parentTaskName: string,
+  subtaskTitle: string,
+): Promise<void> => {
+  const parentTask = page.locator(`task:has-text("${parentTaskName}")`).first();
+  await parentTask.waitFor({ state: 'visible', timeout: 10000 });
+
+  // Focus the task and use keyboard shortcut 'a' to add a subtask
+  await parentTask.focus();
+  await page.waitForTimeout(100);
+  await parentTask.press('a');
+
+  const draftInput = page.locator('.e2e-add-subtask-input');
+  await draftInput.waitFor({ state: 'visible', timeout: 5000 });
+  await draftInput.fill(subtaskTitle);
+  await page.keyboard.press('Enter');
+  await page.keyboard.press('Escape');
+  await draftInput.waitFor({ state: 'detached', timeout: 5000 });
+
+  await waitForTask(page, subtaskTitle);
+  await page.waitForTimeout(200);
+};
+
+/** The chevron on the parent cycles Show -> HideAll -> Show (isEndless). */
+const clickSubTaskToggle = async (
+  page: SimulatedE2EClient['page'],
+  parentTaskName: string,
+): Promise<void> => {
+  const toggleBtn = page
+    .locator(`task:not(.hasNoSubTasks):has-text("${parentTaskName}")`)
+    .first()
+    .locator('.toggle-sub-tasks-btn');
+  await toggleBtn.waitFor({ state: 'visible', timeout: 10000 });
+  await toggleBtn.click();
+};
+
+const subtaskLocator = (
+  page: SimulatedE2EClient['page'],
+  subtaskName: string,
+): ReturnType<SimulatedE2EClient['page']['locator']> =>
+  page.locator(`task.hasNoSubTasks:has-text("${subtaskName}")`);
+
+test.describe('@supersync Clear field via undefined (#9776)', () => {
+  test('expanding subtasks on A syncs the cleared _hideSubTasksMode to B', async ({
+    browser,
+    baseURL,
+    testRunId,
+  }) => {
+    let clientA: SimulatedE2EClient | null = null;
+    let clientB: SimulatedE2EClient | null = null;
+
+    try {
+      const user = await createTestUser(testRunId);
+      const syncConfig = getSuperSyncConfig(user);
+
+      clientA = await createSimulatedClient(browser, baseURL!, 'A', testRunId);
+      await clientA.sync.setupSuperSync(syncConfig);
+
+      clientB = await createSimulatedClient(browser, baseURL!, 'B', testRunId);
+      await clientB.sync.setupSuperSync(syncConfig);
+
+      // 1. Client A creates parent + subtask, both clients sync
+      const parentName = `Parent-${testRunId}`;
+      const subName = `Sub-${testRunId}`;
+      await clientA.workView.addTask(parentName);
+      await waitForTask(clientA.page, parentName);
+      await addSubtask(clientA.page, parentName, subName);
+
+      await clientA.sync.syncAndWait();
+      await clientB.sync.syncAndWait();
+      await waitForTask(clientB.page, parentName);
+      await expect(subtaskLocator(clientB.page, subName)).toBeVisible({
+        timeout: 10000,
+      });
+      console.log('[ClearField9776] Both clients see parent + subtask');
+
+      // 2. CONTROL: collapse on A -> B collapses too (HideAll is a real
+      // enum value and synced even before the fix)
+      await clickSubTaskToggle(clientA.page, parentName);
+      await expect(subtaskLocator(clientA.page, subName)).toBeHidden({
+        timeout: 10000,
+      });
+      await clientA.page.waitForTimeout(500); // let op-log capture settle
+      await clientA.sync.syncAndWait();
+      await clientB.sync.syncAndWait();
+      await expect(subtaskLocator(clientB.page, subName)).toBeHidden({
+        timeout: 10000,
+      });
+      console.log('[ClearField9776] Collapse synced A -> B (control)');
+
+      // 3. THE BUG: expand on A -> B must expand too. Before the fix the
+      // expand op serialized to changes: {} and B stayed collapsed.
+      await clickSubTaskToggle(clientA.page, parentName);
+      await expect(subtaskLocator(clientA.page, subName)).toBeVisible({
+        timeout: 10000,
+      });
+      await clientA.page.waitForTimeout(500); // let op-log capture settle
+      await clientA.sync.syncAndWait();
+      await clientB.sync.syncAndWait();
+      await expect(subtaskLocator(clientB.page, subName)).toBeVisible({
+        timeout: 10000,
+      });
+      console.log('[ClearField9776] ✓ Expand synced A -> B');
+    } finally {
+      if (clientA) await closeClient(clientA);
+      if (clientB) await closeClient(clientB);
+    }
+  });
+});

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.spec.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.spec.ts
@@ -23,6 +23,7 @@ import {
 import { TaskCopy, TaskReminderOptionId, TaskWithDueTime } from '../../tasks/task.model';
 import { ReminderService } from '../../reminder/reminder.service';
 import { PlannerActions } from '../store/planner.actions';
+import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
 import { getDbDateStr } from '../../../util/get-db-date-str';
 import { selectAllTasksWithDueTimeSorted } from '../../tasks/store/task.selectors';
 import { ScheduleConfig } from '../../config/global-config.model';
@@ -436,6 +437,51 @@ describe('DialogScheduleTaskComponent', () => {
         }),
       );
       expect(dialogRefSpy.close).toHaveBeenCalledWith(true);
+    });
+
+    // Issue #9776: updateTask({ changes: { remindAt: undefined } }) loses the
+    // key at JSON.stringify, so the clear never replayed on other devices.
+    // dismissReminderOnly clears remindAt inside its reducer (replay-safe).
+    it('should dispatch dismissReminderOnly (not a lossy updateTask) when "Do not remind" is picked', async () => {
+      const today = new Date();
+      const mockTask = {
+        id: 'taskWithReminder',
+        title: 'Task With Reminder',
+        tagIds: [] as string[],
+        projectId: 'DEFAULT',
+        timeSpentOnDay: {},
+        attachments: [],
+        timeEstimate: 0,
+        timeSpent: 0,
+        isDone: false,
+        created: 1640995200000,
+        subTaskIds: [],
+        dueWithTime: today.getTime(),
+        dueDay: getDbDateStr(today),
+        remindAt: today.getTime(),
+      } as unknown as TaskCopy;
+
+      const dispatchSpy = spyOn(store, 'dispatch');
+
+      component.task = mockTask;
+      component.data = { task: mockTask } as any;
+      component.selectedDate = new Date(today);
+      component.selectedTime = null;
+      component.selectedReminderCfgId = TaskReminderOptionId.DoNotRemind;
+
+      await component.submit();
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        TaskSharedActions.dismissReminderOnly({ id: 'taskWithReminder' }),
+      );
+      const updateTaskCalls = dispatchSpy.calls
+        .allArgs()
+        .filter(
+          (args) =>
+            (args[0] as unknown as { type: string }).type ===
+            TaskSharedActions.updateTask.type,
+        );
+      expect(updateTaskCalls).toEqual([]);
     });
   });
 

--- a/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
+++ b/src/app/features/planner/dialog-schedule-task/dialog-schedule-task.component.ts
@@ -451,15 +451,12 @@ export class DialogScheduleTaskComponent implements AfterViewInit {
       this.selectedReminderCfgId === TaskReminderOptionId.DoNotRemind &&
       this.data.task.remindAt !== undefined
     ) {
+      // NOT updateTask({ changes: { remindAt: undefined } }): JSON serialization
+      // drops undefined-valued keys from the op payload, so that clear never
+      // replayed on other devices (#9776). dismissReminderOnly clears remindAt
+      // inside its reducer, which is deterministic on replay.
       this._store.dispatch(
-        TaskSharedActions.updateTask({
-          task: {
-            id: this.data.task.id,
-            changes: {
-              remindAt: undefined,
-            },
-          },
-        }),
+        TaskSharedActions.dismissReminderOnly({ id: this.data.task.id }),
       );
     }
   }

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cfg.actions.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cfg.actions.ts
@@ -3,6 +3,7 @@ import { Update } from '@ngrx/entity';
 import { TaskRepeatCfg } from '../task-repeat-cfg.model';
 import { PersistentActionMeta } from '../../../op-log/core/persistent-action.interface';
 import { OpType } from '../../../op-log/core/operation.types';
+import { clearedFieldsProps } from '../../../util/cleared-update-fields';
 
 export const addTaskRepeatCfgToTask = createAction(
   '[TaskRepeatCfg][Task] Add TaskRepeatCfg to Task',
@@ -29,6 +30,10 @@ export const updateTaskRepeatCfg = createAction(
     isAskToUpdateAllTaskInstances?: boolean;
   }) => ({
     ...cfgProps,
+    // `changes: { someField: undefined }` loses the key at JSON.stringify on
+    // every sync path; list cleared keys out-of-band so replay restores them
+    // (issue #9776 — e.g. a cleared startTime never synced).
+    ...clearedFieldsProps(cfgProps.taskRepeatCfg.changes),
     meta: {
       isPersistent: true,
       entityType: 'TASK_REPEAT_CFG',

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cfg.reducer.spec.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cfg.reducer.spec.ts
@@ -5,6 +5,9 @@ import {
 import * as TaskRepeatCfgActions from './task-repeat-cfg.actions';
 import { loadAllData } from '../../../root-store/meta/load-all-data.action';
 import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
+import { convertOpToAction } from '../../../op-log/apply/operation-converter.util';
+import { ActionType, Operation } from '../../../op-log/core/operation.types';
+import { TaskReminderOptionId } from '../../tasks/task.model';
 import {
   DEFAULT_TASK_REPEAT_CFG,
   TaskRepeatCfg,
@@ -196,6 +199,51 @@ describe('TaskRepeatCfgReducer', () => {
 
       expect(result.entities['cfg1']!.repeatEvery).toBe(2);
       expect(result.entities['cfg1']!.projectId).toBe('project-1');
+    });
+
+    // Issue #9776: clearing a field dispatches `changes: { someField: undefined }`,
+    // but JSON.stringify drops undefined-valued keys from the op payload, so the
+    // clear replayed as a no-op on every other device. The action creator lists
+    // cleared keys out-of-band in `clearedFields` (a string[] that survives
+    // JSON) and the reducer restores them before applying the update.
+    it('should round-trip clearing fields through capture, serialization and replay', () => {
+      const existingCfg = createTaskRepeatCfg('cfg1', {
+        startTime: '10:00',
+        remindAt: TaskReminderOptionId.AtStart,
+      });
+      const existingState = createStateWithCfgs([existingCfg]);
+
+      const action = TaskRepeatCfgActions.updateTaskRepeatCfg({
+        taskRepeatCfg: {
+          id: 'cfg1',
+          changes: { startTime: undefined, remindAt: undefined },
+        },
+      });
+
+      // Mirror the capture effect exactly: everything except type/meta becomes
+      // the op's actionPayload (operation-log.effects.ts).
+      const { type, meta, ...rawActionPayload } = action;
+      const op: Operation = {
+        id: 'op-9776',
+        actionType: type as ActionType,
+        opType: meta.opType,
+        entityType: meta.entityType,
+        entityId: meta.entityId as string,
+        payload: { actionPayload: rawActionPayload, entityChanges: [] },
+        clientId: 'clientA',
+        vectorClock: { clientA: 1 },
+        timestamp: 0,
+        schemaVersion: 1,
+      };
+
+      const wireOp = JSON.parse(JSON.stringify(op)) as Operation;
+      const replayAction = convertOpToAction(wireOp);
+      const replayed = taskRepeatCfgReducer(existingState, replayAction);
+
+      expect(replayed.entities['cfg1']!.startTime).toBeUndefined();
+      expect(replayed.entities['cfg1']!.remindAt).toBeUndefined();
+      // A defined value in the same update must still apply.
+      expect(replayed.entities['cfg1']!.title).toBe('Repeat Config cfg1');
     });
   });
 

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cfg.reducer.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cfg.reducer.ts
@@ -12,6 +12,7 @@ import { createReducer, on } from '@ngrx/store';
 import { loadAllData } from '../../../root-store/meta/load-all-data.action';
 import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
 import { adapter } from './task-repeat-cfg.selectors';
+import { applyClearedFields } from '../../../util/cleared-update-fields';
 
 export { TASK_REPEAT_CFG_FEATURE_NAME } from './task-repeat-cfg.selectors';
 
@@ -63,8 +64,16 @@ export const taskRepeatCfgReducer = createReducer<TaskRepeatCfgState>(
   on(addTaskRepeatCfgToTask, (state, { taskRepeatCfg }) =>
     adapter.addOne(taskRepeatCfg, state),
   ),
-  on(updateTaskRepeatCfg, (state, { taskRepeatCfg }) =>
-    adapter.updateOne(taskRepeatCfg, state),
+  on(updateTaskRepeatCfg, (state, { taskRepeatCfg, clearedFields }) =>
+    // Restore keys that JSON serialization dropped from a replayed op's
+    // changes (`{ someField: undefined }`) — see issue #9776.
+    adapter.updateOne(
+      {
+        id: taskRepeatCfg.id as string,
+        changes: applyClearedFields(taskRepeatCfg.changes, clearedFields),
+      },
+      state,
+    ),
   ),
   on(upsertTaskRepeatCfg, (state, { taskRepeatCfg }) =>
     adapter.upsertOne(taskRepeatCfg, state),

--- a/src/app/features/tasks/store/task.actions.ts
+++ b/src/app/features/tasks/store/task.actions.ts
@@ -4,6 +4,7 @@ import { Task, TaskDetailTargetPanel } from '../task.model';
 import { RoundTimeOption } from '../../project/project.model';
 import { PersistentActionMeta } from '../../../op-log/core/persistent-action.interface';
 import { OpType } from '../../../op-log/core/operation.types';
+import { clearedFieldsProps } from '../../../util/cleared-update-fields';
 
 export const setCurrentTask = createAction(
   '[Task] SetCurrentTask',
@@ -44,6 +45,10 @@ export const updateTaskUi = createAction(
   '[Task] Update Task Ui',
   (taskProps: { task: Update<Task> }) => ({
     ...taskProps,
+    // `changes: { someField: undefined }` loses the key at JSON.stringify on
+    // every sync path; list cleared keys out-of-band so replay restores them
+    // (issue #9776 — e.g. expanding subtasks never synced).
+    ...clearedFieldsProps(taskProps.task.changes),
     meta: {
       isPersistent: true,
       entityType: 'TASK',

--- a/src/app/features/tasks/store/task.reducer.spec.ts
+++ b/src/app/features/tasks/store/task.reducer.spec.ts
@@ -1372,5 +1372,47 @@ describe('Task Reducer', () => {
 
       expect(replayed.entities.task1?._hideSubTasksMode).toBe(HideSubTasksMode.HideAll);
     });
+
+    // Issue #9776: the EXPAND direction. Collapse round-trips fine (a real enum
+    // value), but "shown" is `undefined`, and JSON.stringify silently drops the
+    // key from the op payload — the expand then replays as a no-op on every
+    // other device, which stays collapsed forever. The action creator therefore
+    // lists cleared keys out-of-band in `clearedFields` (a string[] that
+    // survives JSON) and the reducer restores them before applying the update.
+    it('should round-trip clearing _hideSubTasksMode (expand) through capture, serialization and replay', () => {
+      const stateCollapsed: TaskState = {
+        ...initialTaskState,
+        ids: ['task1'],
+        entities: {
+          task1: createTask('task1', { _hideSubTasksMode: HideSubTasksMode.HideAll }),
+        },
+      };
+
+      const action = fromActions.updateTaskUi({
+        task: { id: 'task1', changes: { _hideSubTasksMode: undefined } },
+      });
+
+      // Mirror the capture effect exactly: everything except type/meta becomes
+      // the op's actionPayload (operation-log.effects.ts).
+      const { type, meta, ...rawActionPayload } = action;
+      const op: Operation = {
+        id: 'op-9776',
+        actionType: type as ActionType,
+        opType: meta.opType,
+        entityType: meta.entityType,
+        entityId: meta.entityId as string,
+        payload: { actionPayload: rawActionPayload, entityChanges: [] },
+        clientId: 'clientA',
+        vectorClock: { clientA: 1 },
+        timestamp: 0,
+        schemaVersion: 1,
+      };
+
+      const wireOp = JSON.parse(JSON.stringify(op)) as Operation;
+      const replayAction = convertOpToAction(wireOp);
+      const replayed = taskReducer(stateCollapsed, replayAction);
+
+      expect(replayed.entities.task1?._hideSubTasksMode).toBeUndefined();
+    });
   });
 });

--- a/src/app/features/tasks/store/task.reducer.ts
+++ b/src/app/features/tasks/store/task.reducer.ts
@@ -53,6 +53,7 @@ import {
 import { TaskLog } from '../../../core/log';
 import { devError } from '../../../util/dev-error';
 import { moveValidIdsToFront } from '../util/move-valid-ids-to-front';
+import { applyClearedFields } from '../../../util/cleared-update-fields';
 
 export { taskAdapter };
 
@@ -363,8 +364,16 @@ export const taskReducer = createReducer<TaskState>(
     return taskAdapter.updateMany(taskUpdates, state);
   }),
 
-  on(updateTaskUi, (state, { task }) => {
-    return taskAdapter.updateOne(task, state);
+  on(updateTaskUi, (state, { task, clearedFields }) => {
+    // Restore keys that JSON serialization dropped from a replayed op's
+    // changes (`{ someField: undefined }`) — see issue #9776.
+    return taskAdapter.updateOne(
+      {
+        id: task.id as string,
+        changes: applyClearedFields(task.changes, clearedFields),
+      },
+      state,
+    );
   }),
 
   // Bulk task updates - used for archive task batch operations

--- a/src/app/util/cleared-update-fields.spec.ts
+++ b/src/app/util/cleared-update-fields.spec.ts
@@ -1,0 +1,54 @@
+import { applyClearedFields, clearedFieldsProps } from './cleared-update-fields';
+
+interface TestEntity {
+  id: string;
+  a?: number;
+  b?: string;
+}
+
+describe('clearedFieldsProps', () => {
+  it('should list keys whose value is undefined', () => {
+    expect(clearedFieldsProps<TestEntity>({ a: undefined, b: 'x' })).toEqual({
+      clearedFields: ['a'],
+    });
+  });
+
+  it('should return no prop at all when nothing is cleared', () => {
+    expect(clearedFieldsProps<TestEntity>({ b: 'x' })).toEqual({});
+    expect(clearedFieldsProps<TestEntity>({})).toEqual({});
+  });
+});
+
+describe('applyClearedFields', () => {
+  it('should restore undefined for listed keys dropped by JSON serialization', () => {
+    const changes = JSON.parse(
+      JSON.stringify({ a: undefined, b: 'x' }),
+    ) as Partial<TestEntity>;
+    expect('a' in changes).toBe(false);
+
+    const restored = applyClearedFields(changes, ['a']);
+    expect('a' in restored).toBe(true);
+    expect(restored.a).toBeUndefined();
+    expect(restored.b).toBe('x');
+  });
+
+  it('should return changes unchanged without clearedFields', () => {
+    const changes: Partial<TestEntity> = { b: 'x' };
+    expect(applyClearedFields(changes, undefined)).toBe(changes);
+    expect(applyClearedFields(changes, [])).toBe(changes);
+  });
+
+  it('should tolerate junk from the wire and never clear id', () => {
+    const changes: Partial<TestEntity> = { b: 'x' };
+    expect(
+      applyClearedFields(changes, 'nope' as unknown as (keyof TestEntity & string)[]),
+    ).toBe(changes);
+
+    const restored = applyClearedFields(changes, [
+      'id',
+      42,
+    ] as unknown as (keyof TestEntity & string)[]);
+    expect('id' in restored).toBe(false);
+    expect(restored).toEqual({ b: 'x' });
+  });
+});

--- a/src/app/util/cleared-update-fields.ts
+++ b/src/app/util/cleared-update-fields.ts
@@ -1,0 +1,52 @@
+/**
+ * Clearing an entity field via an NgRx update dispatches
+ * `changes: { someField: undefined }`. That works locally (and in the
+ * IndexedDB op-log, which structured-clones the payload), but every JSON
+ * serialization of the op — SuperSync HTTP/E2EE, file-based sync providers,
+ * the SQLite op-log — drops undefined-valued keys entirely, so the clear
+ * replays as a no-op on other devices (issue #9776).
+ *
+ * Fix pattern: the action creator lists the cleared keys out-of-band via
+ * {@link clearedFieldsProps} (a plain string[] survives JSON), and the reducer
+ * restores them with {@link applyClearedFields} before handing the changes to
+ * the entity adapter. Older clients simply ignore the extra `clearedFields`
+ * action prop, so the clear degrades to today's no-op instead of corrupting
+ * their state (see sync rule 10 — no schema bump needed).
+ */
+
+/**
+ * Returns the optional `clearedFields` action prop for an update's changes:
+ * the keys whose value is `undefined`, or no prop at all when there are none.
+ */
+export const clearedFieldsProps = <T extends object>(
+  changes: Partial<T>,
+): { clearedFields?: (keyof T & string)[] } => {
+  const cleared = (Object.keys(changes) as (keyof T & string)[]).filter(
+    (key) => changes[key] === undefined,
+  );
+  return cleared.length ? { clearedFields: cleared } : {};
+};
+
+/**
+ * Restores `undefined` for the keys listed in `clearedFields` (idempotent for
+ * local dispatches, where the keys are still present in `changes`).
+ * `clearedFields` may come off the wire, so tolerate junk: non-arrays are
+ * ignored, and `id` is skipped because clearing it would re-key the entity in
+ * the adapter — entity ids are never cleared through updates.
+ */
+export const applyClearedFields = <T extends object>(
+  changes: Partial<T>,
+  clearedFields?: readonly (keyof T & string)[],
+): Partial<T> => {
+  if (!Array.isArray(clearedFields) || clearedFields.length === 0) {
+    return changes;
+  }
+  const restored: Partial<T> = { ...changes };
+  for (const key of clearedFields) {
+    if (typeof key !== 'string' || key === 'id') {
+      continue;
+    }
+    restored[key] = undefined;
+  }
+  return restored;
+};


### PR DESCRIPTION
Fixes #9776.

Clearing a field via `changes: { someField: undefined }` loses the key at `JSON.stringify` on every sync path (SuperSync HTTP/E2EE, file-based providers, SQLite op-log — only the IndexedDB structured clone keeps it), so the clear replayed as a no-op on other devices.

## Changes

- **Sites 1 & 3** (`updateTaskUi` / `updateTaskRepeatCfg`): action creators list cleared keys out-of-band in a `clearedFields: string[]` prop (survives JSON) via new `src/app/util/cleared-update-fields.ts`; the reducers restore `undefined` for those keys before `adapter.updateOne`. Old clients ignore the extra prop, so the clear degrades to today's no-op there — no schema bump, no sentinel values in state.
- **Site 2** (schedule dialog "Do not remind"): dispatches the existing `TaskSharedActions.dismissReminderOnly` (reducer-side clear, deterministic on replay) instead of a lossy `updateTask`. Note `planTaskForDay`'s reducer already clears `remindAt` since #6342, so the lossy dispatch was only load-bearing in the "already planned that day" branch.
- Documents the pattern in `docs/sync-and-op-log/contributor-sync-model.md` ("Clearing a field — `undefined` does not survive the wire").

## Why not the issue's suggested `Show = 0` enum fix

Old released clients apply payload `changes` verbatim, and their typia model is `_hideSubTasksMode?: 1 | 2` — a synced `0` (or any in-band sentinel like `null`) would land in their state, fail validation with no matching `auto-fix-typia-errors` branch, and can end in `sessionValidation.setFailed()` after remote-ops processing. The out-of-band `clearedFields` prop follows the rule-10 envelope pattern and leaves old clients exactly where they are today.

## Tests

- Capture → `JSON.stringify` → `convertOpToAction` → reducer round-trip specs for the expand direction (task.reducer.spec) and cleared repeat-cfg fields (task-repeat-cfg.reducer.spec) — both written first and confirmed red on the pre-fix code.
- Dialog spec asserting `dismissReminderOnly` is dispatched and no lossy `updateTask`.
- Util spec covering wire-junk tolerance (`id` never cleared, non-arrays ignored).
- New two-client SuperSync E2E (`supersync-clear-field-9776.spec.ts`): collapse on A → B collapses (control), expand on A → B must expand (the broken direction).

Full unit suite: 14439 SUCCESS.

## Sync-risk notes

- Wire/compat verified end-to-end: capture keeps sibling action props, `convertOpToAction` spreads them back, client and server payload validators are shape-permissive.
- Conflict resolution treats a remote cleared-only op as `changes: {}` (opaque → whole-entity LWW) since it doesn't read `clearedFields` — identical to pre-fix behavior, conservative.

https://claude.ai/code/session_01DtcXCn2R52yJcoPARqNhE4