### PR TITLE
fix(work-view): stop re-creating the Finish Day button; harden two flaky E2E clicks

### DIFF
--- a/docs/styling-guide.md
+++ b/docs/styling-guide.md
@@ -35,6 +35,7 @@ Rules:
 
 - **Icons:** drop generic `check`/`close` icons on OK/Cancel/Save/Submit — they add nothing. Keep icons that carry meaning (`alarm`/`today`/`event_busy` in scheduling, `wb_sunny`, `save`, `cloud_upload`, `delete_forever`).
 - **No `color` on cancel/close** — leftover `color="primary"` on a Cancel just tints it; remove it.
+- **Reactive appearance** — when a button's appearance must change at runtime, bind it on a single element (`[matButton]="cond ? 'filled' : 'outlined'"`) instead of swapping two buttons in an `@if`/`@else`. The attribute form is fixed at construction, and the swap re-creates the node, dropping focus and any click that lands mid-flip. See `finish-day-btn.component.html`.
 - **No dead classes** — the legacy Bootstrap `btn btn-primary` classes are gone; don't reintroduce them. `submit-button` is only styled inside `dialog-create-tag`.
 - **Symmetric choice dialogs** (e.g. sync "use remote" vs "use local") may use two matched `mat-stroked-button`s — there is no single primary.
 

--- a/e2e/pages/project.page.ts
+++ b/e2e/pages/project.page.ts
@@ -743,11 +743,23 @@ export class ProjectPage extends BasePage {
   async reopenArchivedProject(projectName: string): Promise<void> {
     const row = this.archivedProjectRow(projectName);
     const reopenBtn = row.getByRole('button', { name: 'Reopen' });
+    // Assert the button up front: without this, a project that was archived
+    // without being completed renders "Restore project" instead, the loop below
+    // would skip the click forever and report the row as merely still present.
+    await expect(reopenBtn).toBeVisible();
+
+    let attempts = 0;
     await expect(async () => {
+      attempts++;
       if (await reopenBtn.isVisible()) {
         await reopenBtn.click({ timeout: 2000 });
       }
       await expect(row).toHaveCount(0, { timeout: 2000 });
     }).toPass({ timeout: 15000 });
+    if (attempts > 1) {
+      // Surface the retry: the suite runs with retries: 0 so that
+      // non-determinism stays visible, and a silent in-test retry defeats that.
+      console.warn(`[reopenArchivedProject] took ${attempts} attempts`);
+    }
   }
 }

--- a/e2e/pages/project.page.ts
+++ b/e2e/pages/project.page.ts
@@ -721,4 +721,33 @@ export class ProjectPage extends BasePage {
       .locator('.mat-mdc-menu-content')
       .waitFor({ state: 'visible', timeout: 3000 });
   }
+
+  /** The archived-projects row for a project, matched by its prefixed title. */
+  archivedProjectRow(projectName: string): Locator {
+    return this.page
+      .locator('archived-projects-page .project-row')
+      .filter({ hasText: this.applyPrefix(projectName) });
+  }
+
+  /**
+   * Reopen a completed project from the archived-projects page.
+   *
+   * A single click is not reliable here: in CI the click is delivered but the
+   * handler never runs (no `[Project] Reopen Project` is dispatched, seen in
+   * the trace of run 33189475377), most likely because the page is still
+   * mid route-transition. So re-issue it until the row actually leaves the
+   * list. The click is bounded and skipped once the row is gone so a slow
+   * store update fails on the row assertion instead of an opaque click
+   * timeout.
+   */
+  async reopenArchivedProject(projectName: string): Promise<void> {
+    const row = this.archivedProjectRow(projectName);
+    const reopenBtn = row.getByRole('button', { name: 'Reopen' });
+    await expect(async () => {
+      if (await reopenBtn.isVisible()) {
+        await reopenBtn.click({ timeout: 2000 });
+      }
+      await expect(row).toHaveCount(0, { timeout: 2000 });
+    }).toPass({ timeout: 15000 });
+  }
 }

--- a/e2e/tests/project/project-completion.spec.ts
+++ b/e2e/tests/project/project-completion.spec.ts
@@ -61,20 +61,9 @@ test.describe('Project completion', () => {
     await expect(celebration).toBeHidden();
 
     await page.goto('/#/archived-projects');
-    const archivedProject = page
-      .locator('archived-projects-page .project-row')
-      .filter({ hasText: 'Test Project' });
-    await expect(archivedProject).toBeVisible();
+    await expect(projectPage.archivedProjectRow('Test Project')).toBeVisible();
 
-    // The archived-projects page renders while the previous route transition is
-    // still animating, so Angular can re-create the row right after Playwright
-    // resolves the button; the click then lands on the detached copy and
-    // silently no-ops. Re-issue it until the project actually leaves the list.
-    const reopenBtn = archivedProject.getByRole('button', { name: 'Reopen' });
-    await expect(async () => {
-      await reopenBtn.click();
-      await expect(archivedProject).toHaveCount(0, { timeout: 2000 });
-    }).toPass({ timeout: 20000 });
+    await projectPage.reopenArchivedProject('Test Project');
     await projectPage.navigateToProjectByName('Test Project');
     await expect(page).toHaveURL(/\/#\/project\/.+\/tasks/);
 

--- a/e2e/tests/project/project-completion.spec.ts
+++ b/e2e/tests/project/project-completion.spec.ts
@@ -66,9 +66,15 @@ test.describe('Project completion', () => {
       .filter({ hasText: 'Test Project' });
     await expect(archivedProject).toBeVisible();
 
-    await archivedProject.getByRole('button', { name: 'Reopen' }).click();
-
-    await expect(archivedProject).toHaveCount(0);
+    // The archived-projects page renders while the previous route transition is
+    // still animating, so Angular can re-create the row right after Playwright
+    // resolves the button; the click then lands on the detached copy and
+    // silently no-ops. Re-issue it until the project actually leaves the list.
+    const reopenBtn = archivedProject.getByRole('button', { name: 'Reopen' });
+    await expect(async () => {
+      await reopenBtn.click();
+      await expect(archivedProject).toHaveCount(0, { timeout: 2000 });
+    }).toPass({ timeout: 20000 });
     await projectPage.navigateToProjectByName('Test Project');
     await expect(page).toHaveURL(/\/#\/project\/.+\/tasks/);
 

--- a/e2e/tests/sync/supersync-worklog.spec.ts
+++ b/e2e/tests/sync/supersync-worklog.spec.ts
@@ -60,20 +60,7 @@ test.describe('@supersync Worklog Sync', () => {
       console.log('[Worklog Test] Client A marked tasks done');
 
       // ============ PHASE 2: Client A Archives ============
-      const finishDayBtn = clientA.page.locator('.e2e-finish-day');
-      await finishDayBtn.waitFor({ state: 'visible', timeout: 10000 });
-      await finishDayBtn.click();
-
-      await clientA.page.waitForURL(/daily-summary/, { timeout: 10000 });
-      await clientA.page.waitForLoadState('networkidle');
-
-      const saveBtn = clientA.page.locator(
-        'daily-summary button[mat-flat-button]:has(mat-icon:has-text("wb_sunny"))',
-      );
-      await saveBtn.waitFor({ state: 'visible', timeout: 10000 });
-      await saveBtn.click();
-
-      await clientA.page.waitForURL(/tag\/TODAY/, { timeout: 10000 });
+      await archiveDoneTasks(clientA);
       console.log('[Worklog Test] Client A archived tasks');
 
       // ============ PHASE 3: Sync ============
@@ -158,19 +145,7 @@ test.describe('@supersync Worklog Sync', () => {
       await markTaskDone(clientA, taskName);
 
       // ============ PHASE 2: Archive ============
-      const finishDayBtn = clientA.page.locator('.e2e-finish-day');
-      await finishDayBtn.waitFor({ state: 'visible', timeout: 10000 });
-      await finishDayBtn.click();
-
-      await clientA.page.waitForURL(/daily-summary/, { timeout: 10000 });
-
-      const saveBtn = clientA.page.locator(
-        'daily-summary button[mat-flat-button]:has(mat-icon:has-text("wb_sunny"))',
-      );
-      await saveBtn.waitFor({ state: 'visible', timeout: 10000 });
-      await saveBtn.click();
-
-      await clientA.page.waitForURL(/tag\/TODAY/, { timeout: 10000 });
+      await archiveDoneTasks(clientA);
 
       // ============ PHASE 3: Sync ============
       await clientA.sync.syncAndWait();

--- a/e2e/tests/sync/supersync-worklog.spec.ts
+++ b/e2e/tests/sync/supersync-worklog.spec.ts
@@ -5,6 +5,7 @@ import {
   createSimulatedClient,
   closeClient,
   markTaskDone,
+  archiveDoneTasks,
   type SimulatedE2EClient,
 } from '../../utils/supersync-helpers';
 import { waitForAppReady } from '../../utils/waits';
@@ -235,17 +236,7 @@ test.describe('@supersync Worklog Sync', () => {
       await clientA.workView.addTask(taskA1);
 
       await markTaskDone(clientA, taskA1);
-
-      // Archive
-      const finishDayBtnA = clientA.page.locator('.e2e-finish-day');
-      await finishDayBtnA.click();
-      await clientA.page.waitForURL(/daily-summary/, { timeout: 10000 });
-
-      const saveBtnA = clientA.page.locator(
-        'daily-summary button[mat-flat-button]:has(mat-icon:has-text("wb_sunny"))',
-      );
-      await saveBtnA.click();
-      await clientA.page.waitForURL(/tag\/TODAY/, { timeout: 10000 });
+      await archiveDoneTasks(clientA);
       console.log('[Multi Archive Test] Client A archived first batch');
 
       await clientA.sync.syncAndWait();
@@ -259,17 +250,7 @@ test.describe('@supersync Worklog Sync', () => {
       await clientB.workView.addTask(taskB1);
 
       await markTaskDone(clientB, taskB1);
-
-      // Archive
-      const finishDayBtnB = clientB.page.locator('.e2e-finish-day');
-      await finishDayBtnB.click();
-      await clientB.page.waitForURL(/daily-summary/, { timeout: 10000 });
-
-      const saveBtnB = clientB.page.locator(
-        'daily-summary button[mat-flat-button]:has(mat-icon:has-text("wb_sunny"))',
-      );
-      await saveBtnB.click();
-      await clientB.page.waitForURL(/tag\/TODAY/, { timeout: 10000 });
+      await archiveDoneTasks(clientB);
       console.log('[Multi Archive Test] Client B archived second batch');
 
       // ============ PHASE 3: Sync Both ============

--- a/e2e/utils/supersync-helpers.ts
+++ b/e2e/utils/supersync-helpers.ts
@@ -1332,21 +1332,29 @@ export const markTaskDoneByKey = async (
  * @param client - The simulated E2E client
  */
 export const archiveDoneTasks = async (client: SimulatedE2EClient): Promise<void> => {
-  // Click the "Finish Day" button to go to Daily Summary.
-  // The button is a routerLink inside an @if (hasDoneTasks()) / @else swap, so
-  // marking a task done re-creates the element; a single click can land in the
-  // window before Angular wires up the routerLink and silently no-ops (30s hang).
-  // Racing waitForURL against a one-shot click doesn't cover that gap, so re-issue
-  // the click until navigation actually starts.
+  // Click the "Finish Day" button to go to Daily Summary, re-issuing the click
+  // until navigation actually starts. The button itself no longer swaps on
+  // hasDoneTasks() (fixed in the finish-day-btn template), but it still sits
+  // inside work-view's own @if, so a click can land while Angular re-creates
+  // the element and silently no-op before the routerLink is wired.
   const finishDayBtn = client.page.locator('.e2e-finish-day');
   await finishDayBtn.waitFor({ state: 'visible', timeout: UI_VISIBLE_TIMEOUT });
+  let finishDayAttempts = 0;
   await expect(async () => {
-    // Bound the click: once navigation has started the button is gone, and an
-    // unbounded retry would block for the full actionTimeout and then report a
-    // click timeout for a navigation that actually succeeded.
-    await finishDayBtn.click({ timeout: 2000 });
+    finishDayAttempts++;
+    // Skip the click once we are already navigating: the button is gone by
+    // then, and clicking a missing element would report a click timeout for a
+    // navigation that actually succeeded. Bound it for the same reason.
+    if (!/daily-summary/.test(client.page.url())) {
+      await finishDayBtn.click({ timeout: 2000 });
+    }
     await client.page.waitForURL(/daily-summary/, { timeout: 2000 });
   }).toPass({ timeout: UI_VISIBLE_TIMEOUT_LONG });
+  if (finishDayAttempts > 1) {
+    // Surface the retry: the suite runs with retries: 0 so that non-determinism
+    // stays visible, and a silent in-test retry would defeat that.
+    console.warn(`[archiveDoneTasks] Finish Day took ${finishDayAttempts} attempts`);
+  }
 
   // Click "Save & Go Home" button (has sun icon wb_sunny)
   const saveAndGoHomeBtn = client.page.locator(

--- a/e2e/utils/supersync-helpers.ts
+++ b/e2e/utils/supersync-helpers.ts
@@ -1341,9 +1341,12 @@ export const archiveDoneTasks = async (client: SimulatedE2EClient): Promise<void
   const finishDayBtn = client.page.locator('.e2e-finish-day');
   await finishDayBtn.waitFor({ state: 'visible', timeout: UI_VISIBLE_TIMEOUT });
   await expect(async () => {
-    await finishDayBtn.click();
+    // Bound the click: once navigation has started the button is gone, and an
+    // unbounded retry would block for the full actionTimeout and then report a
+    // click timeout for a navigation that actually succeeded.
+    await finishDayBtn.click({ timeout: 2000 });
     await client.page.waitForURL(/daily-summary/, { timeout: 2000 });
-  }).toPass({ timeout: UI_VISIBLE_TIMEOUT });
+  }).toPass({ timeout: UI_VISIBLE_TIMEOUT_LONG });
 
   // Click "Save & Go Home" button (has sun icon wb_sunny)
   const saveAndGoHomeBtn = client.page.locator(

--- a/src/app/features/work-view/finish-day-btn/finish-day-btn.component.html
+++ b/src/app/features/work-view/finish-day-btn/finish-day-btn.component.html
@@ -4,7 +4,10 @@
     One element, appearance bound: an @if/@else swap between a flat and a
     stroked button re-creates the node whenever hasDoneTasks() flips, and a
     click landing in that window is dropped before the routerLink is wired.
-    matButton sets the same classes as mat-flat-button / mat-stroked-button.
+    matButton sets the same classes as mat-flat-button / mat-stroked-button —
+    but as property bindings they write no DOM attributes, so theme rules
+    keyed on button[mat-flat-button][color='primary'] do not match this one;
+    target the .mat-mdc-*-button classes those rules already list alongside.
   -->
   <button
     [matButton]="hasDoneTasks() ? 'filled' : 'outlined'"

--- a/src/app/features/work-view/finish-day-btn/finish-day-btn.component.html
+++ b/src/app/features/work-view/finish-day-btn/finish-day-btn.component.html
@@ -1,28 +1,20 @@
 <div class="finish-day-button-wrapper">
   <!-- NOTE: tabindex is same as for tasks -->
-  @if (hasDoneTasks()) {
-    <button
-      [matTooltip]="T.WW.FINISH_DAY_TOOLTIP | translate"
-      color="primary"
-      mat-flat-button
-      routerLink="/active/daily-summary"
-      tabindex="1"
-      class="e2e-finish-day"
-    >
-      <mat-icon>done_all</mat-icon>
-      {{ T.WW.FINISH_DAY | translate }}
-    </button>
-  } @else {
-    <button
-      [matTooltip]="T.WW.FINISH_DAY_TOOLTIP | translate"
-      color=""
-      mat-stroked-button
-      routerLink="/active/daily-summary"
-      tabindex="1"
-      class="e2e-finish-day"
-    >
-      <mat-icon>done_all</mat-icon>
-      {{ T.WW.FINISH_DAY | translate }}
-    </button>
-  }
+  <!--
+    One element, appearance bound: an @if/@else swap between a flat and a
+    stroked button re-creates the node whenever hasDoneTasks() flips, and a
+    click landing in that window is dropped before the routerLink is wired.
+    matButton sets the same classes as mat-flat-button / mat-stroked-button.
+  -->
+  <button
+    [matButton]="hasDoneTasks() ? 'filled' : 'outlined'"
+    [color]="hasDoneTasks() ? 'primary' : ''"
+    [matTooltip]="T.WW.FINISH_DAY_TOOLTIP | translate"
+    routerLink="/active/daily-summary"
+    tabindex="1"
+    class="e2e-finish-day"
+  >
+    <mat-icon>done_all</mat-icon>
+    {{ T.WW.FINISH_DAY | translate }}
+  </button>
 </div>

--- a/src/app/features/work-view/finish-day-btn/finish-day-btn.component.spec.ts
+++ b/src/app/features/work-view/finish-day-btn/finish-day-btn.component.spec.ts
@@ -3,6 +3,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
+import { MatButton } from '@angular/material/button';
 import { FinishDayBtnComponent } from './finish-day-btn.component';
 
 describe('FinishDayBtnComponent', () => {
@@ -10,6 +11,15 @@ describe('FinishDayBtnComponent', () => {
 
   const btnEl = (): HTMLButtonElement =>
     fixture.debugElement.query(By.css('.e2e-finish-day')).nativeElement;
+
+  /** The appearance as MatButton reports it, rather than its internal classes. */
+  const appearance = (): string =>
+    fixture.debugElement.query(By.directive(MatButton)).componentInstance.appearance;
+
+  const setHasDoneTasks = (value: boolean): void => {
+    fixture.componentRef.setInput('hasDoneTasks', value);
+    fixture.detectChanges();
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -23,16 +33,27 @@ describe('FinishDayBtnComponent', () => {
   });
 
   it('renders an outlined button while there are no done tasks', () => {
-    expect(btnEl().classList).toContain('mat-mdc-outlined-button');
+    expect(appearance()).toBe('outlined');
     expect(btnEl().classList).toContain('mat-unthemed');
   });
 
   it('renders a filled primary button once there are done tasks', () => {
-    fixture.componentRef.setInput('hasDoneTasks', true);
-    fixture.detectChanges();
+    setHasDoneTasks(true);
 
-    expect(btnEl().classList).toContain('mat-mdc-unelevated-button');
+    expect(appearance()).toBe('filled');
     expect(btnEl().classList).toContain('mat-primary');
+  });
+
+  // MatButton applies the appearance by mutating classList imperatively while
+  // `color` is an Angular [class] host binding. Flipping back is the direction
+  // where those two class-management mechanisms could diverge.
+  it('restores the outlined appearance when the flip reverses', () => {
+    setHasDoneTasks(true);
+    setHasDoneTasks(false);
+
+    expect(appearance()).toBe('outlined');
+    expect(btnEl().classList).toContain('mat-unthemed');
+    expect(btnEl().classList).not.toContain('mat-primary');
   });
 
   // The button is a routerLink: an @if/@else swap between the two appearances
@@ -41,9 +62,17 @@ describe('FinishDayBtnComponent', () => {
   it('keeps the same DOM node across the flip', () => {
     const before = btnEl();
 
-    fixture.componentRef.setInput('hasDoneTasks', true);
-    fixture.detectChanges();
+    setHasDoneTasks(true);
 
     expect(btnEl()).toBe(before);
+  });
+
+  // The @if/@else pair dropped keyboard focus on every flip; one node keeps it.
+  it('keeps focus across the flip', () => {
+    btnEl().focus();
+
+    setHasDoneTasks(true);
+
+    expect(document.activeElement).toBe(btnEl());
   });
 });

--- a/src/app/features/work-view/finish-day-btn/finish-day-btn.component.spec.ts
+++ b/src/app/features/work-view/finish-day-btn/finish-day-btn.component.spec.ts
@@ -1,0 +1,49 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+import { By } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
+import { FinishDayBtnComponent } from './finish-day-btn.component';
+
+describe('FinishDayBtnComponent', () => {
+  let fixture: ComponentFixture<FinishDayBtnComponent>;
+
+  const btnEl = (): HTMLButtonElement =>
+    fixture.debugElement.query(By.css('.e2e-finish-day')).nativeElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FinishDayBtnComponent, NoopAnimationsModule, TranslateModule.forRoot()],
+      providers: [provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FinishDayBtnComponent);
+    fixture.componentRef.setInput('hasDoneTasks', false);
+    fixture.detectChanges();
+  });
+
+  it('renders an outlined button while there are no done tasks', () => {
+    expect(btnEl().classList).toContain('mat-mdc-outlined-button');
+    expect(btnEl().classList).toContain('mat-unthemed');
+  });
+
+  it('renders a filled primary button once there are done tasks', () => {
+    fixture.componentRef.setInput('hasDoneTasks', true);
+    fixture.detectChanges();
+
+    expect(btnEl().classList).toContain('mat-mdc-unelevated-button');
+    expect(btnEl().classList).toContain('mat-primary');
+  });
+
+  // The button is a routerLink: an @if/@else swap between the two appearances
+  // would re-create the node whenever hasDoneTasks() flips, and a click landing
+  // in that window is dropped before the link is wired (CI run 33189475377).
+  it('keeps the same DOM node across the flip', () => {
+    const before = btnEl();
+
+    fixture.componentRef.setInput('hasDoneTasks', true);
+    fixture.detectChanges();
+
+    expect(btnEl()).toBe(before);
+  });
+});


### PR DESCRIPTION
## Why

The scheduled E2E run [33189475377](https://github.com/super-productivity/super-productivity/actions/runs/33189475377) on master failed two tests with the same signature: Playwright reported the click as delivered ("click action done"), but the Angular handler never ran — the trace shows **zero NgRx actions** for the following 20s, then an assertion timeout.

- `project/project-completion.spec.ts:71` — Reopen click no-op
- `sync/supersync-worklog.spec.ts:217` — Finish Day click no-op

## What changed

**Product fix — `finish-day-btn`.** The button lived in an `@if (hasDoneTasks()) / @else` pair that differed only in appearance, so every flip destroyed and re-created the node. Verified in a browser: the old template loses node identity across the flip, the new one keeps it. Collapsed onto a single element with Material's `[matButton]` appearance input.

Beyond the dropped click, the swap also **dropped keyboard focus** on every flip and churned the tooltip's `aria-describedby` — both fixed as a side effect, and both more durable arguments than the rare dead click.

The rendered classes are unchanged (`mdc-button--outlined mat-mdc-outlined-button mat-unthemed` / `mdc-button--unelevated mat-mdc-unelevated-button mat-primary`), so there is no visual change. Note this is the repo's first `[matButton]` binding — the legacy `mat-flat-button` / `mat-stroked-button` attributes are fixed at construction and cannot express a reactive appearance on one node. `docs/styling-guide.md` now sanctions the form, and the template notes that property bindings write no DOM attributes, so theme rules keyed on `button[mat-flat-button][color='primary']` no longer match this button (each of those rules already lists the class selector alongside, so nothing regresses today).

**Test fixes.** Retry the two clicks until they take effect, bounded so a slow-but-successful action can't be reported as a click timeout:

- `ProjectPage.reopenArchivedProject()` — new page-object method; also fixes a real test-isolation bug (the spec matched the unprefixed `'Test Project'`).
- `archiveDoneTasks` — guard the re-click on the URL, not the button. Four inline copies of the Finish Day + Save-and-go-home flow in `supersync-worklog.spec.ts` now share it.
- Both loops warn when they need a second attempt: the suite runs `retries: 0` so non-determinism stays visible, and a silent in-test retry defeats that.

## Verification

- `finish-day-btn.component.spec.ts` — 5 new tests; **2 fail against the old template** (node identity, focus retention).
- 45/45 work-view unit tests; `project-completion` E2E 3/3 locally; `ng build` clean; all files lint/prettier clean.
- **Not verified:** the `@supersync` suite has not run — local docker ports were occupied. The `archiveDoneTasks` URL guard is source-level reasoning only, and it gates 9 spec files across the SuperSync and WebDAV jobs. Please let the scheduled E2E workflow run before merging.

## Root cause honesty

The trace proves the Reopen click no-ops; it does not prove *why*. The commit hedges rather than asserts a mechanism — `@for` tracks by `project.id` and `warpRoute` doesn't re-create the entering node, so the row-recreation story has no confirmed cause. The retry is a bounded mitigation with a clear failure message, not a claimed fix.

https://claude.ai/code/session_015z2CW2pVYiwsY92XzdbR4y
