### PR TITLE
feat(android): URL scheme task actions

### DIFF
--- a/.github/workflows/build-create-windows-store-on-release.yml
+++ b/.github/workflows/build-create-windows-store-on-release.yml
@@ -38,12 +38,6 @@ jobs:
           git config --global url."https://github.com/".insteadOf
           ssh://git@github.com/
 
-      - name: Load Electron Builder Windows Store Config
-        run: echo $WIN_STORE_ELECTRON_BUILDER_YML | base64 --decode > electron-builder.yaml
-        shell: bash
-        env:
-          WIN_STORE_ELECTRON_BUILDER_YML: ${{secrets.WIN_STORE_ELECTRON_BUILDER_YML}}
-
       - name: Get npm cache directory
         id: npm-cache-dir
         shell: bash
@@ -68,6 +62,13 @@ jobs:
 
       - name: Build Frontend & Electron
         run: npm run build
+
+      # `npm run build` checks the repository's Linux packaging config during lint.
+      - name: Load Electron Builder Windows Store Config
+        run: echo $WIN_STORE_ELECTRON_BUILDER_YML | base64 --decode > electron-builder.yaml
+        shell: bash
+        env:
+          WIN_STORE_ELECTRON_BUILDER_YML: ${{secrets.WIN_STORE_ELECTRON_BUILDER_YML}}
 
       - name: Build/Release Electron app
         uses: johannesjo/action-electron-builder@9ea9e2d991c97668843d57337848e3e2b1ffab3d # v1

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -124,6 +124,22 @@
           android:scheme="com.superproductivity.superproductivity"
           android:pathPrefix="/plugin-oauth-callback" />
       </intent-filter>
+
+      <!-- URL Scheme task actions (create-task / complete-task), same scheme and
+           trust model as the OAuth callbacks above. Parsed on the JS side by
+           parse-app-uri-task-action.ts via Capacitor's appUrlOpen; docs:
+           docs/wiki/3.01-API.md §4 -->
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data
+          android:scheme="com.super-productivity.app"
+          android:host="create-task" />
+        <data
+          android:scheme="com.super-productivity.app"
+          android:host="complete-task" />
+      </intent-filter>
     </activity>
 
     <activity

--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -133,6 +133,15 @@ class CapacitorMainActivity : BridgeActivity() {
         registerPlugin(WebDavHttpPlugin::class.java)
         registerPlugin(NavigationBarPlugin::class.java)
 
+        // On Activity recreation (config change / process death) getIntent() still
+        // holds the original launch intent and BridgeActivity.load() replays it
+        // through onNewIntent — without the LAUNCHED_FROM_HISTORY flag, so the
+        // recents guard in onNewIntent doesn't catch it. A stale VIEW data URI
+        // would re-fire appUrlOpen and duplicate the URL scheme task action;
+        // clear it (mirrors the savedInstanceState guard for share intents below).
+        if (savedInstanceState != null) {
+            intent?.data = null
+        }
         try {
             super.onCreate(savedInstanceState)
         } catch (e: Throwable) {
@@ -316,6 +325,14 @@ class CapacitorMainActivity : BridgeActivity() {
     }
 
     override fun onNewIntent(intent: Intent) {
+        // A relaunch from recents redelivers the task's base intent. Replaying a
+        // VIEW data URI would re-fire Capacitor's appUrlOpen and repeat the URL
+        // scheme task action (create-task would add the same task again, syncing
+        // a duplicate to all devices), so strip the stale URI. OAuth callback
+        // replays are equally unwanted. SEND shares carry no data URI — unaffected.
+        if (intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY != 0) {
+            intent.data = null
+        }
         super.onNewIntent(intent)
         handleIntent(intent)
     }

--- a/docs/wiki/3.01-API.md
+++ b/docs/wiki/3.01-API.md
@@ -466,22 +466,23 @@ curl http://127.0.0.1:3876/tags
 
 ## 4. URL Scheme Actions
 
-Two task actions are reachable through the app's existing custom URL scheme, without opening the app UI first: **add a task** and **complete a task** (matched by title). This is intended for external automation — most notably an iOS Shortcut's "Open URLs" action, since Apple Shortcuts has no other lightweight way to reach a non-App-Intents app — but works anywhere a URL can be opened.
+Two task actions are reachable through the app's existing custom URL scheme, without opening the app UI first: **add a task** and **complete a task** (matched by title). This is intended for external automation — most notably an iOS Shortcut's "Open URLs" action (which also makes the actions reachable via Siri, see below) and Android automation apps — but works anywhere a URL can be opened.
 
-Currently iOS and desktop only. Android support is not yet implemented (the app doesn't declare the intent-filters these actions need) and is tracked as a follow-up.
+Not available in the web (browser) build, which has no URL scheme registration.
 
 ### Platforms and Schemes
 
-| Platform           | Scheme                          | Example                                                     |
-| ------------------ | ------------------------------- | ----------------------------------------------------------- |
-| iOS (Capacitor)    | `com.super-productivity.app://` | `com.super-productivity.app://create-task?title=Buy%20milk` |
-| Desktop (Electron) | `superproductivity://`          | `superproductivity://create-task?title=Buy%20milk`          |
+| Platform            | Scheme                          | Example                                                     |
+| ------------------- | ------------------------------- | ----------------------------------------------------------- |
+| iOS (Capacitor)     | `com.super-productivity.app://` | `com.super-productivity.app://create-task?title=Buy%20milk` |
+| Android (Capacitor) | `com.super-productivity.app://` | `com.super-productivity.app://create-task?title=Buy%20milk` |
+| Desktop (Electron)  | `superproductivity://`          | `superproductivity://create-task?title=Buy%20milk`          |
 
 Both schemes are already registered for other purposes (OAuth callbacks on mobile; global-shortcut and window-visibility actions on desktop) — these are two more recognized actions on the same schemes, not a new registration.
 
 ### Actions
 
-**Add a task** — action `create-task` on both platforms (desktop also accepts the title as a path segment, `create-task/<title>`, matching the pre-existing desktop action shipped since v14.2.4 — whose title handling this changes, see the Short Syntax note below). Not `add-task`: desktop's `add-task` protocol action already exists and does something unrelated (opens the quick-add-task input bar).
+**Add a task** — action `create-task` on all platforms (desktop also accepts the title as a path segment, `create-task/<title>`, matching the pre-existing desktop action shipped since v14.2.4 — whose title handling this changes, see the Short Syntax note below). Not `add-task`: desktop's `add-task` protocol action already exists and does something unrelated (opens the quick-add-task input bar).
 
 | Query parameter | Required | Description                                                                                                                                   |
 | --------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -491,11 +492,11 @@ Both schemes are already registered for other purposes (OAuth callbacks on mobil
 
 **Short Syntax is _not_ parsed** (see [[3.04-Short-Syntax]]): tokens like `+Project`, `#tag`, or `@date` in the title are stored literally rather than creating/assigning a project, tags, or a due date (surrounding whitespace is still trimmed). A URL is untrusted external content, so — as with the email-drop import — it can't silently create tags/projects or override an explicit `projectId`. Use the `projectId` parameter to set the project.
 
-> **Behavior change:** the pre-existing desktop `create-task` action (shipped since v14.2.4) previously parsed Short Syntax on the title, like a manually typed task. As of this change the title is stored literally on both platforms. Pass `projectId` for the project; `+`/`#`/`@` tokens are no longer interpreted.
+> **Behavior change:** the pre-existing desktop `create-task` action (shipped since v14.2.4) previously parsed Short Syntax on the title, like a manually typed task. As of this change the title is stored literally on all platforms. Pass `projectId` for the project; `+`/`#`/`@` tokens are no longer interpreted.
 
 Without an explicit `projectId`, the task is added to whichever project/tag/context is currently active in the app — which on a cold launch is whatever was last open, not necessarily the Inbox. Pass `projectId` for deterministic placement.
 
-**Complete a task** — action `complete-task` on both platforms.
+**Complete a task** — action `complete-task` on all platforms.
 
 | Query parameter | Required | Description                                                                                                                                                                                        |
 | --------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -513,11 +514,17 @@ superproductivity://create-task?title=Buy%20milk
 superproductivity://complete-task?title=Buy%20milk
 ```
 
+### Triggering via Voice Assistants
+
+- **Siri (iOS):** create a Shortcut in the Apple Shortcuts app — "Ask for Input" (text) followed by "Open URLs" with `com.super-productivity.app://create-task?title=` and the input appended — then invoke it by name: "Hey Siri, \<shortcut name\>". Siri dictates the title, the URL opens the app, and the task is added. Query parameter values must be URL-encoded; Shortcuts' "URL Encode" action handles titles with spaces or special characters.
+- **Google Assistant / Gemini (Android):** no direct voice integration exists — Google removed third-party notes/lists Assistant integration in 2023, and its successor (AppFunctions) is not yet publicly available. Android automation apps (e.g. Tasker, Automate) can open these URLs to create tasks from their own triggers.
+
 ### Behavior Notes
 
-- Both platforms show a snack notification on success (task added/completed) or failure (no matching/ambiguous task, unknown project) — there is no other feedback channel for a URL triggered from outside the app.
+- All platforms show a snack notification on success (task added/completed) or failure (no matching/ambiguous task, unknown project) — there is no other feedback channel for a URL triggered from outside the app.
 - An action received during a cold launch (app not already running) is queued until the app's own data has finished loading, so it never races initial hydration.
-- Not available in the web (browser) build, or on Android yet — see [[3.05-Web-App-vs-Desktop]].
+- On Android, opening the URL brings the app to the foreground (the action is handled by the main activity); there is no background execution.
+- Not available in the web (browser) build — see [[3.05-Web-App-vs-Desktop]].
 
 ## 5. Versioning and Compatibility
 
@@ -551,5 +558,5 @@ pruning it, so an input-validation limit is not the stored clock size.
   Electron have different capabilities. See [[2.21-Manage-Plugins]],
   [[3.05-Web-App-vs-Desktop]], and the repository plugin guide.
 - **Local REST API:** Desktop-only, localhost-bound, and protected by a Bearer access token on every request except `/health`. For automation and scripting. See [[3.05-Web-App-vs-Desktop]] for platform differences.
-- **URL Scheme Actions:** iOS (Capacitor) and desktop (Electron) only, not the web build or Android. No authentication — any process able to open a URL on the device can trigger it, same trust model as the existing OAuth-callback/global-shortcut actions on the same schemes.
+- **URL Scheme Actions:** iOS and Android (Capacitor) and desktop (Electron), not the web build. No authentication — any process able to open a URL on the device can trigger it, same trust model as the existing OAuth-callback/global-shortcut actions on the same schemes.
 - **Further documentation:** Sync Server README and auth docs in `packages/super-sync-server/`; Plugin API and examples in `packages/plugin-api/`, `docs/plugin-development.md`, and example plugins under `packages/plugin-dev/`; Local REST API types in `electron/shared-with-frontend/local-rest-api.model.ts`.

--- a/docs/wiki/3.01-API.md
+++ b/docs/wiki/3.01-API.md
@@ -480,6 +480,8 @@ Not available in the web (browser) build, which has no URL scheme registration.
 
 Both schemes are already registered for other purposes (OAuth callbacks on mobile; global-shortcut and window-visibility actions on desktop) — these are two more recognized actions on the same schemes, not a new registration.
 
+Use the action names in lowercase. On Android the OS matches the declared hosts case-sensitively, so `://Create-Task` won't resolve at all; iOS and desktop register the whole scheme and lowercase the action in the app, but lowercase is the only form that works everywhere.
+
 ### Actions
 
 **Add a task** — action `create-task` on all platforms (desktop also accepts the title as a path segment, `create-task/<title>`, matching the pre-existing desktop action shipped since v14.2.4 — whose title handling this changes, see the Short Syntax note below). Not `add-task`: desktop's `add-task` protocol action already exists and does something unrelated (opens the quick-add-task input bar).
@@ -517,7 +519,7 @@ superproductivity://complete-task?title=Buy%20milk
 ### Triggering via Voice Assistants
 
 - **Siri (iOS):** create a Shortcut in the Apple Shortcuts app — "Ask for Input" (text) followed by "Open URLs" with `com.super-productivity.app://create-task?title=` and the input appended — then invoke it by name: "Hey Siri, \<shortcut name\>". Siri dictates the title, the URL opens the app, and the task is added. Query parameter values must be URL-encoded; Shortcuts' "URL Encode" action handles titles with spaces or special characters.
-- **Google Assistant / Gemini (Android):** no direct voice integration exists — Google removed third-party notes/lists Assistant integration in 2023, and its successor (AppFunctions) is not yet publicly available. Android automation apps (e.g. Tasker, Automate) can open these URLs to create tasks from their own triggers.
+- **Google Assistant / Gemini (Android):** no direct voice integration exists for this app — Google removed third-party notes/lists Assistant integration in 2023, and Gemini's successor mechanism (AppFunctions) has no public third-party integration path yet (as of 2026-08). Android automation apps (e.g. Tasker, Automate) can open these URLs to create tasks from their own triggers.
 
 ### Behavior Notes
 

--- a/docs/wiki/3.05-Web-App-vs-Desktop.md
+++ b/docs/wiki/3.05-Web-App-vs-Desktop.md
@@ -30,7 +30,7 @@ The web app updates itself through its service worker and prompts for a reload w
 
 ### URL Scheme Actions
 
-The `create-task`/`complete-task` URL scheme actions (see [[3.01-API]]) rely on the app having a registered custom URL scheme, which only Electron and the Capacitor iOS build have (Android support isn't implemented yet). Not available in the web (browser) build.
+The `create-task`/`complete-task` URL scheme actions (see [[3.01-API]]) rely on the app having a registered custom URL scheme, which Electron and the Capacitor iOS and Android builds have. Not available in the web (browser) build.
 
 ## Browser-Related Limitations
 

--- a/src/app/features/tasks/util/parse-app-uri-task-action.ts
+++ b/src/app/features/tasks/util/parse-app-uri-task-action.ts
@@ -15,7 +15,9 @@ export type AppUriTaskAction = AppUriAddTaskAction | AppUriCompleteTaskAction;
 /**
  * Parses the `com.super-productivity.app://create-task?title=...` and
  * `.../complete-task?title=...` custom URL scheme actions (used by iOS
- * Shortcuts' "Open URLs" action). `create-task` (not `add-task`) matches the
+ * Shortcuts' "Open URLs" action and Android automation apps — both platforms
+ * declare VIEW filters for these hosts and route through the same Capacitor
+ * `appUrlOpen` listener). `create-task` (not `add-task`) matches the
  * desktop Electron protocol action name — desktop's own `add-task` action
  * already means something unrelated (opens the quick-add-task input bar).
  * Returns `null` for any other/unrecognized URL, including the existing

--- a/src/main.ts
+++ b/src/main.ts
@@ -570,9 +570,9 @@ if (IS_IOS_NATIVE) {
 }
 
 // Handle app URL open (for OAuth callbacks, deep links, etc.) on iOS *and*
-// Android: Android declares no task-action host, but its VIEW intent filters
-// do carry plugin OAuth callbacks, so gating this on iOS alone leaves that
-// callback with no listener at all.
+// Android: both declare VIEW intent filters for the task-action hosts
+// (create-task / complete-task) and the plugin OAuth callbacks, so gating
+// this on iOS alone leaves those routes with no listener at all.
 //
 // This must be the ONLY `appUrlOpen` listener in the app. `@capacitor/app`
 // emits a cold-start URL with `retainUntilConsumed: true`, and Capacitor

--- a/tools/verify-linux-wm-class.test.js
+++ b/tools/verify-linux-wm-class.test.js
@@ -76,3 +76,28 @@ test('the argv wrapper execs the binary afterPack actually renames', () => {
   const wrapper = readRoot('build', 'linux', 'snap-wrapper.sh');
   assert.match(wrapper, new RegExp(`/${RENAMED}"`));
 });
+
+test('the Windows Store config is loaded after repository config checks', () => {
+  const workflow = readRoot(
+    '.github',
+    'workflows',
+    'build-create-windows-store-on-release.yml',
+  );
+  const buildStep = workflow.indexOf('- name: Build Frontend & Electron');
+  const loadStoreConfigStep = workflow.indexOf(
+    '- name: Load Electron Builder Windows Store Config',
+  );
+  const packageStep = workflow.indexOf('- name: Build/Release Electron app');
+
+  assert.notEqual(buildStep, -1, 'Windows Store frontend build step not found');
+  assert.notEqual(loadStoreConfigStep, -1, 'Windows Store config-loading step not found');
+  assert.notEqual(packageStep, -1, 'Windows Store packaging step not found');
+  assert.ok(
+    loadStoreConfigStep > buildStep,
+    'the Store-only config must not replace electron-builder.yaml before npm run build checks the repository config',
+  );
+  assert.ok(
+    loadStoreConfigStep < packageStep,
+    'the Store-only config must replace electron-builder.yaml before electron-builder packages the app',
+  );
+});


### PR DESCRIPTION
## Summary

- Declares VIEW intent-filters for `com.super-productivity.app://create-task` and `://complete-task` on `CapacitorMainActivity`, closing the tracked Android gap in the URL Scheme Actions API (docs/wiki/3.01-API.md §4). The JS routing (`appUrlOpen` → `parse-app-uri-task-action`) already ran on Android; only the manifest declaration was missing.
- Guards against the Android deep-link double-fire: a relaunch from recents (or Activity recreation) redelivers the original VIEW intent, which would re-fire `appUrlOpen` and create the task a second time — syncing a duplicate to all devices. The activity now strips the stale data URI on `FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY` and on recreation, mirroring the existing share-intent guard.
- Wiki: Android added to the URL-scheme platform table, a "Triggering via Voice Assistants" section (Siri/iOS-Shortcuts recipe; Android voice status as of 2026-08), case-sensitive host matching note, stale comments corrected.

No new sync surface: one URL → one `appUrlOpen` → one plain local add-task/complete dispatch (one intent = one op); actions queue behind initial hydration.

## Review

Reviewed by a code-review agent: the replay-duplicate finding (critical) and both doc suggestions were addressed in `34cc28e23c`. Known out-of-scope note: `pendingCapacitorAppUriAction$` is a `ReplaySubject(1)`, so two URL actions during one cold launch keep only the last — pre-existing and shared with iOS.

## Verification

- `checkFile` on touched TS files; manifest XML validated; wiki files pass prettier.
- **Pending (needs a device/emulator — sandbox couldn't run Gradle):**
  ```
  adb shell am start -a android.intent.action.VIEW -d "com.super-productivity.app://create-task?title=test"
  ```
  cold start, warm start, then Back → reopen from recents (must NOT create a duplicate); same for `complete-task` (no spurious snack on reopen).

Note: branch is based on `4e1d663822` ("fix(ci): defer windows store config until packaging"), which is not yet on `origin/master`, so it appears in this PR's commit list.

https://claude.ai/code/session_01GKo5idA19rzFWrueNcBgwK