### PR TITLE
fix(schedule): stop touch swipes from moving or resizing schedule events

### DIFF
--- a/docs/wiki/4.04-Schedule-View.md
+++ b/docs/wiki/4.04-Schedule-View.md
@@ -35,6 +35,10 @@ All segments belong to the same task, so clicking any of them opens it. Only the
 
 Tasks that run past midnight are continued on the next day, so you see the full span of the work.
 
+## Moving Tasks on Touch
+
+On a touch device, press and hold a task before dragging it to a new time. A plain swipe always scrolls the timeline, so a day filled with calendar events stays scrollable. Dragging the bottom edge of a task to change its estimate is a mouse-only shortcut; on touch, tap the task and edit the estimate in the task detail panel.
+
 ## What You See
 
 The Schedule shows a range of days (the upcoming 30 days). How many days are visible at once depends on the view mode and your screen size: the **day** view shows a single day, while the **week** and **month** views show fewer days on narrow screens and more on wide ones.

--- a/e2e/tests/schedule/schedule-touch-scroll-9675.spec.ts
+++ b/e2e/tests/schedule/schedule-touch-scroll-9675.spec.ts
@@ -6,6 +6,11 @@ const MOBILE_VIEWPORT = { width: 390, height: 844 };
 // this size and the viewport shrinks to a phone before the schedule is touched.
 const SETUP_VIEWPORT = { width: 1024, height: 900 };
 const SCROLL_WRAPPER = 'schedule .scroll-wrapper';
+// Mirrors DRAG_DELAY_FOR_TOUCH in src/app/app.constants.ts. E2E does not import from
+// src, so if the source value ever rises above the hold below, the long-press test
+// fails on its final assertion — the drag never starts.
+const DRAG_DELAY_FOR_TOUCH = 500;
+const DRAG_STEP_PX = 15;
 
 type TouchDriver = {
   move: (x: number, y: number) => Promise<void>;
@@ -135,5 +140,51 @@ test.describe('Schedule touch scrolling (#9675)', () => {
     // purpose with a finger, but easy to hit by accident, which is how a scroll swipe
     // became a duration change.
     await expect(event.locator('.resize-handle')).toHaveCount(0);
+  });
+
+  // The counterpart of the swipe test: raising the delay must not have traded an
+  // unscrollable schedule for an unmovable task. This one passes on the pre-fix tree
+  // too — it is a regression guard for the positive path, not a reproduction.
+  test('a long press still moves a task to a new time', async ({
+    page,
+    workViewPage,
+  }) => {
+    await seedTaskAndOpenSchedule(page, workViewPage, 'Touch drag task /1h/');
+
+    // While a drag is live, CDK's clone is a second schedule-event with the same text.
+    const event = page
+      .locator('schedule-event:not(.custom-drag-preview)')
+      .filter({ hasText: 'Touch drag task' });
+    await expect(event).toBeVisible();
+
+    // grid-row encodes the start row, so a changed style means the task landed on a
+    // different time. Scrolling alone never changes it.
+    const styleBefore = await event.getAttribute('style');
+
+    const box = await event.boundingBox();
+    expect(box).not.toBeNull();
+    const halfWidth = box!.width / 2;
+    const halfHeight = box!.height / 2;
+    const x = box!.x + halfWidth;
+    const y = box!.y + halfHeight;
+
+    const touch = await touchDriver(page);
+    await touch.start(x, y);
+
+    // Hold still past DRAG_DELAY_FOR_TOUCH before crossing CDK's 5px threshold. CDK
+    // decides scroll-vs-drag at the crossing, so with the delay already elapsed the
+    // same movement that scrolls in the test above must drag here.
+    await page.waitForTimeout(DRAG_DELAY_FOR_TOUCH + 200);
+
+    for (let i = 1; i <= 8; i++) {
+      const travelled = i * DRAG_STEP_PX;
+      await touch.move(x, y + travelled);
+      await page.waitForTimeout(15);
+    }
+    await touch.end();
+    await touch.detach();
+
+    await expect(event).not.toHaveClass(/cdk-drag-dragging/);
+    await expect.poll(() => event.getAttribute('style')).not.toBe(styleBefore);
   });
 });

--- a/e2e/tests/schedule/schedule-touch-scroll-9675.spec.ts
+++ b/e2e/tests/schedule/schedule-touch-scroll-9675.spec.ts
@@ -1,0 +1,139 @@
+import { expect, test } from '../../fixtures/test.fixture';
+import type { Page } from '@playwright/test';
+
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+// The global add-task button only exists in the wide layout, so tasks are seeded at
+// this size and the viewport shrinks to a phone before the schedule is touched.
+const SETUP_VIEWPORT = { width: 1024, height: 900 };
+const SCROLL_WRAPPER = 'schedule .scroll-wrapper';
+
+type TouchDriver = {
+  move: (x: number, y: number) => Promise<void>;
+  start: (x: number, y: number) => Promise<void>;
+  end: () => Promise<void>;
+  detach: () => Promise<void>;
+};
+
+/**
+ * Real touch input via CDP. Synthetic TouchEvents never produce native scrolling, so
+ * they cannot tell "the page scrolled" apart from "nothing happened".
+ */
+const touchDriver = async (page: Page): Promise<TouchDriver> => {
+  const cdp = await page.context().newCDPSession(page);
+  const send = (type: string, points: { x: number; y: number }[]): Promise<unknown> =>
+    cdp.send('Input.dispatchTouchEvent', { type, touchPoints: points } as never);
+
+  return {
+    start: (x, y) => send('touchStart', [{ x, y }]) as Promise<void>,
+    move: (x, y) => send('touchMove', [{ x, y }]) as Promise<void>,
+    end: () => send('touchEnd', []) as Promise<void>,
+    detach: () => cdp.detach(),
+  };
+};
+
+/**
+ * Seed a task, then open the schedule as a phone would.
+ *
+ * The reload matters: input intent is per-session and Playwright seeds tasks with real
+ * mouse clicks, which legitimately flips the app to mouse intent. A hash navigation
+ * would keep that state, so the reload restores the touch-primary bootstrap a phone
+ * actually gets — without it, `dragDelayForTouch()` is the mouse value of 0 and the
+ * test proves nothing.
+ */
+const seedTaskAndOpenSchedule = async (
+  page: Page,
+  workViewPage: {
+    waitForTaskList: () => Promise<void>;
+    addTask: (t: string) => Promise<void>;
+  },
+  taskTitle: string,
+): Promise<void> => {
+  await workViewPage.waitForTaskList();
+  await workViewPage.addTask(taskTitle);
+
+  await page.setViewportSize(MOBILE_VIEWPORT);
+  await page.goto('/#/schedule');
+  await page.reload();
+  await expect(page.locator('schedule-week')).toBeVisible();
+};
+
+test.describe('Schedule touch scrolling (#9675)', () => {
+  // isMobile makes Chromium report `pointer: coarse`, which is what puts detect-it in
+  // touchOnly mode and InputIntentService in 'touch' intent from bootstrap.
+  test.use({
+    viewport: SETUP_VIEWPORT,
+    hasTouch: true,
+    isMobile: true,
+  });
+
+  test('a deliberate swipe over a task scrolls instead of moving it', async ({
+    page,
+    workViewPage,
+  }) => {
+    await seedTaskAndOpenSchedule(page, workViewPage, 'Touch scroll task /3h/');
+
+    const scrollWrapper = page.locator(SCROLL_WRAPPER);
+    const event = page.locator('schedule-event').filter({ hasText: 'Touch scroll task' });
+    await expect(event).toBeVisible();
+
+    // grid-row encodes both the start row and the span, so one comparison catches a
+    // task that was moved to another time AND one whose duration was resized.
+    const styleBefore = await event.getAttribute('style');
+    const scrollBefore = await scrollWrapper.evaluate((el) => el.scrollTop);
+
+    const box = await event.boundingBox();
+    expect(box).not.toBeNull();
+    const halfWidth = box!.width / 2;
+    const halfHeight = box!.height / 2;
+    const x = box!.x + halfWidth;
+    const y = box!.y + halfHeight;
+
+    const touch = await touchDriver(page);
+    await touch.start(x, y);
+
+    // Creep below CDK's 5px threshold for ~120ms. CDK only decides scroll-vs-drag at
+    // the moment the threshold is crossed: if the drag start delay has elapsed by then
+    // it drags, otherwise it abandons the sequence and the browser keeps the scroll.
+    // This is what a slow, deliberate swipe looks like, and it is why the old 75ms
+    // delay moved the task while the app-wide 500ms long press does not.
+    for (let i = 1; i <= 4; i++) {
+      await page.waitForTimeout(30);
+      await touch.move(x, y - i);
+    }
+
+    // first move past the threshold — the decision point
+    await page.waitForTimeout(15);
+    await touch.move(x, y - 30);
+
+    for (let i = 2; i <= 8; i++) {
+      await page.waitForTimeout(15);
+      const step = i * 20;
+      const travelled = 30 + step;
+      await touch.move(x, y - travelled);
+    }
+    await touch.end();
+    await touch.detach();
+
+    // With the drag delay too short, the swipe is consumed as a task move: the
+    // schedule does not scroll and the task lands on a different grid row.
+    await expect
+      .poll(() => scrollWrapper.evaluate((el) => el.scrollTop))
+      .toBeGreaterThan(scrollBefore);
+    expect(await event.getAttribute('style')).toBe(styleBefore);
+  });
+
+  test('the resize handle is not rendered while touch is the active input', async ({
+    page,
+    workViewPage,
+  }) => {
+    await seedTaskAndOpenSchedule(page, workViewPage, 'Touch resize task /2h/');
+
+    const event = page.locator('schedule-event').filter({ hasText: 'Touch resize task' });
+    await expect(event).toBeVisible();
+
+    // The handle is a 12px band on the bottom edge of every event — unhittable on
+    // purpose with a finger, but easy to hit by accident, which is how a scroll swipe
+    // became a duration change.
+    await expect(event.locator('.resize-handle')).toHaveCount(0);
+  });
+});

--- a/src/app/features/schedule/schedule-event/schedule-event.component.html
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.html
@@ -158,7 +158,6 @@
     [matTooltipDisabled]="!se().isBeyondBudget"
     [attr.aria-label]="se().isBeyondBudget ? beyondBudgetTooltip : null"
     (mousedown)="onResizeStart($event)"
-    (touchstart)="onResizeStart($event)"
   >
     <div class="resize-grip"></div>
   </div>

--- a/src/app/features/schedule/schedule-event/schedule-event.component.spec.ts
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.spec.ts
@@ -12,6 +12,7 @@ import { CalendarEventActionsService } from '../../calendar-integration/calendar
 import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
 import { selectTaskByIdWithSubTaskData } from '../../tasks/store/task.selectors';
 import { TaskRepeatCfg } from '../../task-repeat-cfg/task-repeat-cfg.model';
+import { isTouchActive } from '../../../util/input-intent';
 
 const makeCalendarScheduleEvent = (isReferenceCalendar: boolean): ScheduleEvent => ({
   id: 'cal-1',
@@ -248,6 +249,63 @@ describe('ScheduleEventComponent – isReferenceCalendar', () => {
       fixture.detectChanges();
 
       expect(component.isResizable()).toBe(false);
+    });
+
+    // The handle is a 12px band on the bottom edge of every event, unreachable on
+    // purpose with a finger but easy to hit by accident, so it is mouse-only (#9675).
+    describe('mouse-only resizing', () => {
+      const getHandle = (): HTMLElement => {
+        fixture.componentRef.setInput('event', makeTaskScheduleEvent());
+        fixture.detectChanges();
+        const handle = fixture.nativeElement.querySelector('.resize-handle');
+        expect(handle).withContext('resize handle must be rendered').toBeTruthy();
+        return handle as HTMLElement;
+      };
+
+      const mouseDownOnHandle = (clientY: number): void =>
+        void getHandle().dispatchEvent(
+          new MouseEvent('mousedown', { bubbles: true, cancelable: true, clientY }),
+        );
+
+      afterEach(() => {
+        // release any gesture a failing expectation left armed
+        document.dispatchEvent(new MouseEvent('mouseup'));
+      });
+
+      it('should render the handle while mouse is the active input', () => {
+        // the test env reports mouseOnly, so this pins the non-touch branch only
+        expect(isTouchActive()).toBe(false);
+        getHandle();
+        expect(component.isResizable()).toBe(true);
+      });
+
+      it('should follow the mouse while resizing', () => {
+        const handle = getHandle();
+        const heightAtStart = fixture.nativeElement.offsetHeight;
+        handle.dispatchEvent(
+          new MouseEvent('mousedown', { bubbles: true, cancelable: true, clientY: 100 }),
+        );
+
+        expect(component.cssClass()).toContain('is-resizing');
+
+        document.dispatchEvent(new MouseEvent('mousemove', { clientY: 160 }));
+
+        // no .grid-container ancestor in the fixture, so the unsnapped fallback applies
+        expect(component._resizeHeight()).toBe(`${heightAtStart + 60}px`);
+
+        document.dispatchEvent(new MouseEvent('mouseup'));
+        expect(component.cssClass()).not.toContain('is-resizing');
+      });
+
+      it('should drop document listeners once the gesture ends', () => {
+        mouseDownOnHandle(100);
+        document.dispatchEvent(new MouseEvent('mouseup'));
+
+        component._resizeHeight.set('');
+        document.dispatchEvent(new MouseEvent('mousemove', { clientY: 300 }));
+
+        expect(component._resizeHeight()).toBe('');
+      });
     });
   });
 

--- a/src/app/features/schedule/schedule-event/schedule-event.component.ts
+++ b/src/app/features/schedule/schedule-event/schedule-event.component.ts
@@ -42,6 +42,7 @@ import { TaskContextMenuComponent } from '../../tasks/task-context-menu/task-con
 import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
 import { FH } from '../schedule.const';
 import { CalendarEventActionsService } from '../../calendar-integration/calendar-event-actions.service';
+import { isTouchActive } from '../../../util/input-intent';
 
 const FIVE_MINUTES_IN_MS = 5 * 60 * 1000;
 
@@ -278,6 +279,7 @@ export class ScheduleEventComponent implements AfterViewInit, OnDestroy {
       cancelAnimationFrame(this._measureRafId);
     }
     this._resizeObserver?.disconnect();
+    this._endResizeGesture?.();
   }
 
   private _scheduleTitleLineClampUpdate(): void {
@@ -530,9 +532,19 @@ export class ScheduleEventComponent implements AfterViewInit, OnDestroy {
   readonly _resizeHeight = signal('');
   private _startY = 0;
   private _startHeight = 0;
+  private _endResizeGesture: (() => void) | null = null;
 
   isResizable(): boolean {
     if (this.isResizeDisabled() || this.isDragPreview() || this.isMonthView()) {
+      return false;
+    }
+
+    // Not on touch. The handle is a 12px band along the bottom edge of every event —
+    // about 2mm on a phone, against a finger contact patch of 8-10mm. It cannot be hit
+    // on purpose, only by accident, which on a densely filled schedule turned every
+    // scroll swipe into a duration change (#9675). Estimates stay editable by tapping
+    // the event and using the task detail panel.
+    if (isTouchActive()) {
       return false;
     }
 
@@ -553,34 +565,36 @@ export class ScheduleEventComponent implements AfterViewInit, OnDestroy {
     );
   }
 
-  onResizeStart(event: MouseEvent | TouchEvent): void {
+  onResizeStart(event: MouseEvent): void {
     if (!this.isResizable()) return;
 
+    // Keep the gesture away from the host's cdkDrag: the handle resizes, the body moves.
     event.stopPropagation();
     event.preventDefault();
 
-    this._isResizing.set(true);
-
-    const clientY = 'touches' in event ? event.touches[0].clientY : event.clientY;
-    this._startY = clientY;
+    this._endResizeGesture?.();
+    this._startY = event.clientY;
     this._startHeight = this._elRef.nativeElement.offsetHeight;
 
-    // Add event listeners for mouse/touch move and end
-    const moveHandler = (e: MouseEvent | TouchEvent): void => this._onResizeMove(e);
-    const endHandler = (): void => this._onResizeEnd(moveHandler, endHandler);
-
+    const moveHandler = (e: MouseEvent): void => this._onResizeMove(e);
+    const endHandler = (): void => this._onResizeEnd();
     document.addEventListener('mousemove', moveHandler);
     document.addEventListener('mouseup', endHandler);
-    document.addEventListener('touchmove', moveHandler);
-    document.addEventListener('touchend', endHandler);
+    this._endResizeGesture = () => {
+      document.removeEventListener('mousemove', moveHandler);
+      document.removeEventListener('mouseup', endHandler);
+      this._endResizeGesture = null;
+      this._isResizing.set(false);
+    };
+
+    this._isResizing.set(true);
   }
 
-  private _onResizeMove(event: MouseEvent | TouchEvent): void {
+  private _onResizeMove(event: MouseEvent): void {
     if (!this._isResizing()) return;
 
     event.preventDefault();
-    const clientY = 'touches' in event ? event.touches[0].clientY : event.clientY;
-    const deltaY = clientY - this._startY;
+    const deltaY = event.clientY - this._startY;
 
     // Calculate new height based on grid row height for snap-to-grid behavior
     const gridContainer = this._elRef.nativeElement.closest(
@@ -602,22 +616,16 @@ export class ScheduleEventComponent implements AfterViewInit, OnDestroy {
     }
   }
 
-  private _onResizeEnd(moveHandler: any, endHandler: any): void {
+  private _onResizeEnd(): void {
     if (!this._isResizing()) return;
 
-    this._isResizing.set(false);
+    this._endResizeGesture?.();
 
     // Set cooldown flag to prevent immediate click events
     this._justFinishedResizing.set(true);
     setTimeout(() => {
       this._justFinishedResizing.set(false);
     }, 200); // 200ms cooldown
-
-    // Remove event listeners
-    document.removeEventListener('mousemove', moveHandler);
-    document.removeEventListener('mouseup', endHandler);
-    document.removeEventListener('touchmove', moveHandler);
-    document.removeEventListener('touchend', endHandler);
 
     // Calculate new duration based on height change
     const currentHeight = this._elRef.nativeElement.offsetHeight;

--- a/src/app/features/schedule/schedule-week/schedule-week.component.html
+++ b/src/app/features/schedule/schedule-week/schedule-week.component.html
@@ -128,7 +128,7 @@
         (cdkDragMoved)="dragMoved($event)"
         (cdkDragStarted)="dragStarted($event)"
         (cdkDragReleased)="dragReleased($event)"
-        [cdkDragStartDelay]="isTouchActive() ? touchDragStartDelayMs : 0"
+        [cdkDragStartDelay]="dragDelayForTouch()"
         [event]="ev"
       ></schedule-event>
     } @else {

--- a/src/app/features/schedule/schedule-week/schedule-week.component.ts
+++ b/src/app/features/schedule/schedule-week/schedule-week.component.ts
@@ -23,7 +23,7 @@ import { ScheduleEventComponent } from '../schedule-event/schedule-event.compone
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { MatIcon } from '@angular/material/icon';
 import { T } from '../../../t.const';
-import { isTouchActive } from '../../../util/input-intent';
+import { dragDelayForTouch, isTouchActive } from '../../../util/input-intent';
 import { MatTooltip } from '@angular/material/tooltip';
 import { DateTimeFormatService } from '../../../core/date-time-format/date-time-format.service';
 import { parseDbDateStr } from '../../../util/parse-db-date-str';
@@ -43,7 +43,6 @@ const MIN_ROW_HEIGHT_PX = 5;
 const MAX_ROW_HEIGHT_PX = 24;
 const ROW_HEIGHT_STEP_PX = 1;
 const MOBILE_ROW_HEIGHT_FACTOR = DEFAULT_MOBILE_ROW_HEIGHT_PX / DEFAULT_ROW_HEIGHT_PX;
-const TOUCH_DRAG_START_DELAY_MS = 75;
 
 interface ScheduleTaskDataLike {
   id?: string;
@@ -105,11 +104,13 @@ export class ScheduleWeekComponent implements OnInit, AfterViewInit, OnDestroy {
   readonly isShiftNoScheduleMode = this._service.isShiftMode;
 
   FH = FH;
-  protected readonly isTouchActive = isTouchActive;
   SVEType: typeof SVEType = SVEType;
   T: typeof T = T;
   protected readonly isDraggableSE = isDraggableSE;
-  protected readonly touchDragStartDelayMs = TOUCH_DRAG_START_DELAY_MS;
+  // Touch drags must wait out the app-wide long press. A shorter delay turns any
+  // deliberate (= slow) vertical swipe that starts on an event into a task move,
+  // which makes a densely filled schedule unscrollable on mobile (#9675).
+  protected readonly dragDelayForTouch = dragDelayForTouch;
 
   rowsByNr = Array.from({ length: D_HOURS * FH }, (_, index) => index).filter(
     (_, index) => index % FH === 0,


### PR DESCRIPTION
Closes #9675

On a densely filled schedule almost every vertical swipe starts on an event, and both gesture paths hijacked it.

**Drag.** `cdkDragStartDelay` for touch was a bespoke 75ms. CDK decides scroll-vs-drag only at the moment the pointer crosses its 5px threshold — if the delay has elapsed by then it drags, otherwise it abandons the sequence and the browser keeps the scroll. At 75ms a swipe had to exceed ~67px/s to read as a scroll, so fast flicks worked and deliberate scrolls became task moves. This is a regression: the same binding used the app-wide `DRAG_DELAY_FOR_TOUCH` until a template consolidation in b15c22db35 (shipped v18.10.0). Restored.

**Resize.** The handle is a 12px band along the bottom edge of every event — roughly 2mm on a phone against an 8–10mm finger contact patch — and its `touchstart` `preventDefault()`ed unconditionally, killing the scroll and turning the swipe into a duration change. `isResizable()` now returns false while touch is the active input and the handler is mouse-only. Pen and mouse keep the handle, since `InputIntentService` maps pen to mouse intent.

Also fixes the resize listeners leaking when the component is destroyed mid-gesture.

## Testing

`e2e/tests/schedule/schedule-touch-scroll-9675.spec.ts` drives real touch input through CDP — synthetic `TouchEvent`s produce no native scrolling, so they cannot tell "the page scrolled" apart from "nothing happened".

| test | pre-fix | post-fix |
|---|---|---|
| a deliberate swipe scrolls instead of moving | fails | passes |
| resize handle absent while touch is active | fails | passes |
| a long press still moves a task | passes | passes |

The third is a regression guard rather than a reproduction — it was falsified separately by pinning `cdkDragStartDelay` to 5000ms, which turns it red on the drag assertion. All three verified green across repeated runs.

## Open question for @shatteringglassanimation-sys

Verified only in Chromium with `isMobile: true` + CDP touch, which approximates but is not a real Android/iOS browser. A preview build will be linked on this PR shortly — three things worth checking on your phone:

1. Does a slow, deliberate scroll over a full day now scroll instead of dragging tasks?
2. Can you still move a task by pressing and holding it first?
3. Does losing the bottom-edge drag-to-resize on touch bother you? Estimates stay editable by tapping the task and using the detail panel — but the fix works without this part, so it can be dropped if the affordance is worth keeping.
