### PR TITLE
test(android): run instrumented tests on a minified build and fix the R8 crash they expose

### DIFF
--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -126,7 +126,12 @@ jobs:
           target: google_apis
           arch: x86_64
           working-directory: ./android
-          script: ./gradlew :app:connectedPlayDebugAndroidTest
+          # r8Test, not debug: build.gradle sets `testBuildType "r8Test"` so the
+          # instrumented suite runs against a minified, release-configured APK.
+          # Nothing else in CI exercises R8, and #9785 was a crash that only
+          # exists after minification. play, not fdroid: play is the flavor that
+          # ships to the Play internal track on every master push.
+          script: ./gradlew :app:connectedPlayR8TestAndroidTest
 
       - name: Upload instrumentation test results on failure
         if: failure() && steps.changes.outputs.android == 'true'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -84,7 +84,24 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
+        r8Test {
+            // Keep a permanently minified release-like target for instrumentation tests.
+            // Release minification was disabled after #9784, but without exercising R8 in
+            // CI the same class of runtime-only failure could return when it is re-enabled.
+            initWith release
+            signingConfig signingConfigs.debug
+            minifyEnabled true
+            shrinkResources true
+            setProguardFiles([
+                    getDefaultProguardFile("proguard-android-optimize.txt"),
+                    "proguard-rules.pro",
+            ])
+            testProguardFiles "proguard-rules.pro"
+            matchingFallbacks = ["release"]
+        }
     }
+
+    testBuildType "r8Test"
 
     flavorDimensions "version"
     productFlavors {

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,14 +1,15 @@
 # R8 rules for the release build.
 #
-# INERT RIGHT NOW: release builds run with minifyEnabled false (see build.gradle
-# for why — enabling it shipped a startup crash to the Play internal track). This
-# file is kept staged for re-enabling minification ahead of Google Play's
-# February 2027 DEX shrinking/obfuscation requirement.
+# Release builds still run with minifyEnabled false (see build.gradle for why —
+# enabling it shipped a startup crash to the Play internal track), so these rules
+# do not affect anything that ships today. They are NOT inert, though: the
+# r8Test build type is minified and is what instrumentation tests run against, so
+# every rule here is exercised on every Android PR.
 #
-# It is NOT known to be sufficient: it was only ever validated by grepping
-# mapping.txt, never by starting a minified build. Treat the rules below as a
-# starting point, and re-land minification only behind CI that actually launches
-# the minified APK.
+# That is also the only validation they have. Treat them as a starting point for
+# the re-land ahead of Google Play's February 2027 DEX shrinking/obfuscation
+# requirement, and re-land minification only once CI launches the shipped
+# variant, not just the test one.
 #
 # Everything R8 cannot see statically has to be kept here — reflection and the
 # WebView bridge both look like dead code to it.
@@ -34,6 +35,36 @@
 # permits shrinking, so R8 would drop it. Same silent failure as above.
 -keep class * extends androidx.work.ListenableWorker {
     public <init>(android.content.Context, androidx.work.WorkerParameters);
+}
+
+# --- Capacitor plugin permissions -------------------------------------------
+# Load-bearing, and the cause of #9785 / #9793: nothing in the program ever
+# constructs a @CapacitorPlugin — annotation instances are runtime-generated
+# proxies — so R8 concludes PluginHandle.pluginAnnotation can only ever hold
+# null. It deletes the field and constant-folds every read, which compiles
+# Plugin.getPermissionStates(), requestPermissions(), requestPermissionForAliases()
+# and pluginRequestAllPermissions() down to a literal `throw null`. On device the
+# first JS call that touched permissions (LocalNotifications.checkPermissions)
+# killed the process ~3s after launch.
+#
+# Not fixed by keeping the annotation: dexdump confirms @CapacitorPlugin survives
+# intact on the plugin classes. Not caused by R8 full mode either — compat mode
+# (android.enableR8.fullMode=false) emits the same `throw null`. Keeping the
+# field's owner is what stops the fold.
+#
+# Capacitor's own consumer rules keep the plugin classes but say nothing about
+# PluginHandle, so this has to live here.
+# Enforced by CapacitorLifecycleBridgeInstrumentedTest on the r8Test variant.
+-keep class com.getcapacitor.PluginHandle { *; }
+
+# --- Instrumented-test seams ------------------------------------------------
+# `testBuildType "r8Test"` runs the instrumented suite against a minified APK,
+# so an app member that only androidTest sources call is unreachable as far as
+# R8 is concerned: it gets shrunk out of the app APK and the test dies on
+# NoSuchMethodError. Any future test-only seam needs a line here — check
+# build/outputs/mapping/<variant>/usage.txt if a test suddenly cannot find one.
+-keepclassmembers class com.superproductivity.superproductivity.service.BackgroundSyncCredentialStore {
+    public void forgetCachedPrefsForTest();
 }
 
 # --- Tink (via androidx.security-crypto) ------------------------------------

--- a/android/app/src/androidTest/java/com/superproductivity/superproductivity/CapacitorLifecycleBridgeInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/superproductivity/superproductivity/CapacitorLifecycleBridgeInstrumentedTest.kt
@@ -1,5 +1,6 @@
 package com.superproductivity.superproductivity
 
+import android.content.Context
 import android.os.SystemClock
 import android.webkit.WebView
 import androidx.lifecycle.Lifecycle
@@ -7,7 +8,11 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.runner.AndroidJUnit4
 import com.capacitorjs.plugins.app.AppPlugin
+import com.getcapacitor.Plugin
+import com.getcapacitor.annotation.CapacitorPlugin
 import com.superproductivity.plugins.webdavhttp.WebDavHttpPlugin
+import com.superproductivity.superproductivity.plugins.NavigationBarPlugin
+import com.superproductivity.superproductivity.plugins.SafBridgePlugin
 import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -23,22 +28,108 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
  * Native smoke for the Capacitor shell.
  *
- * The test serves controlled HTML through Capacitor's real local server so the
- * production JavaScript injection, plugin bridge, activity lifecycle, and
- * WebDavHttp transport all participate. It deliberately stops at that native
- * boundary; configured-provider background sync is covered separately by #9152.
+ * Two angles, both on the minified r8Test variant. [everyRegisteredPluginResolvesItsPermissionStates]
+ * checks natively that every plugin the app registers survives R8 intact.
+ * [capacitorPluginsSurviveMinificationAndBackgroundResume] serves controlled
+ * HTML through Capacitor's real local server so the production JavaScript
+ * injection, plugin bridge, activity lifecycle and WebDavHttp transport all
+ * participate. Both stop at the native boundary; configured-provider background
+ * sync is covered separately by #9152.
  */
 @RunWith(AndroidJUnit4::class)
 class CapacitorLifecycleBridgeInstrumentedTest {
 
+    /**
+     * The suite claims to cover minification, so refuse to report green from an
+     * unminified variant. Without this, changing `testBuildType` in build.gradle
+     * would silently disarm every assertion below.
+     */
+    @Before
+    fun requireMinifiedVariant() {
+        assertEquals(
+            "These tests only mean anything on the minified r8Test variant",
+            "r8Test",
+            BuildConfig.BUILD_TYPE,
+        )
+    }
+
+    /**
+     * Every registered Capacitor plugin must resolve its permission state.
+     *
+     * Regression for #9785/#9793. R8 sees nothing in the program constructing a
+     * `@CapacitorPlugin` — annotation instances are runtime-generated proxies —
+     * so it concludes `PluginHandle.pluginAnnotation` can only hold null, drops
+     * the field and folds every read, compiling `Plugin.getPermissionStates()`
+     * down to a literal `throw null`. On device that killed the process on the
+     * first JS call touching permissions. Fails without the PluginHandle keep
+     * rule in proguard-rules.pro.
+     *
+     * Native and on the test thread on purpose: the same defect reached through
+     * JS lands on Capacitor's own handler thread, where it kills the process
+     * instead of failing a test. Here it names the plugin that broke.
+     */
     @Test
-    fun bridgeAndWebDavRequestSurviveBackgroundResume() {
+    fun everyRegisteredPluginResolvesItsPermissionStates() {
+        val scenario = ActivityScenario.launch(CapacitorMainActivity::class.java)
+        try {
+            scenario.onActivity { activity ->
+                val bridge = activity.bridge
+                registeredPluginClasses(activity).forEach { pluginClass ->
+                    val annotation = requireNotNull(
+                        pluginClass.getAnnotation(CapacitorPlugin::class.java),
+                    ) { "@CapacitorPlugin missing on ${pluginClass.name}" }
+                    val id = annotation.name.ifEmpty { pluginClass.simpleName }
+
+                    val handle = bridge.getPlugin(id)
+                    assertNotNull("Plugin '$id' is not registered on the bridge", handle)
+                    val instance = handle.instance
+                    assertNotNull("Plugin '$id' registered but never loaded", instance)
+                    // The assertion is that this does not throw: on a minified
+                    // build without the PluginHandle keep rule it is a literal
+                    // `throw null`. The map itself is never null.
+                    assertNotNull(
+                        "Plugin '$id' cannot resolve its permission states",
+                        instance.permissionStates,
+                    )
+                }
+            }
+        } finally {
+            scenario.close()
+        }
+    }
+
+    /**
+     * The plugins Capacitor loads from `capacitor.plugins.json` — the same asset
+     * it reads itself, so `npx cap update` keeps this current — plus the three
+     * registered by hand in [CapacitorMainActivity.onCreate], named as classes
+     * so removing one breaks the build rather than shrinking the coverage.
+     */
+    private fun registeredPluginClasses(context: Context): List<Class<out Plugin>> {
+        val registry = context.assets.open(CAPACITOR_PLUGINS_ASSET).use {
+            JSONTokener(it.readBytes().decodeToString()).nextValue() as JSONArray
+        }
+        val fromAssets = (0 until registry.length()).map { i ->
+            @Suppress("UNCHECKED_CAST")
+            Class.forName(registry.getJSONObject(i).getString("classpath")) as Class<out Plugin>
+        }
+        // Guards against a silently empty registry making the whole test vacuous.
+        assertTrue("$CAPACITOR_PLUGINS_ASSET listed no plugins", fromAssets.isNotEmpty())
+        return fromAssets + listOf(
+            SafBridgePlugin::class.java,
+            WebDavHttpPlugin::class.java,
+            NavigationBarPlugin::class.java,
+        )
+    }
+
+    @Test
+    fun capacitorPluginsSurviveMinificationAndBackgroundResume() {
         val responseGate = CountDownLatch(1)
         val requestStarted = CountDownLatch(1)
         val recordedRequest = AtomicReference<RecordedRequest>()
@@ -87,7 +178,12 @@ class CapacitorLifecycleBridgeInstrumentedTest {
             assertTrue(readyState.getBoolean("hasAndroidBridge"))
             assertTrue(readyState.getBoolean("hasSupAndroid"))
             assertTrue(readyState.getBoolean("hasAppPlugin"))
+            assertTrue(readyState.getBoolean("hasLocalNotificationsPlugin"))
             assertTrue(readyState.getBoolean("hasWebDavPlugin"))
+            assertTrue(
+                "Capacitor plugin initialization should not reject: ${readyState.optString("readyError")}",
+                !readyState.has("readyError"),
+            )
 
             evaluateJavaScript(
                 webView,
@@ -199,6 +295,9 @@ class CapacitorLifecycleBridgeInstrumentedTest {
     }
 
     private companion object {
+        /** Generated by `npx cap update`; the same asset Capacitor itself reads. */
+        const val CAPACITOR_PLUGINS_ASSET = "capacitor.plugins.json"
+
         val TEST_PAGE = """
             <!doctype html>
             <html>
@@ -214,6 +313,9 @@ class CapacitorLifecycleBridgeInstrumentedTest {
                       typeof window.SUPAndroid.getVersion === 'function',
                     hasAppPlugin:
                       typeof window.Capacitor?.Plugins?.App?.addListener === 'function',
+                    hasLocalNotificationsPlugin:
+                      typeof window.Capacitor?.Plugins?.LocalNotifications?.checkPermissions ===
+                      'function',
                     hasWebDavPlugin:
                       typeof window.Capacitor?.Plugins?.WebDavHttp?.request === 'function',
                     supPause: 0,
@@ -256,7 +358,10 @@ class CapacitorLifecycleBridgeInstrumentedTest {
                   window.Capacitor.Plugins.App.getState()
                     .then(() => smoke.ready = true)
                     .catch((error) => {
+                      // Still ready: a rejection has to reach the assertions as
+                      // readyError, not as an opaque predicate timeout.
                       smoke.readyError = String(error?.message || error);
+                      smoke.ready = true;
                     });
                 </script>
               </body>

--- a/android/app/src/androidTest/java/com/superproductivity/superproductivity/app/KeyValStoreInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/superproductivity/superproductivity/app/KeyValStoreInstrumentedTest.kt
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith
  * to the WebView as "Error invoking loadFromDb: Java exception …", so the
  * eviction-recovery path (#7901) silently failed and the user lost everything.
  *
- * Run: ./gradlew :app:connectedPlayDebugAndroidTest (emulator/device required).
+ * Run: ./gradlew :app:connectedPlayR8TestAndroidTest (emulator/device required).
  */
 @RunWith(AndroidJUnit4::class)
 class KeyValStoreInstrumentedTest {

--- a/android/app/src/androidTest/java/com/superproductivity/superproductivity/service/BackgroundSyncCredentialStoreInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/superproductivity/superproductivity/service/BackgroundSyncCredentialStoreInstrumentedTest.kt
@@ -30,7 +30,7 @@ import java.security.KeyStore
  * clear from the first launch onward, and never re-encrypted, because create()
  * keeps failing on the stale keyset on every later process start.
  *
- * Run: ./gradlew :app:connectedPlayDebugAndroidTest (emulator/device required).
+ * Run: ./gradlew :app:connectedPlayR8TestAndroidTest (emulator/device required).
  */
 @RunWith(AndroidJUnit4::class)
 class BackgroundSyncCredentialStoreInstrumentedTest {
@@ -50,15 +50,7 @@ class BackgroundSyncCredentialStoreInstrumentedTest {
     private fun wipe() {
         BackgroundSyncCredentialStore.clear(context)
         context.deleteSharedPreferences(PREFS_NAME)
-        forgetCachedPrefs()
-    }
-
-    /** Drops the process-lifetime `prefs` cache so the next call re-opens the store. */
-    private fun forgetCachedPrefs() {
-        BackgroundSyncCredentialStore::class.java.getDeclaredField("prefs").apply {
-            isAccessible = true
-            set(BackgroundSyncCredentialStore, null)
-        }
+        BackgroundSyncCredentialStore.forgetCachedPrefsForTest()
     }
 
     /**
@@ -69,7 +61,7 @@ class BackgroundSyncCredentialStoreInstrumentedTest {
     private fun simulateDeviceMigration() {
         KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
             .deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
-        forgetCachedPrefs()
+        BackgroundSyncCredentialStore.forgetCachedPrefsForTest()
     }
 
     @Test

--- a/android/app/src/main/java/com/superproductivity/superproductivity/service/BackgroundSyncCredentialStore.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/service/BackgroundSyncCredentialStore.kt
@@ -3,6 +3,7 @@ package com.superproductivity.superproductivity.service
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 
@@ -36,6 +37,21 @@ object BackgroundSyncCredentialStore {
     // cache reads go through here. All access is via @Synchronized methods,
     // so a plain field is safe.
     private var prefs: SharedPreferences? = null
+
+    /**
+     * Drops the process-lifetime cache so the next call re-opens the store —
+     * what the instrumented tests need to stand in for a fresh process on a
+     * migrated device.
+     *
+     * Exists because doing this by reflection does not survive minification:
+     * R8 renames the backing field, and `getDeclaredField("prefs")` is a string
+     * it never rewrites. Instrumented tests run on the minified r8Test variant.
+     */
+    @VisibleForTesting
+    @Synchronized
+    fun forgetCachedPrefsForTest() {
+        prefs = null
+    }
 
     private fun getPrefs(context: Context): SharedPreferences {
         prefs?.let { return it }


### PR DESCRIPTION
#9785/#9793 shipped a build that died ~3s after launch on the first JS call touching permissions. Nothing in CI could have caught it: the emulator job installed the **debug** variant, and the R8 job only grepped `mapping.txt`, which cannot see a build that throws at runtime.

So point the instrumented suite at a minified target, and fix what it finds.

## The defect

R8 sees nothing in the program constructing a `@CapacitorPlugin` — annotation instances are runtime-generated proxies — so it concludes `PluginHandle.pluginAnnotation` can only ever hold null, deletes the field and constant-folds every read. `Plugin.getPermissionStates()`, `requestPermissions()`, `requestPermissionForAliases()` and `pluginRequestAllPermissions()` all compile down to a literal `throw null`:

```
invoke-virtual  getPluginHandle()
invoke-virtual  Object.getClass()   # null-check
const/4 v0, #int 0
throw v0
```

Two things that are **not** the cause, both checked: the `@CapacitorPlugin` annotation survives intact on the plugin classes (`dexdump` shows it with its permissions array), and R8 full mode is not implicated — compat mode (`android.enableR8.fullMode=false`) emits the same `throw null`. Keeping the field's *owner* is what stops the fold, hence `-keep class com.getcapacitor.PluginHandle { *; }`.

## The change

- **`r8Test` build type + `testBuildType "r8Test"`** — `initWith release` plus `minifyEnabled`/`shrinkResources`, debug signing, `proguard-android-optimize.txt`: the config #9766 shipped. Release itself stays unminified; this is a proxy for the re-land, not the re-land.
- **`everyRegisteredPluginResolvesItsPermissionStates`** walks `capacitor.plugins.json` — the same asset `PluginManager` reads, via the same `Class.forName` — plus the three plugins `CapacitorMainActivity` registers by hand, and resolves permission states for each. 12 plugins, no hand-maintained list. Native and on the test thread deliberately: reached through JS the same defect lands on Capacitor's handler thread, where it kills the process instead of failing a test.
- `android-tests.yml` runs `connectedPlayR8TestAndroidTest`; the Debug task stops existing once `testBuildType` moves.
- `BackgroundSyncCredentialStore.forgetCachedPrefsForTest()` replaces the test's `getDeclaredField("prefs")` — R8 renames that field, and string literals are never rewritten by `-applymapping`. It needs its own keep rule: called only from androidTest, R8 shrank it out of the app APK and the test would have died on `NoSuchMethodError`. Every future test-only seam needs the same; `usage.txt` is where that shows up.
- A `@Before` pinning `BuildConfig.BUILD_TYPE`, so changing `testBuildType` cannot silently disarm the suite.

## Verification

No emulator was available locally (no `/dev/kvm`), so **this suite has never been executed** — that is what this PR's CI run is for. Everything below was verified statically, on both the play and fdroid `r8Test` variants:

- `getPermissionStates()` is a real 168-unit body calling `PluginHandle.getPluginAnnotation()` after the fix, against the literal `throw null` measured before it; `com.getcapacitor` has no `throw null` sites left.
- `mapping.txt` keeps `PluginHandle` unrenamed with `pluginAnnotation` intact; `usage.txt` lists neither it nor `forgetCachedPrefsForTest` as removed.
- All 9 registry plugin classes map to themselves, so the test's `Class.forName` resolves under minification.
- `-applymapping` rewrites the test's store reference correctly — the androidTest dex references `Lr5/b;` and `forgetCachedPrefsForTest`.
- App APK is non-debuggable and both APKs carry the same signer, which is the precondition `am instrument` actually gates on.
- Assertion failures inside `ActivityScenario.onActivity` do reach the test thread: `MonitoringInstrumentation.runOnMainSync` wraps the runnable in a `FutureTask` and rethrows `Error` as-is.

## Not included, and still true

Release minification stays off (Play's requirement starts February 2027). The shipped unminified release variant is exercised by nothing. `FullscreenActivity` — the actual MAIN/LAUNCHER — is never launched minified. And `android-tests.yml` runs on `pull_request` only, so a direct master push still reaches the Play internal track ungated.

https://claude.ai/code/session_0187JMtiJMAVNuEbVntcBLDJ
