### PR TITLE
fix(android): disable R8 minification that crashes the beta on start

### DIFF
--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -49,7 +49,7 @@ jobs:
           # packages/sync-core is included because the Kotlin op-payload
           # decryptor must stay wire-compatible with its encrypt() — the live
           # round-trip test below is what catches drift on sync-core PRs.
-          ANDROID_PATTERN='^(android/|packages/sync-core/|tools/(generate-android-crypto-fixtures|verify-r8-mapping)\.mjs$|capacitor\.config\.ts$|package(-lock)?\.json$|\.github/workflows/android-tests\.yml$)'
+          ANDROID_PATTERN='^(android/|packages/sync-core/|tools/generate-android-crypto-fixtures\.mjs$|capacitor\.config\.ts$|package(-lock)?\.json$|\.github/workflows/android-tests\.yml$)'
           if grep -Eq "${ANDROID_PATTERN}" <<< "${CHANGED_FILES}"; then android=true; fi
 
           echo "→ android=${android}"
@@ -109,17 +109,6 @@ jobs:
         env:
           LIVE_CRYPTO_FIXTURES: ${{ github.workspace }}/android/app/build/live-crypto-fixtures.tsv
         run: ./gradlew :app:testPlayDebugUnitTest :app:testFdroidDebugUnitTest
-
-      # Release builds are minified, and both keep-rule failures are silent: a
-      # stripped @JavascriptInterface method or WorkManager worker builds and
-      # installs fine, it just never runs. Nothing else here exercises R8 — the
-      # emulator tests below run the debug build — so check the mapping instead.
-      - name: Verify R8 keep rules survive minification
-        if: steps.changes.outputs.android == 'true'
-        run: |
-          (cd android && ./gradlew :app:minifyFdroidReleaseWithR8)
-          node tools/verify-r8-mapping.mjs \
-            android/app/build/outputs/mapping/fdroidRelease/mapping.txt
 
       - name: Enable KVM
         if: steps.changes.outputs.android == 'true'

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -124,11 +124,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sup-android-release
-          # The R8 mapping travels with the APKs: release builds are minified, so
-          # without it a release stack trace cannot be retraced.
-          path: |
-            android/app/build/outputs/apk/**/*.apk
-            android/app/build/outputs/mapping/**/mapping.txt
+          path: android/app/build/outputs/apk/**/*.apk
 
       # Ship the dev-versioned APK to the Play `internal` track (non-tag master
       # pushes only, and only when the versionCode was actually applied). This is
@@ -149,7 +145,6 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.superproductivity.superproductivity
           releaseFiles: android/app/build/outputs/apk/play/release/*.apk
-          mappingFile: android/app/build/outputs/mapping/playRelease/mapping.txt
           releaseName: 'dev ${{ steps.devvc.outputs.code }} (${{ steps.devvc.outputs.sha }})'
           tracks: internal
           status: completed
@@ -198,7 +193,6 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.superproductivity.superproductivity
           releaseFiles: android/app/build/outputs/apk/play/release/*.apk
-          mappingFile: android/app/build/outputs/mapping/playRelease/mapping.txt
           tracks: internal
           status: completed
           inAppUpdatePriority: 2

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -56,13 +56,33 @@ android {
             }
 
             signingConfig signingConfigs.release
-            // Google Play requires a minimum level of DEX shrinking, obfuscation
-            // and optimization for app uploads from February 2027. The plain
-            // "proguard-android.txt" is not enough on its own: it sets
-            // -dontoptimize, so it would satisfy neither half of that.
-            minifyEnabled true
-            shrinkResources true
-            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
+            // Minification is deliberately OFF.
+            //
+            // Turning it on (#9766) produced a release build that crashes on
+            // start, and it reached every Play internal-track tester before
+            // anyone launched it: master auto-publishes to that track, so two
+            // minified builds shipped before the crash was reported.
+            //
+            // Nothing in CI ever starts a minified build. The emulator job
+            // installs the DEBUG variant, and the R8 job only checked keep rules
+            // against mapping.txt — a build that dies in onCreate passes both.
+            // That job also minified the FDROID flavor only, while the APK that
+            // ships to Play is the PLAY flavor. R8 full mode is the default
+            // under AGP 8+ (android.enableR8.fullMode is unset), so obfuscation,
+            // shrinking, optimization and resource shrinking all ran against
+            // this app for the first time, simultaneously, in production.
+            //
+            // Google Play's DEX shrinking/obfuscation requirement only starts in
+            // February 2027, so there is nothing to buy by carrying that risk in
+            // the meantime.
+            //
+            // Before re-enabling: make CI actually launch a minified release
+            // build on the emulator (android-tests.yml), so a startup crash is a
+            // red check instead of a shipped one. proguard-rules.pro and
+            // tools/verify-r8-mapping.mjs are kept ready for that; both are inert
+            // while minifyEnabled is false.
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
 

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,14 +1,22 @@
 # R8 rules for the release build.
 #
-# Release builds are minified (see build.gradle) because Google Play requires a
-# minimum level of DEX shrinking, obfuscation and optimization from February 2027.
+# INERT RIGHT NOW: release builds run with minifyEnabled false (see build.gradle
+# for why — enabling it shipped a startup crash to the Play internal track). This
+# file is kept staged for re-enabling minification ahead of Google Play's
+# February 2027 DEX shrinking/obfuscation requirement.
+#
+# It is NOT known to be sufficient: it was only ever validated by grepping
+# mapping.txt, never by starting a minified build. Treat the rules below as a
+# starting point, and re-land minification only behind CI that actually launches
+# the minified APK.
+#
 # Everything R8 cannot see statically has to be kept here — reflection and the
 # WebView bridge both look like dead code to it.
 
 # --- WebView JS bridge ------------------------------------------------------
 # The Angular app calls these methods by name off the injected window property,
-# so R8 must neither rename nor drop them. Redundant today: the default
-# proguard-android-optimize.txt keeps @JavascriptInterface members globally.
+# so R8 must neither rename nor drop them. Redundant today: the AGP default
+# proguard file keeps @JavascriptInterface members globally.
 # Kept because it names the one class we actually depend on, and because the
 # failure is silent — a stripped bridge method builds and installs fine, the JS
 # call just goes nowhere. tools/verify-r8-mapping.mjs is what enforces it.

--- a/tools/verify-r8-mapping.mjs
+++ b/tools/verify-r8-mapping.mjs
@@ -1,15 +1,21 @@
 #!/usr/bin/env node
 /**
- * Guards the two R8 keep rules whose failure is invisible at build time.
+ * DORMANT: nothing runs this today. Release builds are built with
+ * minifyEnabled false (see android/app/build.gradle for why), so no mapping.txt
+ * is produced and no workflow invokes this tool. It is kept staged for the
+ * re-land of minification. Nothing below is currently enforcing anything.
  *
- * A minified release that drops a @JavascriptInterface method or a WorkManager
- * worker builds and installs fine — the bridge call just goes nowhere and the
- * worker never runs. Both only surface on a device, and release builds ship to
- * the Play internal track straight off master, so this reads the mapping R8
- * already produces and fails the build instead.
+ * What it was for: a minified release that drops a @JavascriptInterface method
+ * or a WorkManager worker builds and installs fine — the bridge call just goes
+ * nowhere and the worker never runs. Both only surface on a device, so this
+ * reads the mapping R8 emits and fails the build instead.
  *
  * Expectations come from the Kotlin sources, not a hardcoded list, so adding a
  * bridge method or a worker keeps the check honest without touching this file.
+ *
+ * Note for the re-land: checking the mapping is NOT sufficient. It cannot see a
+ * build that dies in onCreate, and it was only ever run against the fdroid
+ * flavor, while the APK that ships to Play is the play flavor.
  *
  * Usage: node tools/verify-r8-mapping.mjs <mapping.txt> [androidSrcRoot]
  */


### PR DESCRIPTION
The Play internal-track build published from master at 17:31 UTC (4622ffe)
crashes on start. It is the first build ever produced with minifyEnabled
true: #9766 turned on R8 shrinking, obfuscation, optimization and
shrinkResources roughly an hour earlier, and every master push
auto-publishes to that track with status: completed, so it reached
testers' phones — and their real data — within minutes.

Nothing in CI could have caught it. The emulator job installs the DEBUG
variant (connectedPlayDebugAndroidTest), and the R8 job only runs
minifyFdroidReleaseWithR8 and greps mapping.txt for two keep rules. No
minified APK is launched anywhere, so a build that dies in onCreate
passes both checks — the workflow's own comment says as much. R8 full
mode is the default under AGP 8+, so obfuscation, shrinking and
optimization had never run against this app until that commit.

The startup path offers plenty of room for a keep-rule gap to be fatal
rather than silent: CapacitorMainActivity calls
BackgroundSyncCredentialStore.get() from onCreate outside any try/catch,
and createPrefs() catches Exception only, so an Error propagates. That is
a candidate, not a diagnosis — pinning the actual frame needs a device
stack trace, which is exactly what nobody had before shipping.

So revert the enablement rather than guess at rules. Google Play's 25%
DEX shrinking/obfuscation requirement starts in February 2027; there is
nothing to buy by carrying an unlaunched, unvalidated minification
config until then.

Reverted:
- minifyEnabled/shrinkResources/proguard-android-optimize.txt in
  build.gradle
- the R8 verify step in android-tests.yml, whose gradle task does not
  exist while minification is off (it would fail every Android PR)
- the mappingFile inputs and artifact glob in build-android.yml, which
  point at a mapping.txt that is no longer generated

Kept, because they are independent of minification and worth having:
the BackgroundSyncCredentialStore plaintext-fallback fix, the backup and
device-transfer exclusions, and the instrumented regression.

proguard-rules.pro and tools/verify-r8-mapping.mjs stay in the tree,
staged for a re-land, with their headers corrected to say the rules are
inert and were never validated against a running minified build.

Before re-enabling: make CI actually start a minified release build on
the emulator, so a startup crash is a red check instead of a shipped one.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y8hv3wGzyVpdQEedAEVcgP