### PR TITLE
fix(task-repeat): stop reminders from blocking skipOverdue cleanup

### DIFF
--- a/docs/wiki/4.13-Repeating-Tasks.md
+++ b/docs/wiki/4.13-Repeating-Tasks.md
@@ -104,7 +104,7 @@ This option works independently from "Repeat from completion date" (which re-anc
 
 ## Don't Let Overdue Instances Pile Up Option
 
-When you enable **"Don't let overdue instances pile up"** on a repeating task, missed occurrences don't accumulate as a stack of duplicate overdue tasks—you keep a single, up-to-date instance instead. An empty missed instance is removed once a newer one exists; any instance where you tracked time, completed subtasks, or made edits is always kept.
+When you enable **"Don't let overdue instances pile up"** on a repeating task, missed occurrences don't accumulate as a stack of duplicate overdue tasks—you keep a single, up-to-date instance instead. An empty missed instance is removed once a newer one exists; any instance where you tracked time, completed subtasks, or edited the task itself (title, notes, estimate, tags, or the scheduled time) is always kept. Reminders are not counted as an edit—a reminder that has fired, been dismissed, or been snoozed still leaves the instance eligible for cleanup, since the app rewrites that field on its own.
 
 ### Default Behavior
 

--- a/docs/wiki/4.13-Repeating-Tasks.md
+++ b/docs/wiki/4.13-Repeating-Tasks.md
@@ -104,7 +104,7 @@ This option works independently from "Repeat from completion date" (which re-anc
 
 ## Don't Let Overdue Instances Pile Up Option
 
-When you enable **"Don't let overdue instances pile up"** on a repeating task, missed occurrences don't accumulate as a stack of duplicate overdue tasks—you keep a single, up-to-date instance instead. An empty missed instance is removed once a newer one exists; any instance where you tracked time, completed subtasks, or edited the task itself (title, notes, estimate, tags, or the scheduled time) is always kept. Reminders are not counted as an edit—a reminder that has fired, been dismissed, or been snoozed still leaves the instance eligible for cleanup, since the app rewrites that field on its own.
+When you enable **"Don't let overdue instances pile up"** on a repeating task, missed occurrences don't accumulate as a stack of duplicate overdue tasks—you keep a single, up-to-date instance instead. An empty missed instance is removed once a newer one exists; any instance where you tracked time, completed subtasks, or edited the task itself (title, notes, estimate, tags, attachments, deadline, project, sub-tasks, or the scheduled time) is always kept. Reminders are not counted as an edit—a reminder that has fired, been dismissed, or been snoozed still leaves the instance eligible for cleanup, since the app rewrites that field on its own. Snoozing an overdue instance therefore does not preserve it: the snoozed reminder goes away with the instance, and the current instance carries the task forward.
 
 ### Default Behavior
 

--- a/e2e/tests/recurring/skip-overdue-reaps-timed-instance.spec.ts
+++ b/e2e/tests/recurring/skip-overdue-reaps-timed-instance.spec.ts
@@ -1,0 +1,277 @@
+import { expect, test } from '../../fixtures/test.fixture';
+import { type Page } from '@playwright/test';
+import type { WorkViewPage } from '../../pages/work-view.page';
+import type { TaskPage } from '../../pages/task.page';
+import {
+  openRecurDialog,
+  openRecurScheduleDialog,
+  saveRecurDialog,
+} from '../../utils/recurring-task-helpers';
+
+/**
+ * skipOverdue ("Don't let overdue instances pile up") for a TIMED daily repeat,
+ * end to end.
+ *
+ * Why this needs an e2e: the unit specs for TaskRepeatCleanupEffects mock the
+ * effect's whole gating chain and hand-build the task objects, so nothing
+ * asserts that an instance produced by the REAL creation path
+ * (TaskRepeatCfgService -> scheduleTaskWithTime) is recognised as unmodified by
+ * the reaper's template comparison. _hasTemplateSchedule reconstructs
+ * getDateTimeFromClockString(cfg.startTime, dateStrToUtcDate(dueStr)) and
+ * assumes it equals what creation produced; if either side drifts, both unit
+ * suites stay green while skipOverdue silently stops working — which is exactly
+ * the bug that shipped.
+ *
+ * Strategy mirrors repeat-timed-cold-reopen-day-change.spec.ts: a MOVING clock
+ * via page.clock.setSystemTime (a frozen setFixedTime would wedge the create
+ * effect's debounceTime(1000)), Day X and Day X+1 both booting at 09:00 so the
+ * 13:00 instance is created scheduled-in-the-future.
+ *
+ * The reminder then really fires: page.clock does not reach into the reminder
+ * Worker, so the worker compares the instance's remindAt against the REAL clock
+ * and always finds the (fixed, long past) Day X reminder overdue. That gives
+ * the tests the genuine reminder dialog to act on — snoozing rewrites remindAt,
+ * starting the task clears it — which is precisely the app-managed drift that
+ * used to make a timed instance unreapable forever.
+ */
+
+const DAY_X = '2026-06-15T09:00:00';
+const DAY_X_PLUS_1 = '2026-06-16T09:05:00';
+const START_TIME = '13:00';
+const REMINDER_DIALOG = 'dialog-view-task-reminder';
+
+interface RepeatInstances {
+  /** Active (not done, not sub-task) instances of the repeat config. */
+  count: number;
+  /** Precondition: the Daily preset must have defaulted skipOverdue to ON. */
+  skipOverdue: boolean | null;
+  totalTimeSpent: number;
+  /** remindAt of every active instance, to prove the reminder really drifted. */
+  remindAts: (number | null)[];
+  /** Local due day (YYYY-MM-DD) of every active instance. */
+  dueDays: (string | null)[];
+}
+
+/** Read instance state straight from the NgRx store (see skip-overdue-default-8644). */
+const readInstances = async (page: Page, title: string): Promise<RepeatInstances> =>
+  page.evaluate((taskTitle: string) => {
+    type TaskLike = {
+      title?: string;
+      isDone?: boolean;
+      parentId?: string | null;
+      repeatCfgId?: string | null;
+      timeSpent?: number;
+      remindAt?: number;
+      dueWithTime?: number;
+      dueDay?: string;
+    };
+    type CfgLike = { id?: string; title?: string | null; skipOverdue?: boolean };
+    type StoreState = {
+      tasks?: { entities?: Record<string, TaskLike | undefined> };
+      taskRepeatCfg?: { entities?: Record<string, CfgLike | undefined> };
+    };
+    type StoreLike = {
+      subscribe: (next: (s: StoreState) => void) => { unsubscribe: () => void };
+    };
+    const store = (window as unknown as { __e2eTestHelpers?: { store?: StoreLike } })
+      .__e2eTestHelpers?.store;
+    if (!store) {
+      throw new Error('__e2eTestHelpers.store missing');
+    }
+    let latest: StoreState | undefined;
+    store
+      .subscribe((s) => {
+        latest = s;
+      })
+      .unsubscribe();
+
+    const cfg = Object.values(latest?.taskRepeatCfg?.entities ?? {}).find((c) =>
+      c?.title?.includes(taskTitle),
+    );
+    const instances = Object.values(latest?.tasks?.entities ?? {}).filter(
+      (t): t is TaskLike =>
+        !!t && !t.parentId && !t.isDone && !!cfg?.id && t.repeatCfgId === cfg.id,
+    );
+    return {
+      count: instances.length,
+      skipOverdue: cfg ? (cfg.skipOverdue ?? null) : null,
+      totalTimeSpent: instances.reduce((acc, t) => acc + (t.timeSpent ?? 0), 0),
+      remindAts: instances.map((t) => t.remindAt ?? null),
+      dueDays: instances.map((t) => {
+        if (typeof t.dueWithTime === 'number') {
+          const d = new Date(t.dueWithTime);
+          const pad = (n: number): string => `${n}`.padStart(2, '0');
+          return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+        }
+        return t.dueDay ?? null;
+      }),
+    };
+  }, title);
+
+/**
+ * Boot on Day X and create `title` as a TIMED daily repeat (13:00). Leaves the
+ * Day X instance in place: scheduled, empty, and about to become overdue.
+ */
+const createTimedDailyRepeat = async (
+  page: Page,
+  workViewPage: WorkViewPage,
+  taskPage: TaskPage,
+  title: string,
+): Promise<void> => {
+  await page.clock.setSystemTime(new Date(DAY_X));
+  await page.reload();
+  await workViewPage.waitForTaskList();
+
+  await workViewPage.addTask(title);
+  const task = taskPage.getTaskByText(title).first();
+  await expect(task).toBeVisible({ timeout: 10000 });
+
+  await taskPage.openTaskDetail(task);
+  await openRecurDialog(page);
+
+  // Timed daily: setting a start time makes remindAt default to AtStart.
+  const scheduleDialog = await openRecurScheduleDialog(page);
+  const startTimeField = scheduleDialog.getByLabel('Time');
+  await expect(startTimeField).toBeVisible({ timeout: 5000 });
+  await startTimeField.fill(START_TIME);
+  await startTimeField.blur();
+  await scheduleDialog.locator('[data-test-id="schedule-submit-btn"]').click();
+  await scheduleDialog.waitFor({ state: 'hidden', timeout: 5000 });
+
+  // Save the (default DAILY) repeat config — skipOverdue defaults ON for it.
+  await saveRecurDialog(page);
+  await page.keyboard.press('Escape');
+
+  await expect(taskPage.getUndoneTasks().filter({ hasText: title }).first()).toBeVisible({
+    timeout: 10000,
+  });
+};
+
+/** The reminder worker runs on the real clock, so the Day X reminder always fires. */
+const waitForReminderDialog = async (page: Page): Promise<void> => {
+  await page
+    .locator(REMINDER_DIALOG)
+    .first()
+    .waitFor({ state: 'visible', timeout: 60000 });
+};
+
+test.describe('Recurring task - skipOverdue reaps a timed overdue instance', () => {
+  test('deletes the empty Day X instance after a cold reopen on Day X+1', async ({
+    page,
+    workViewPage,
+    taskPage,
+    testPrefix,
+  }) => {
+    const taskTitle = `${testPrefix}-SkipOverdueTimed`;
+    await workViewPage.waitForTaskList();
+    await createTimedDailyRepeat(page, workViewPage, taskPage, taskTitle);
+
+    await expect
+      .poll(async () => (await readInstances(page, taskTitle)).skipOverdue, {
+        timeout: 10000,
+      })
+      .toBe(true);
+
+    // Snooze the fired reminder: reScheduleTaskWithTime rewrites remindAt and
+    // keeps dueWithTime, leaving the instance app-modified but user-untouched.
+    await waitForReminderDialog(page);
+    await page.locator(`${REMINDER_DIALOG} .split-btn-main`).first().click();
+    await page
+      .locator(REMINDER_DIALOG)
+      .first()
+      .waitFor({ state: 'hidden', timeout: 10000 });
+
+    // The snooze must really have moved remindAt off the template value
+    // (13:00 on Day X) — otherwise this test would pass with the pre-fix
+    // comparison in place and prove nothing.
+    const templateRemindAt = new Date(`${DAY_X.slice(0, 10)}T${START_TIME}:00`).getTime();
+    await expect
+      .poll(async () => (await readInstances(page, taskTitle)).remindAts, {
+        timeout: 10000,
+      })
+      .not.toContain(templateRemindAt);
+
+    // Let the ops flush to IndexedDB before the cold reopen.
+    await page.waitForTimeout(1500);
+
+    // Day X+1, cold reopen. Creation runs (1s debounce), then the reaper (3s).
+    await page.clock.setSystemTime(new Date(DAY_X_PLUS_1));
+    await page.reload();
+    await workViewPage.waitForTaskList();
+    await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+
+    // Day X+1's instance is created...
+    await expect
+      .poll(async () => (await readInstances(page, taskTitle)).dueDays, {
+        timeout: 60000,
+      })
+      .toContain(DAY_X_PLUS_1.slice(0, 10));
+
+    // ...and the snoozed-but-empty Day X instance is reaped, leaving only it.
+    await expect
+      .poll(async () => (await readInstances(page, taskTitle)).dueDays, {
+        timeout: 30000,
+      })
+      .toEqual([DAY_X_PLUS_1.slice(0, 10)]);
+  });
+
+  test('keeps the Day X instance when time was tracked on it', async ({
+    page,
+    workViewPage,
+    taskPage,
+    testPrefix,
+  }) => {
+    const taskTitle = `${testPrefix}-SkipOverdueTracked`;
+    await workViewPage.waitForTaskList();
+    await createTimedDailyRepeat(page, workViewPage, taskPage, taskTitle);
+
+    // "Start" from the reminder dialog clears remindAt (dismissReminderOnly)
+    // AND starts tracking — the same app-managed drift as above, but now on an
+    // instance carrying real work.
+    await waitForReminderDialog(page);
+    await page
+      .locator(REMINDER_DIALOG)
+      .first()
+      .getByRole('button', { name: /Start/i })
+      .click();
+    await page
+      .locator(REMINDER_DIALOG)
+      .first()
+      .waitFor({ state: 'hidden', timeout: 10000 });
+
+    await expect
+      .poll(async () => (await readInstances(page, taskTitle)).totalTimeSpent, {
+        timeout: 30000,
+      })
+      .toBeGreaterThan(0);
+
+    // Stop the tracker. Tracked time lives in an in-memory accumulator that is
+    // only committed on a 5-minute interval or when the current task changes,
+    // so without this the time never reaches the store and the reload starts
+    // from zero.
+    await page.locator('play-button .play-btn').first().click();
+    await page.waitForTimeout(1500);
+
+    await page.clock.setSystemTime(new Date(DAY_X_PLUS_1));
+    await page.reload();
+    await workViewPage.waitForTaskList();
+    await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+
+    // Precondition for the assertion below: the tracked time survived the reload.
+    await expect
+      .poll(async () => (await readInstances(page, taskTitle)).totalTimeSpent, {
+        timeout: 30000,
+      })
+      .toBeGreaterThan(0);
+
+    // Both instances must be present: Day X+1's new one and the tracked Day X one.
+    await expect
+      .poll(async () => (await readInstances(page, taskTitle)).count, { timeout: 60000 })
+      .toBe(2);
+
+    // Hold past the reaper's 3s debounce. The sibling test proves the reaper
+    // fires under this exact timing, so this is not a vacuous pass.
+    await page.waitForTimeout(8000);
+    expect((await readInstances(page, taskTitle)).count).toBe(2);
+  });
+});

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.spec.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.spec.ts
@@ -403,6 +403,105 @@ describe('TaskRepeatCleanupEffects', () => {
       sub.unsubscribe();
     }));
 
+    it("deletes yesterday's timed overdue instance after its reminder fired and cleared remindAt", fakeAsync(() => {
+      const dueWithTime = getDateTimeFromClockString('09:00', yesterdayMs);
+      repeatCfgs$.next([
+        skipOverdueCfg('cfg-dismissed', '', {
+          title: 'Morgen Routine',
+          startTime: '09:00',
+          remindAt: TaskReminderOptionId.m15,
+        }),
+      ]);
+      // The reminder fired and was dismissed -> remindAt cleared on the instance.
+      const yesterdayInstance: Task = {
+        ...DEFAULT_TASK,
+        projectId: 'p1',
+        id: 'dismissed-yesterday',
+        title: 'Morgen Routine',
+        repeatCfgId: 'cfg-dismissed',
+        created: yesterdayMs,
+        dueDay: undefined,
+        dueWithTime,
+        remindAt: undefined,
+        isDone: false,
+        timeSpent: 0,
+      };
+      const todayInstance: Task = {
+        ...DEFAULT_TASK,
+        projectId: 'p1',
+        id: 'dismissed-today',
+        title: 'Morgen Routine',
+        repeatCfgId: 'cfg-dismissed',
+        created: todayMs,
+        dueDay: getDbDateStr(todayMs),
+        isDone: false,
+        timeSpent: 0,
+      };
+
+      repeatableTasks$.next([
+        wrapWithSubTasks(yesterdayInstance),
+        wrapWithSubTasks(todayInstance),
+      ]);
+
+      const sub = effects.cleanupDuplicateRepeatInstances$.subscribe();
+      tick(3001);
+
+      expect(getDispatchedDeleteIds()).toEqual(['dismissed-yesterday']);
+
+      sub.unsubscribe();
+    }));
+
+    it('deletes a weekly overdue instance whose reminder was snoozed to a new time', fakeAsync(() => {
+      const weekMs = 7 * DAY_MS;
+      const lastWeekMs = todayMs - weekMs;
+      const oneHourMs = 60 * 60 * 1000;
+      const dueWithTime = getDateTimeFromClockString('20:00', lastWeekMs);
+      repeatCfgs$.next([
+        skipOverdueCfg('cfg-snoozed', '', {
+          title: 'Export Bookmarks',
+          startTime: '20:00',
+          remindAt: TaskReminderOptionId.AtStart,
+        }),
+      ]);
+      const lastWeekInstance: Task = {
+        ...DEFAULT_TASK,
+        projectId: 'p1',
+        id: 'snoozed-last-week',
+        title: 'Export Bookmarks',
+        repeatCfgId: 'cfg-snoozed',
+        created: lastWeekMs,
+        dueDay: undefined,
+        dueWithTime,
+        // snoozed by 1h from the notification -> no longer the template value
+        remindAt: dueWithTime + oneHourMs,
+        isDone: false,
+        timeSpent: 0,
+      };
+      const todayInstance: Task = {
+        ...DEFAULT_TASK,
+        projectId: 'p1',
+        id: 'snoozed-today',
+        title: 'Export Bookmarks',
+        repeatCfgId: 'cfg-snoozed',
+        created: todayMs,
+        dueDay: getDbDateStr(todayMs),
+        isDone: false,
+        timeSpent: 0,
+      };
+
+      repeatableTasks$.next([
+        wrapWithSubTasks(lastWeekInstance),
+        wrapWithSubTasks(todayInstance),
+      ]);
+
+      const sub = effects.cleanupDuplicateRepeatInstances$.subscribe();
+      tick(3001);
+
+      expect(getDispatchedDeleteIds()).toEqual(['snoozed-last-week']);
+
+      sub.unsubscribe();
+    }));
+
     it('keeps an overdue instance whose schedule differs from the template', fakeAsync(() => {
       const editedDueWithTime = getDateTimeFromClockString('10:00', yesterdayMs);
       repeatCfgs$.next([

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.spec.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.spec.ts
@@ -403,101 +403,66 @@ describe('TaskRepeatCleanupEffects', () => {
       sub.unsubscribe();
     }));
 
-    it("deletes yesterday's timed overdue instance after its reminder fired and cleared remindAt", fakeAsync(() => {
-      const dueWithTime = getDateTimeFromClockString('09:00', yesterdayMs);
-      repeatCfgs$.next([
-        skipOverdueCfg('cfg-dismissed', '', {
-          title: 'Morgen Routine',
-          startTime: '09:00',
-          remindAt: TaskReminderOptionId.m15,
-        }),
-      ]);
-      // The reminder fired and was dismissed -> remindAt cleared on the instance.
-      const yesterdayInstance: Task = {
-        ...DEFAULT_TASK,
-        projectId: 'p1',
-        id: 'dismissed-yesterday',
-        title: 'Morgen Routine',
-        repeatCfgId: 'cfg-dismissed',
-        created: yesterdayMs,
-        dueDay: undefined,
-        dueWithTime,
-        remindAt: undefined,
-        isDone: false,
-        timeSpent: 0,
-      };
-      const todayInstance: Task = {
-        ...DEFAULT_TASK,
-        projectId: 'p1',
-        id: 'dismissed-today',
-        title: 'Morgen Routine',
-        repeatCfgId: 'cfg-dismissed',
-        created: todayMs,
-        dueDay: getDbDateStr(todayMs),
-        isDone: false,
-        timeSpent: 0,
-      };
-
-      repeatableTasks$.next([
-        wrapWithSubTasks(yesterdayInstance),
-        wrapWithSubTasks(todayInstance),
-      ]);
-
-      const sub = effects.cleanupDuplicateRepeatInstances$.subscribe();
-      tick(3001);
-
-      expect(getDispatchedDeleteIds()).toEqual(['dismissed-yesterday']);
-
-      sub.unsubscribe();
-    }));
-
-    it('deletes a weekly overdue instance whose reminder was snoozed to a new time', fakeAsync(() => {
+    it('deletes timed overdue instances whose reminder was cleared or snoozed', fakeAsync(() => {
+      // remindAt is app-managed: firing + dismissing clears it, snoozing rewrites
+      // it to a new time. Neither is a user edit, so both must still be reaped.
       const weekMs = 7 * DAY_MS;
       const lastWeekMs = todayMs - weekMs;
       const oneHourMs = 60 * 60 * 1000;
-      const dueWithTime = getDateTimeFromClockString('20:00', lastWeekMs);
+      const yesterdayDue = getDateTimeFromClockString('20:00', yesterdayMs);
+      const lastWeekDue = getDateTimeFromClockString('20:00', lastWeekMs);
       repeatCfgs$.next([
-        skipOverdueCfg('cfg-snoozed', '', {
+        skipOverdueCfg('cfg-reminder', '', {
           title: 'Export Bookmarks',
           startTime: '20:00',
           remindAt: TaskReminderOptionId.AtStart,
         }),
       ]);
-      const lastWeekInstance: Task = {
+      const base = {
         ...DEFAULT_TASK,
         projectId: 'p1',
-        id: 'snoozed-last-week',
         title: 'Export Bookmarks',
-        repeatCfgId: 'cfg-snoozed',
-        created: lastWeekMs,
+        repeatCfgId: 'cfg-reminder',
         dueDay: undefined,
-        dueWithTime,
-        // snoozed by 1h from the notification -> no longer the template value
-        remindAt: dueWithTime + oneHourMs,
         isDone: false,
         timeSpent: 0,
       };
+      const dismissed: Task = {
+        ...base,
+        id: 'reminder-dismissed',
+        created: yesterdayMs,
+        dueWithTime: yesterdayDue,
+        // fired, then dismissed -> dismissReminderOnly cleared remindAt
+        remindAt: undefined,
+      };
+      const snoozed: Task = {
+        ...base,
+        id: 'reminder-snoozed',
+        created: lastWeekMs,
+        dueWithTime: lastWeekDue,
+        // snoozed 1h from the notification -> rewritten, dueWithTime untouched
+        remindAt: lastWeekDue + oneHourMs,
+      };
       const todayInstance: Task = {
-        ...DEFAULT_TASK,
-        projectId: 'p1',
-        id: 'snoozed-today',
-        title: 'Export Bookmarks',
-        repeatCfgId: 'cfg-snoozed',
+        ...base,
+        id: 'reminder-today',
         created: todayMs,
         dueDay: getDbDateStr(todayMs),
-        isDone: false,
-        timeSpent: 0,
       };
 
       repeatableTasks$.next([
-        wrapWithSubTasks(lastWeekInstance),
+        wrapWithSubTasks(dismissed),
+        wrapWithSubTasks(snoozed),
         wrapWithSubTasks(todayInstance),
       ]);
 
       const sub = effects.cleanupDuplicateRepeatInstances$.subscribe();
       tick(3001);
 
-      expect(getDispatchedDeleteIds()).toEqual(['snoozed-last-week']);
+      expect(getDispatchedDeleteIds().sort()).toEqual([
+        'reminder-dismissed',
+        'reminder-snoozed',
+      ]);
 
       sub.unsubscribe();
     }));

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.spec.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.spec.ts
@@ -408,9 +408,11 @@ describe('TaskRepeatCleanupEffects', () => {
       // it to a new time. Neither is a user edit, so both must still be reaped.
       const weekMs = 7 * DAY_MS;
       const lastWeekMs = todayMs - weekMs;
+      const twoDaysAgoMs = yesterdayMs - DAY_MS;
       const oneHourMs = 60 * 60 * 1000;
       const yesterdayDue = getDateTimeFromClockString('20:00', yesterdayMs);
       const lastWeekDue = getDateTimeFromClockString('20:00', lastWeekMs);
+      const twoDaysAgoDue = getDateTimeFromClockString('20:00', twoDaysAgoMs);
       repeatCfgs$.next([
         skipOverdueCfg('cfg-reminder', '', {
           title: 'Export Bookmarks',
@@ -443,6 +445,16 @@ describe('TaskRepeatCleanupEffects', () => {
         // snoozed 1h from the notification -> rewritten, dueWithTime untouched
         remindAt: lastWeekDue + oneHourMs,
       };
+      const snoozedActive: Task = {
+        ...base,
+        id: 'reminder-snoozed-active',
+        created: twoDaysAgoMs,
+        dueWithTime: twoDaysAgoDue,
+        // snoozed into the FUTURE and not fired again yet. Still reaped: making
+        // the verdict depend on Date.now() would make it depend on when the
+        // reaper runs.
+        remindAt: todayMs + oneHourMs,
+      };
       const todayInstance: Task = {
         ...base,
         id: 'reminder-today',
@@ -453,6 +465,7 @@ describe('TaskRepeatCleanupEffects', () => {
       repeatableTasks$.next([
         wrapWithSubTasks(dismissed),
         wrapWithSubTasks(snoozed),
+        wrapWithSubTasks(snoozedActive),
         wrapWithSubTasks(todayInstance),
       ]);
 
@@ -462,7 +475,62 @@ describe('TaskRepeatCleanupEffects', () => {
       expect(getDispatchedDeleteIds().sort()).toEqual([
         'reminder-dismissed',
         'reminder-snoozed',
+        'reminder-snoozed-active',
       ]);
+
+      sub.unsubscribe();
+    }));
+
+    it('keeps a day-planned overdue instance that carries a reminder', fakeAsync(() => {
+      // No in-app path sets remindAt without a dueWithTime, so a day-planned
+      // instance that has one was marked deliberately via PluginAPI.updateTask.
+      // Covers both branches that still compare it: the timed config's
+      // "scheduled action not run yet" shape, and the untimed config.
+      repeatCfgs$.next([
+        skipOverdueCfg('cfg-timed-plugin', '', {
+          title: 'Timed Plugin Reminder',
+          startTime: '20:00',
+          remindAt: TaskReminderOptionId.AtStart,
+        }),
+        skipOverdueCfg('cfg-untimed-plugin', '', { title: 'Untimed Plugin Reminder' }),
+      ]);
+      const base = {
+        ...DEFAULT_TASK,
+        projectId: 'p1',
+        isDone: false,
+        timeSpent: 0,
+      };
+      const mkPair = (cfgId: string, title: string): Task[] => [
+        {
+          ...base,
+          id: `${cfgId}-yesterday`,
+          title,
+          repeatCfgId: cfgId,
+          created: yesterdayMs,
+          dueDay: getDbDateStr(yesterdayMs),
+          remindAt: getDateTimeFromClockString('20:00', yesterdayMs),
+        },
+        {
+          ...base,
+          id: `${cfgId}-today`,
+          title,
+          repeatCfgId: cfgId,
+          created: todayMs,
+          dueDay: getDbDateStr(todayMs),
+        },
+      ];
+
+      repeatableTasks$.next(
+        [
+          ...mkPair('cfg-timed-plugin', 'Timed Plugin Reminder'),
+          ...mkPair('cfg-untimed-plugin', 'Untimed Plugin Reminder'),
+        ].map(wrapWithSubTasks),
+      );
+
+      const sub = effects.cleanupDuplicateRepeatInstances$.subscribe();
+      tick(3001);
+
+      expect(getDispatchedDeleteIds()).toEqual([]);
 
       sub.unsubscribe();
     }));

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.ts
@@ -46,32 +46,34 @@ const _hasTemplateSchedule = (
   cfg: TaskRepeatCfg,
   dueStr: string,
 ): boolean => {
-  // remindAt is deliberately NOT compared, on any branch below: it is
-  // app-managed, not a user edit. Dismissing a fired reminder clears it
-  // (dismissReminderOnly — also dispatched when the reminder's task is started
-  // or "Do not remind" is picked) and snoozing rewrites it
-  // (reScheduleTaskWithTime, which keeps dueWithTime). So any instance whose
-  // reminder was dismissed, started or snoozed became permanently unreapable
-  // and skipOverdue silently piled up one leftover per occurrence.
-  // A still-pending (future) remindAt is treated the same way on purpose:
-  // keying deletion off Date.now() would let two devices disagree about what is
-  // reapable. Untimed instances cannot legitimately carry a remindAt at all
-  // (planTaskForDay clears it), so dropping the check there only ever affects
-  // legacy/imported data. The day itself is still compared below.
   if (isValidSplitTime(cfg.startTime)) {
     const expectedDueWithTime = getDateTimeFromClockString(
       cfg.startTime,
       dateStrToUtcDate(dueStr),
     );
+    // remindAt is deliberately NOT compared for a TIMED instance: there it is
+    // app-managed, not a user edit. Dismissing a fired reminder clears it
+    // (dismissReminderOnly — also dispatched when the reminder's task is
+    // started or "Do not remind" is picked) and snoozing rewrites it
+    // (reScheduleTaskWithTime, which keeps dueWithTime). So any instance whose
+    // reminder was dismissed, started or snoozed became permanently unreapable
+    // and skipOverdue silently piled up one leftover per occurrence. A
+    // still-pending (future) remindAt is treated the same way on purpose:
+    // keying deletion off Date.now() would make the verdict depend on when the
+    // reaper happens to run. The scheduled time itself is still compared.
     const isScheduledTemplate =
       task.dueWithTime === expectedDueWithTime && _isNil(task.dueDay);
+    // Day-planned instances keep the remindAt check: no in-app path sets a
+    // reminder without a dueWithTime (planTaskForDay and unscheduleTask both
+    // clear it), so one that is set came from PluginAPI.updateTask and is a
+    // deliberate mark on this instance.
     const isBeforeScheduleActionTemplate =
-      _isNil(task.dueWithTime) && task.dueDay === dueStr;
+      _isNil(task.dueWithTime) && task.dueDay === dueStr && _isNil(task.remindAt);
 
     return isScheduledTemplate || isBeforeScheduleActionTemplate;
   }
 
-  return _isNil(task.dueWithTime) && task.dueDay === dueStr;
+  return _isNil(task.dueWithTime) && task.dueDay === dueStr && _isNil(task.remindAt);
 };
 
 const _hasTemplateSubTasks = (task: TaskWithSubTasks, cfg: TaskRepeatCfg): boolean => {

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.ts
@@ -46,12 +46,18 @@ const _hasTemplateSchedule = (
   cfg: TaskRepeatCfg,
   dueStr: string,
 ): boolean => {
-  // remindAt is deliberately NOT compared: it is app-managed, not a user edit.
-  // Dismissing a fired reminder clears it (dismissReminderOnly) and snoozing
-  // rewrites it (reScheduleTaskWithTime, which keeps dueWithTime), so comparing
-  // it made every timed recurring instance permanently unreapable and let
-  // skipOverdue silently pile up one leftover per occurrence. The day itself is
-  // still compared below.
+  // remindAt is deliberately NOT compared, on any branch below: it is
+  // app-managed, not a user edit. Dismissing a fired reminder clears it
+  // (dismissReminderOnly — also dispatched when the reminder's task is started
+  // or "Do not remind" is picked) and snoozing rewrites it
+  // (reScheduleTaskWithTime, which keeps dueWithTime). So any instance whose
+  // reminder was dismissed, started or snoozed became permanently unreapable
+  // and skipOverdue silently piled up one leftover per occurrence.
+  // A still-pending (future) remindAt is treated the same way on purpose:
+  // keying deletion off Date.now() would let two devices disagree about what is
+  // reapable. Untimed instances cannot legitimately carry a remindAt at all
+  // (planTaskForDay clears it), so dropping the check there only ever affects
+  // legacy/imported data. The day itself is still compared below.
   if (isValidSplitTime(cfg.startTime)) {
     const expectedDueWithTime = getDateTimeFromClockString(
       cfg.startTime,

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.ts
@@ -47,10 +47,11 @@ const _hasTemplateSchedule = (
   dueStr: string,
 ): boolean => {
   // remindAt is deliberately NOT compared: it is app-managed, not a user edit.
-  // Firing, dismissing, snoozing or re-scheduling a reminder rewrites or clears
-  // it (dismissReminderOnly, mobile pre-scheduling), which made every timed
-  // recurring instance permanently unreapable and let skipOverdue silently pile
-  // up one leftover per occurrence. The day itself is still compared below.
+  // Dismissing a fired reminder clears it (dismissReminderOnly) and snoozing
+  // rewrites it (reScheduleTaskWithTime, which keeps dueWithTime), so comparing
+  // it made every timed recurring instance permanently unreapable and let
+  // skipOverdue silently pile up one leftover per occurrence. The day itself is
+  // still compared below.
   if (isValidSplitTime(cfg.startTime)) {
     const expectedDueWithTime = getDateTimeFromClockString(
       cfg.startTime,

--- a/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.ts
+++ b/src/app/features/task-repeat-cfg/store/task-repeat-cleanup.effects.ts
@@ -21,7 +21,6 @@ import { TODAY_TAG } from '../../tag/tag.const';
 import { isValidSplitTime } from '../../../util/is-valid-split-time';
 import { getDateTimeFromClockString } from '../../../util/get-date-time-from-clock-string';
 import { dateStrToUtcDate } from '../../../util/date-str-to-utc-date';
-import { remindOptionToMilliseconds } from '../../tasks/util/remind-option-to-milliseconds';
 import { TaskTimeSyncService } from '../../tasks/task-time-sync.service';
 
 const _sameStringSet = (a: readonly string[], b: readonly string[]): boolean => {
@@ -47,25 +46,25 @@ const _hasTemplateSchedule = (
   cfg: TaskRepeatCfg,
   dueStr: string,
 ): boolean => {
+  // remindAt is deliberately NOT compared: it is app-managed, not a user edit.
+  // Firing, dismissing, snoozing or re-scheduling a reminder rewrites or clears
+  // it (dismissReminderOnly, mobile pre-scheduling), which made every timed
+  // recurring instance permanently unreapable and let skipOverdue silently pile
+  // up one leftover per occurrence. The day itself is still compared below.
   if (isValidSplitTime(cfg.startTime)) {
     const expectedDueWithTime = getDateTimeFromClockString(
       cfg.startTime,
       dateStrToUtcDate(dueStr),
     );
-    const expectedRemindAt = cfg.remindAt
-      ? remindOptionToMilliseconds(expectedDueWithTime, cfg.remindAt)
-      : undefined;
     const isScheduledTemplate =
-      task.dueWithTime === expectedDueWithTime &&
-      _isNil(task.dueDay) &&
-      task.remindAt === expectedRemindAt;
+      task.dueWithTime === expectedDueWithTime && _isNil(task.dueDay);
     const isBeforeScheduleActionTemplate =
-      _isNil(task.dueWithTime) && task.dueDay === dueStr && _isNil(task.remindAt);
+      _isNil(task.dueWithTime) && task.dueDay === dueStr;
 
     return isScheduledTemplate || isBeforeScheduleActionTemplate;
   }
 
-  return _isNil(task.dueWithTime) && task.dueDay === dueStr && _isNil(task.remindAt);
+  return _isNil(task.dueWithTime) && task.dueDay === dueStr;
 };
 
 const _hasTemplateSubTasks = (task: TaskWithSubTasks, cfg: TaskRepeatCfg): boolean => {


### PR DESCRIPTION
Fixes the timed half of #7977: with "Don't let overdue instances pile up" enabled, a timed recurring task's overdue instances were never reaped.

## The bug

The skipOverdue reaper treats an instance as "user-modified" — and therefore keeps it — when it differs from the repeat template. `_hasTemplateSchedule` compared `remindAt` against `remindOptionToMilliseconds(expectedDueWithTime, cfg.remindAt)`.

But on a timed instance `remindAt` is app-managed, not a user edit:

- **Dismissing** a fired reminder clears it — `dismissReminderOnly`, which is also dispatched when the reminder's task is **started** (`reminder-countdown.effects.ts` `_startTask`, the dialog's `play()`), when the due task is already the current task (`reminder.module.ts`), and when **"Do not remind"** is picked in the schedule dialog.
- **Snoozing** rewrites it — `reScheduleTaskWithTime`, which passes `dueWithTime` through unchanged.

So any instance whose reminder the user actually acted on became permanently unreapable, and skipOverdue silently accumulated one leftover per occurrence.

## The fix

`remindAt` is no longer compared **on the timed branch only**. The scheduled time itself (`dueWithTime` vs. the template) is still compared, as are `isDone`, `timeSpent`, subtask progress, title, notes, estimate, tags, attachments, project, deadline fields and the subtask templates — so an instance carrying real work or a real edit is still preserved.

The day-planned branches keep `_isNil(task.remindAt)` (unchanged from master). No in-app path sets a reminder without a `dueWithTime`: `planTaskForDay` and `unscheduleTask` both clear it, and the legacy reminder migration always sets `dueWithTime` when it sets `remindAt`. That leaves `PluginAPI.updateTask` as the only reacher, and a reminder only a plugin could have set is a deliberate mark on that instance.

A still-pending (future) `remindAt` is treated the same way on purpose: keying deletion off `Date.now()` would make the verdict depend on when the reaper happens to run, so two devices could disagree about what is reapable.

## Tests

- **Unit** (`task-repeat-cleanup.effects.spec.ts`): a dismissed (cleared), a snoozed (rewritten) and a live future-snoozed timed overdue instance are all reaped; a day-planned overdue instance carrying a reminder is kept, under both a timed and an untimed config. The first spec fails without the fix.
- **E2E** (`skip-overdue-reaps-timed-instance.spec.ts`): the unit specs mock the effect's whole gating chain and hand-build the tasks, so nothing asserted that an instance from the **real** creation path is recognised as unmodified by the reaper's template comparison — if the two sides ever drift, both unit suites stay green while skipOverdue stops working. Two tests over a cold reopen across a day boundary: the empty Day X instance is reaped once Day X+1's exists, and one with tracked time survives. The reminder genuinely fires (`page.clock` does not reach the reminder Worker, so it compares against the real clock), so the drift comes from the real dialog — snooze rewrites `remindAt`, Start clears it. Verified failing on master.

## Behavior change worth calling out

Changing only the reminder *offset* on a timed instance (same scheduled time, different "remind me" option) no longer protects it from cleanup. Changing the scheduled time still does. `docs/wiki/4.13-Repeating-Tasks.md` is updated to state this, including the consequence that snoozing an overdue instance does not preserve it — the snoozed reminder goes away with the instance and the current instance carries the task forward.

## Verification

- `npm test` — 14478 passing
- `npm run e2e:file tests/recurring/skip-overdue-reaps-timed-instance.spec.ts` — 2 passed; both fail on master
- `skip-overdue-default-8644`, `repeat-timed-cold-reopen-day-change`, `recurring-skip-and-remove-persistence` — 5 passed
- `npm run checkFile` clean on both changed `.ts` files

https://claude.ai/code/session_01Ehjhp1L4MmWWgMGHTn6jPF
