### PR TITLE
fix(ios): stop the add-task bar jumping and cut the keyboard layout churn (#9779)

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -43,6 +43,8 @@
 } @else {
   <div
     class="app-container"
+    [style.height]="iosShellHeight()"
+    [style.min-height]="iosShellHeight()"
     [class.has-mobile-bottom-nav]="isShowMobileButtonNav()"
     [class.has-vertical-action-bar]="isVerticalActionBar()"
     [class.app-entrance]="isAppEntrance()"

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -46,12 +46,12 @@
   min-height: calc(100vh - var(--safe-area-top));
 }
 
-// iOS keeps 100vh tied to the layout viewport while the soft keyboard is open.
-// Use visualViewport height from JS so the app shell shrinks above the keyboard.
-:host-context(body.isIOS.isKeyboardVisible) .app-container {
-  height: calc(var(--visual-viewport-height) - var(--safe-area-top));
-  min-height: calc(var(--visual-viewport-height) - var(--safe-area-top));
-}
+// iOS keeps 100vh tied to the layout viewport while the soft keyboard is open,
+// so the shell has to be sized from the visualViewport height. That height now
+// arrives as a plain inline `height` from GlobalThemeService._setIosShellHeight
+// rather than a `--visual-viewport-height` rule here: this element wraps the
+// task list, and a custom property it inherits makes WebKit restyle the whole
+// list on every frame of the keyboard animation (#9779).
 
 .main-content {
   flex: 1;

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -48,7 +48,7 @@
 
 // iOS keeps 100vh tied to the layout viewport while the soft keyboard is open,
 // so the shell has to be sized from the visualViewport height. That height now
-// arrives as a plain inline `height` from GlobalThemeService._setIosShellHeight
+// arrives as a plain `height` bound from GlobalThemeService.iosShellHeight
 // rather than a `--visual-viewport-height` rule here: this element wraps the
 // task list, and a custom property it inherits makes WebKit restyle the whole
 // list on every frame of the keyboard animation (#9779).

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -135,6 +135,8 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   private _bannerService = inject(BannerService);
   private _snackService = inject(SnackService);
   private _globalThemeService = inject(GlobalThemeService);
+  /** Sized above the iOS keyboard; null everywhere else. See GlobalThemeService. */
+  readonly iosShellHeight = this._globalThemeService.iosShellHeight;
   private _languageService = inject(LanguageService);
   private _activatedRoute = inject(ActivatedRoute);
   private _matDialog = inject(MatDialog);

--- a/src/app/core/theme/global-theme.service.spec.ts
+++ b/src/app/core/theme/global-theme.service.spec.ts
@@ -17,6 +17,7 @@ import { CustomThemeRef } from './custom-theme.service';
 import { KeyboardInfo, KeyboardPlugin } from '@capacitor/keyboard';
 import { PluginListenerHandle } from '@capacitor/core';
 import { BodyClass } from '../../app.constants';
+import { createOneShotSettle, OneShotSettle } from './ios-keyboard-settle.util';
 
 interface GlobalThemeInitHarness {
   init(): void;
@@ -329,7 +330,8 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     _cssVarCache: Map<string, string>;
     _overlayContainer: { getContainerElement(): HTMLElement };
     _iosViewportVarTarget: HTMLElement;
-    _iosKeyboardSettleTimeout: number | undefined;
+    _iosShowSettle: OneShotSettle;
+    _iosHideSettle: OneShotSettle;
     iosShellHeight: WritableSignal<string | null>;
     _scrollActiveInputIntoView(): void;
     _environmentInjector: EnvironmentInjector;
@@ -338,6 +340,7 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
   type KeyboardHandler = (info: KeyboardInfo) => void;
 
   const BASE_HEIGHT = 800;
+  const SETTLE_FALLBACK_MS = 400;
   const KEYBOARD_HEIGHT = 336;
 
   let harness: IosKeyboardHarness;
@@ -441,6 +444,9 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     harness._iosKeyboardFrameUnreliable = false;
     harness._isIosKeyboardSettled = false;
     harness._cssVarCache = new Map<string, string>();
+    // Field initializers do not run on an Object.create harness.
+    harness._iosShowSettle = createOneShotSettle(SETTLE_FALLBACK_MS);
+    harness._iosHideSettle = createOneShotSettle(SETTLE_FALLBACK_MS);
     harness._scrollActiveInputIntoView = scrollIntoViewSpy;
     harness._environmentInjector = TestBed.inject(EnvironmentInjector);
 
@@ -645,7 +651,7 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
 
       expect(rootVar('--keyboard-overlay-offset')).toBe('0px');
 
-      tick(400);
+      tick(SETTLE_FALLBACK_MS);
       flushRender();
 
       expect(rootVar('--keyboard-overlay-offset')).toBe(`${KEYBOARD_HEIGHT}px`);
@@ -656,7 +662,7 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
       willShow();
       didShow();
       flushRender();
-      tick(400);
+      tick(SETTLE_FALLBACK_MS);
       flushRender();
 
       expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
@@ -665,7 +671,7 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     it('drops the pending timer when the keyboard hides again', fakeAsync(() => {
       willShow();
       willHide();
-      tick(400);
+      tick(SETTLE_FALLBACK_MS);
       flushRender();
 
       expect(harness._isIosKeyboardSettled).toBe(false);
@@ -691,6 +697,52 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
       `calc(${BASE_HEIGHT - KEYBOARD_HEIGHT}px - var(--safe-area-top))`,
     );
   });
+
+  // The mirror of the didShow fallback: without it a single dropped didHide
+  // would strand a stale baseline for the rest of the session.
+  it('takes a fresh baseline on the timer when keyboardDidHide is dropped', fakeAsync(() => {
+    willShow();
+    didShow();
+    willHide();
+    tick(SETTLE_FALLBACK_MS);
+    setWindowHeights(600, 600);
+    willShow();
+    didShow();
+    flushRender();
+
+    expect(harness.iosShellHeight()).toBe(
+      `calc(${600 - KEYBOARD_HEIGHT}px - var(--safe-area-top))`,
+    );
+  }));
+
+  it('does not scroll twice when didShow arrives after the fallback fired', fakeAsync(() => {
+    willShow();
+    tick(SETTLE_FALLBACK_MS);
+    flushRender();
+
+    didShow();
+    flushRender();
+
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+  }));
+
+  // A focus move between two fields: the willHide baseline reset must not fire
+  // behind the keyboard that is already coming back.
+  it('drops the pending baseline reset when focus moves to another field', fakeAsync(() => {
+    willShow();
+    didShow();
+    willHide();
+    setWindowHeights(BASE_HEIGHT - KEYBOARD_HEIGHT, BASE_HEIGHT - KEYBOARD_HEIGHT);
+    willShow();
+    tick(SETTLE_FALLBACK_MS);
+    didShow();
+    flushRender();
+
+    expect(rootVar('--keyboard-height')).toBe(`${KEYBOARD_HEIGHT}px`);
+    expect(harness.iosShellHeight()).toBe(
+      `calc(${BASE_HEIGHT - KEYBOARD_HEIGHT}px - var(--safe-area-top))`,
+    );
+  }));
 
   it('takes a fresh baseline once the web view has grown back', () => {
     willShow();

--- a/src/app/core/theme/global-theme.service.spec.ts
+++ b/src/app/core/theme/global-theme.service.spec.ts
@@ -609,3 +609,72 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     expect(varWrites(setPropertySpy, '--keyboard-height')).toBe(2);
   });
 });
+
+/**
+ * The guard on `_scrollActiveInputIntoView`, which runs on every iOS
+ * `keyboardDidShow`. Real elements in the document, because the decision reads
+ * computed styles and scroll geometry.
+ */
+describe('GlobalThemeService scroll-into-view guard', () => {
+  interface ScrollGuardHarness {
+    document: Document;
+    _canScrollIntoView(el: HTMLElement): boolean;
+  }
+
+  let harness: ScrollGuardHarness;
+  let root: HTMLElement;
+
+  const build = (html: string): HTMLElement => {
+    root.innerHTML = html;
+    return root.querySelector('input') as HTMLElement;
+  };
+
+  beforeEach(() => {
+    harness = Object.create(GlobalThemeService.prototype) as ScrollGuardHarness;
+    harness.document = document;
+    root = document.createElement('div');
+    document.body.appendChild(root);
+  });
+
+  afterEach(() => root.remove());
+
+  it('scrolls an input that sits in a scrollable container', () => {
+    const input = build(`
+      <div style="height: 40px; overflow-y: auto">
+        <div style="height: 400px"><input /></div>
+      </div>
+    `);
+
+    expect(harness._canScrollIntoView(input)).toBe(true);
+  });
+
+  // The global add-task bar: scrolling it into view scrolls the list behind it
+  // instead, which is what made the page jump while the keyboard opened (#9779).
+  it('leaves an input in a fixed bar alone', () => {
+    const input = build(`
+      <div style="position: fixed; bottom: 0"><input /></div>
+    `);
+
+    expect(harness._canScrollIntoView(input)).toBe(false);
+  });
+
+  // #7388: a fullscreen dialog is fixed, but its body scrolls, so an input near
+  // the bottom still has to be brought above the keyboard.
+  it('scrolls an input in a scrollable region inside a fixed dialog', () => {
+    const input = build(`
+      <div style="position: fixed; inset: 0">
+        <div style="height: 40px; overflow-y: auto">
+          <div style="height: 400px"><input /></div>
+        </div>
+      </div>
+    `);
+
+    expect(harness._canScrollIntoView(input)).toBe(true);
+  });
+
+  it('scrolls an input with nothing special above it', () => {
+    const input = build('<div><input /></div>');
+
+    expect(harness._canScrollIntoView(input)).toBe(true);
+  });
+});

--- a/src/app/core/theme/global-theme.service.spec.ts
+++ b/src/app/core/theme/global-theme.service.spec.ts
@@ -8,6 +8,9 @@ import {
   resolveSystemSurfaceColor,
 } from './global-theme.service';
 import { CustomThemeRef } from './custom-theme.service';
+import { KeyboardInfo, KeyboardPlugin } from '@capacitor/keyboard';
+import { PluginListenerHandle } from '@capacitor/core';
+import { BodyClass } from '../../app.constants';
 
 interface GlobalThemeInitHarness {
   init(): void;
@@ -301,5 +304,312 @@ describe('GlobalThemeService.registerSvgIconFromContent()', () => {
     const rendered = renderRegisteredLiteral();
     expect(rendered.querySelector('svg')?.getAttribute('onload')).toBeNull();
     expect(rendered.querySelector('circle')?.getAttribute('r')).toBe('4');
+  });
+});
+
+describe('GlobalThemeService iOS keyboard sequencing', () => {
+  interface IosKeyboardHarness {
+    _initIOSKeyboardHandling(keyboard: KeyboardPlugin): void;
+    document: Document;
+    _destroyRef: { onDestroy(cb: () => void): void };
+    _keyboardListenerHandles: PluginListenerHandle[];
+    _focusinListener: ((event: FocusEvent) => void) | null;
+    _visualViewportResizeListener: (() => void) | null;
+    _iosKeyboardHeight: number;
+    _iosViewportHeightBeforeKeyboard: number;
+    _iosViewportChangeRaf: number | null;
+    _iosKeyboardFrameUnreliable: boolean;
+    _isIosKeyboardSettled: boolean;
+    _cssVarCache: Map<string, string>;
+    _overlayContainer: { getContainerElement(): HTMLElement };
+    _iosViewportVarTarget: HTMLElement | null;
+    _iosShellEl: HTMLElement | null;
+    _iosShellHeightCss: string;
+    _scrollActiveInputIntoView(): void;
+  }
+
+  type KeyboardHandler = (info: KeyboardInfo) => void;
+
+  const BASE_HEIGHT = 800;
+  const KEYBOARD_HEIGHT = 336;
+
+  let harness: IosKeyboardHarness;
+  let root: HTMLElement;
+  let body: HTMLElement;
+  let overlayContainer: HTMLElement;
+  let shell: HTMLElement;
+  let handlers: Record<string, KeyboardHandler>;
+  let visualViewport: { height: number; addEventListener: jasmine.Spy };
+  let setPropertySpy: jasmine.Spy;
+  let overlaySetPropertySpy: jasmine.Spy;
+  let resizeNotifications: number;
+  let scrollIntoViewSpy: jasmine.Spy;
+  let pendingFrame: FrameRequestCallback | null = null;
+  let originalInnerHeight: PropertyDescriptor | undefined;
+  let originalVisualViewport: PropertyDescriptor | undefined;
+
+  /** Stubs the window geometry the service reads; restored in afterEach. */
+  const setWindowHeights = (innerHeight: number, visualViewportHeight: number): void => {
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      get: () => innerHeight,
+    });
+    visualViewport.height = visualViewportHeight;
+  };
+
+  const rootVar = (name: string): string => root.style.getPropertyValue(name);
+  /** Set on the CDK overlay container, which every overlay inherits from. */
+  const overlayVar = (name: string): string =>
+    overlayContainer.style.getPropertyValue(name);
+
+  const flushFrame = (): void => {
+    const frame = pendingFrame;
+    pendingFrame = null;
+    frame?.(0);
+  };
+
+  const varWrites = (spy: jasmine.Spy, name: string): number =>
+    spy.calls.allArgs().filter((args) => args[0] === name).length;
+
+  /** The keyboard shrank the web view, i.e. Capacitor's `resize: 'native'`. */
+  const shrinkViewport = (height: number): void => {
+    visualViewport.height = height;
+    harness._visualViewportResizeListener?.();
+  };
+
+  beforeEach(() => {
+    root = document.createElement('div');
+    body = document.createElement('div');
+    overlayContainer = document.createElement('div');
+    shell = document.createElement('div');
+    handlers = {};
+    resizeNotifications = 0;
+    scrollIntoViewSpy = jasmine.createSpy('_scrollActiveInputIntoView');
+    setPropertySpy = spyOn(root.style, 'setProperty').and.callThrough();
+    overlaySetPropertySpy = spyOn(
+      overlayContainer.style,
+      'setProperty',
+    ).and.callThrough();
+
+    visualViewport = {
+      height: BASE_HEIGHT,
+      addEventListener: jasmine.createSpy('addEventListener'),
+    };
+    originalInnerHeight = Object.getOwnPropertyDescriptor(window, 'innerHeight');
+    originalVisualViewport = Object.getOwnPropertyDescriptor(window, 'visualViewport');
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      get: () => visualViewport,
+    });
+    setWindowHeights(BASE_HEIGHT, BASE_HEIGHT);
+
+    // Hold the frame callback like the browser does — the service coalesces
+    // notifications until it runs — and count the resize instead of dispatching
+    // it, which would reach every listener in the karma page.
+    spyOn(window, 'requestAnimationFrame').and.callFake((cb) => {
+      pendingFrame = cb;
+      return 1;
+    });
+    spyOn(window, 'dispatchEvent').and.callFake((event: Event) => {
+      if (event.type === 'resize') {
+        resizeNotifications++;
+      }
+      return true;
+    });
+
+    harness = Object.create(GlobalThemeService.prototype) as IosKeyboardHarness;
+    harness.document = {
+      documentElement: root,
+      body,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      querySelector: (selector: string) => (selector === '.app-container' ? shell : null),
+    } as unknown as Document;
+    harness._overlayContainer = { getContainerElement: () => overlayContainer };
+    harness._iosViewportVarTarget = null;
+    harness._iosShellEl = null;
+    harness._iosShellHeightCss = '';
+    harness._destroyRef = { onDestroy: () => undefined };
+    harness._keyboardListenerHandles = [];
+    harness._focusinListener = null;
+    harness._visualViewportResizeListener = null;
+    harness._iosKeyboardHeight = 0;
+    harness._iosViewportHeightBeforeKeyboard = 0;
+    harness._iosViewportChangeRaf = null;
+    harness._iosKeyboardFrameUnreliable = false;
+    harness._isIosKeyboardSettled = false;
+    harness._cssVarCache = new Map<string, string>();
+    harness._scrollActiveInputIntoView = scrollIntoViewSpy;
+
+    const keyboard = {
+      setAccessoryBarVisible: () => Promise.resolve(),
+      addListener: (eventName: string, listenerFunc: KeyboardHandler) => {
+        handlers[eventName] = listenerFunc;
+        return Promise.resolve({ remove: () => Promise.resolve() });
+      },
+    } as unknown as KeyboardPlugin;
+    harness._initIOSKeyboardHandling(keyboard);
+    flushFrame();
+    setPropertySpy.calls.reset();
+    overlaySetPropertySpy.calls.reset();
+    resizeNotifications = 0;
+  });
+
+  afterEach(() => {
+    const restore = (name: string, descriptor?: PropertyDescriptor): void => {
+      if (descriptor) {
+        Object.defineProperty(window, name, descriptor);
+      } else {
+        delete (window as unknown as Record<string, unknown>)[name];
+      }
+    };
+    restore('innerHeight', originalInnerHeight);
+    restore('visualViewport', originalVisualViewport);
+  });
+
+  const willShow = (keyboardHeight = KEYBOARD_HEIGHT): void =>
+    handlers['keyboardWillShow']({ keyboardHeight } as KeyboardInfo);
+  const didShow = (): void => handlers['keyboardDidShow']({} as KeyboardInfo);
+  const willHide = (): void => handlers['keyboardWillHide']({} as KeyboardInfo);
+
+  it('registers a listener per keyboard event', () => {
+    expect(Object.keys(handlers).sort()).toEqual([
+      'keyboardDidShow',
+      'keyboardWillHide',
+      'keyboardWillShow',
+    ]);
+  });
+
+  // #9779: the reported frame arrives before the web view has resized, so acting
+  // on it here lifts the fixed add-task bar a keyboard height and drops it back
+  // a few frames later — the jump users see.
+  it('does not move anything on the reported frame alone', () => {
+    willShow();
+
+    expect(body.classList.contains(BodyClass.isKeyboardVisible)).toBe(true);
+    expect(rootVar('--keyboard-height')).toBe(`${KEYBOARD_HEIGHT}px`);
+    expect(rootVar('--keyboard-overlay-offset')).toBe('0px');
+    expect(overlayVar('--visual-viewport-height')).toBe(`${BASE_HEIGHT}px`);
+    expect(shell.style.height).toBe(`calc(${BASE_HEIGHT}px - var(--safe-area-top))`);
+  });
+
+  it('follows the web view once it shrinks around the keyboard', () => {
+    willShow();
+    shrinkViewport(BASE_HEIGHT - KEYBOARD_HEIGHT);
+    didShow();
+
+    expect(overlayVar('--visual-viewport-height')).toBe(
+      `${BASE_HEIGHT - KEYBOARD_HEIGHT}px`,
+    );
+    expect(shell.style.height).toBe(
+      `calc(${BASE_HEIGHT - KEYBOARD_HEIGHT}px - var(--safe-area-top))`,
+    );
+    // The shrunken web view already ends above the keyboard; offsetting the
+    // fixed bar again would move it twice (#8778).
+    expect(rootVar('--keyboard-overlay-offset')).toBe('0px');
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('offsets the overlay layer for a keyboard that never resized the web view', () => {
+    willShow();
+    didShow();
+
+    expect(rootVar('--keyboard-overlay-offset')).toBe(`${KEYBOARD_HEIGHT}px`);
+    expect(overlayVar('--visual-viewport-height')).toBe(
+      `${BASE_HEIGHT - KEYBOARD_HEIGHT}px`,
+    );
+  });
+
+  // Switching to the emoji panel or a taller keyboard re-fires willShow while the
+  // keyboard is already up. Nothing is appearing from zero here, so dropping the
+  // offset until didShow arrives would flick the bar down behind the keyboard.
+  it('keeps the overlay offset when the keyboard changes height while visible', () => {
+    willShow();
+    didShow();
+    setWindowHeights(BASE_HEIGHT, BASE_HEIGHT);
+
+    willShow(KEYBOARD_HEIGHT + 100);
+
+    expect(rootVar('--keyboard-overlay-offset')).toBe(`${KEYBOARD_HEIGHT + 100}px`);
+    expect(overlayVar('--visual-viewport-height')).toBe(
+      `${BASE_HEIGHT - KEYBOARD_HEIGHT - 100}px`,
+    );
+  });
+
+  it('measures the pre-keyboard height only while the keyboard is hidden', () => {
+    willShow();
+    // iOS reports the shrunken window once the keyboard is up; re-capturing it
+    // as the base height would subtract the keyboard twice.
+    setWindowHeights(BASE_HEIGHT - KEYBOARD_HEIGHT, BASE_HEIGHT - KEYBOARD_HEIGHT);
+    willShow();
+    didShow();
+
+    expect(harness._iosViewportHeightBeforeKeyboard).toBe(BASE_HEIGHT);
+    expect(overlayVar('--visual-viewport-height')).toBe(
+      `${BASE_HEIGHT - KEYBOARD_HEIGHT}px`,
+    );
+  });
+
+  it('restores the full viewport when the keyboard hides', () => {
+    willShow();
+    shrinkViewport(BASE_HEIGHT - KEYBOARD_HEIGHT);
+    didShow();
+
+    willHide();
+    shrinkViewport(BASE_HEIGHT);
+
+    expect(body.classList.contains(BodyClass.isKeyboardVisible)).toBe(false);
+    expect(rootVar('--keyboard-height')).toBe('0px');
+    expect(rootVar('--keyboard-overlay-offset')).toBe('0px');
+    expect(overlayVar('--visual-viewport-height')).toBe(`${BASE_HEIGHT}px`);
+    // Handed back to the stylesheet, which sizes the shell without a keyboard.
+    expect(shell.style.height).toBe('');
+    expect(shell.style.minHeight).toBe('');
+  });
+
+  // The show animation fires a burst of visualViewport resizes, most of them on
+  // a height already written. Each write costs a document-wide style recalc and
+  // each notification re-measures every autosizing textarea and CDK overlay.
+  it('writes and notifies only for values that actually changed', () => {
+    willShow();
+    flushFrame();
+    const writesAfterShow = varWrites(overlaySetPropertySpy, '--visual-viewport-height');
+    const notificationsAfterShow = resizeNotifications;
+
+    for (let i = 0; i < 3; i++) {
+      shrinkViewport(BASE_HEIGHT - KEYBOARD_HEIGHT);
+      flushFrame();
+    }
+
+    expect(varWrites(overlaySetPropertySpy, '--visual-viewport-height')).toBe(
+      writesAfterShow + 1,
+    );
+    expect(resizeNotifications).toBe(notificationsAfterShow + 1);
+  });
+
+  it('corrects a bogus keyboard frame to the measured obscured area (#8778)', () => {
+    willShow(BASE_HEIGHT - 10);
+    shrinkViewport(BASE_HEIGHT - KEYBOARD_HEIGHT);
+
+    expect(rootVar('--keyboard-height')).toBe(`${KEYBOARD_HEIGHT}px`);
+    expect(rootVar('--keyboard-overlay-offset')).toBe('0px');
+  });
+
+  // The point of the split: <html> carries only variables that change once per
+  // open/close, never the one the animation drives frame by frame (#9779).
+  it('never writes the per-frame viewport height on <html>', () => {
+    willShow();
+    for (let step = 60; step <= 300; step += 60) {
+      shrinkViewport(BASE_HEIGHT - step);
+      flushFrame();
+    }
+    didShow();
+    willHide();
+    shrinkViewport(BASE_HEIGHT);
+
+    expect(varWrites(setPropertySpy, '--visual-viewport-height')).toBe(0);
+    // One per distinct height: the five shrinks plus the restore on hide.
+    expect(varWrites(overlaySetPropertySpy, '--visual-viewport-height')).toBe(6);
+    expect(varWrites(setPropertySpy, '--keyboard-height')).toBe(2);
   });
 });

--- a/src/app/core/theme/global-theme.service.spec.ts
+++ b/src/app/core/theme/global-theme.service.spec.ts
@@ -1,4 +1,10 @@
-import { EnvironmentInjector, signal, Signal, WritableSignal } from '@angular/core';
+import {
+  ApplicationRef,
+  EnvironmentInjector,
+  signal,
+  Signal,
+  WritableSignal,
+} from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { type WorkContextThemeCfg } from '../../features/work-context/work-context.model';
 import {
@@ -325,6 +331,7 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     _iosViewportVarTarget: HTMLElement | null;
     iosShellHeight: WritableSignal<string | null>;
     _scrollActiveInputIntoView(): void;
+    _environmentInjector: EnvironmentInjector;
   }
 
   type KeyboardHandler = (info: KeyboardInfo) => void;
@@ -435,6 +442,7 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     harness._isIosKeyboardSettled = false;
     harness._cssVarCache = new Map<string, string>();
     harness._scrollActiveInputIntoView = scrollIntoViewSpy;
+    harness._environmentInjector = TestBed.inject(EnvironmentInjector);
 
     const keyboard = {
       setAccessoryBarVisible: () => Promise.resolve(),
@@ -465,6 +473,8 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
   const willShow = (keyboardHeight = KEYBOARD_HEIGHT): void =>
     handlers['keyboardWillShow']({ keyboardHeight } as KeyboardInfo);
   const didShow = (): void => handlers['keyboardDidShow']({} as KeyboardInfo);
+  /** Runs the render pass the deferred scroll waits for. */
+  const flushRender = (): void => TestBed.inject(ApplicationRef).tick();
   const willHide = (): void => handlers['keyboardWillHide']({} as KeyboardInfo);
 
   it('registers a listener per keyboard event', () => {
@@ -504,6 +514,21 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     // The shrunken web view already ends above the keyboard; offsetting the
     // fixed bar again would move it twice (#8778).
     expect(rootVar('--keyboard-overlay-offset')).toBe('0px');
+    flushRender();
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // The shell height is a signal binding now, so at didShow the shell is still
+  // its pre-keyboard size. Scrolling there measures the old viewport, decides
+  // the input is already visible, and leaves it under the keyboard (#9779).
+  it('waits for the shell to be resized before scrolling the input into view', () => {
+    willShow();
+    didShow();
+
+    expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+
+    flushRender();
+
     expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -587,8 +612,27 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     willShow(BASE_HEIGHT - 10);
     shrinkViewport(BASE_HEIGHT - KEYBOARD_HEIGHT);
 
+    // Mid-shrink the clamped frame stands. --keyboard-height has non-overlay
+    // consumers so it has to live on <html>, and the obscured area moves every
+    // frame — correcting here would be a root write per frame (#9779).
+    expect(rootVar('--keyboard-height')).toBe(`${BASE_HEIGHT * 0.6}px`);
+
+    didShow();
+
     expect(rootVar('--keyboard-height')).toBe(`${KEYBOARD_HEIGHT}px`);
     expect(rootVar('--keyboard-overlay-offset')).toBe('0px');
+  });
+
+  it('does not write <html> per frame for a bogus keyboard frame either', () => {
+    willShow(BASE_HEIGHT - 10);
+    const writesAfterShow = varWrites(setPropertySpy, '--keyboard-height');
+
+    for (let step = 60; step <= 300; step += 60) {
+      shrinkViewport(BASE_HEIGHT - step);
+      flushFrame();
+    }
+
+    expect(varWrites(setPropertySpy, '--keyboard-height')).toBe(writesAfterShow);
   });
 
   // The point of the split: <html> carries only variables that change once per
@@ -619,6 +663,7 @@ describe('GlobalThemeService scroll-into-view guard', () => {
   interface ScrollGuardHarness {
     document: Document;
     _canScrollIntoView(el: HTMLElement): boolean;
+    _scrollActiveInputIntoView(): void;
   }
 
   let harness: ScrollGuardHarness;
@@ -627,6 +672,20 @@ describe('GlobalThemeService scroll-into-view guard', () => {
   const build = (html: string): HTMLElement => {
     root.innerHTML = html;
     return root.querySelector('input') as HTMLElement;
+  };
+
+  /**
+   * Focuses the input for real and stubs the scroll call on it, so the assertion
+   * covers `_scrollActiveInputIntoView` end to end rather than the predicate
+   * alone — deleting the guard's call site has to fail a test.
+   */
+  const focusAndWatch = (input: HTMLElement): jasmine.Spy => {
+    const spy = jasmine.createSpy('scrollIntoViewIfNeeded');
+    // An own property, so the branch is taken on any browser karma runs in.
+    (input as unknown as Record<string, unknown>).scrollIntoViewIfNeeded = spy;
+    input.focus();
+    expect(document.activeElement).toBe(input);
+    return spy;
   };
 
   beforeEach(() => {
@@ -676,5 +735,31 @@ describe('GlobalThemeService scroll-into-view guard', () => {
     const input = build('<div><input /></div>');
 
     expect(harness._canScrollIntoView(input)).toBe(true);
+  });
+
+  describe('applied to the focused input', () => {
+    it('does not scroll for an input in a fixed bar', () => {
+      const spy = focusAndWatch(
+        build('<div style="position: fixed; bottom: 0"><input /></div>'),
+      );
+
+      harness._scrollActiveInputIntoView();
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('scrolls for an input inside a scrollable container', () => {
+      const spy = focusAndWatch(
+        build(`
+          <div style="height: 40px; overflow-y: auto">
+            <div style="height: 400px"><input /></div>
+          </div>
+        `),
+      );
+
+      harness._scrollActiveInputIntoView();
+
+      expect(spy).toHaveBeenCalledWith(true);
+    });
   });
 });

--- a/src/app/core/theme/global-theme.service.spec.ts
+++ b/src/app/core/theme/global-theme.service.spec.ts
@@ -5,7 +5,7 @@ import {
   Signal,
   WritableSignal,
 } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { type WorkContextThemeCfg } from '../../features/work-context/work-context.model';
 import {
   GlobalThemeService,
@@ -328,7 +328,8 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     _isIosKeyboardSettled: boolean;
     _cssVarCache: Map<string, string>;
     _overlayContainer: { getContainerElement(): HTMLElement };
-    _iosViewportVarTarget: HTMLElement | null;
+    _iosViewportVarTarget: HTMLElement;
+    _iosKeyboardSettleTimeout: number | undefined;
     iosShellHeight: WritableSignal<string | null>;
     _scrollActiveInputIntoView(): void;
     _environmentInjector: EnvironmentInjector;
@@ -429,7 +430,6 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
       removeEventListener: () => undefined,
     } as unknown as Document;
     harness._overlayContainer = { getContainerElement: () => overlayContainer };
-    harness._iosViewportVarTarget = null;
     harness.iosShellHeight = signal<string | null>(null);
     harness._destroyRef = { onDestroy: () => undefined };
     harness._keyboardListenerHandles = [];
@@ -473,12 +473,14 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
   const willShow = (keyboardHeight = KEYBOARD_HEIGHT): void =>
     handlers['keyboardWillShow']({ keyboardHeight } as KeyboardInfo);
   const didShow = (): void => handlers['keyboardDidShow']({} as KeyboardInfo);
+  const didHide = (): void => handlers['keyboardDidHide']({} as KeyboardInfo);
   /** Runs the render pass the deferred scroll waits for. */
   const flushRender = (): void => TestBed.inject(ApplicationRef).tick();
   const willHide = (): void => handlers['keyboardWillHide']({} as KeyboardInfo);
 
   it('registers a listener per keyboard event', () => {
     expect(Object.keys(handlers).sort()).toEqual([
+      'keyboardDidHide',
       'keyboardDidShow',
       'keyboardWillHide',
       'keyboardWillShow',
@@ -633,6 +635,76 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     }
 
     expect(varWrites(setPropertySpy, '--keyboard-height')).toBe(writesAfterShow);
+  });
+
+  describe('when iOS drops keyboardDidShow', () => {
+    // Everything frame-derived waits for didShow, so without a fallback the
+    // fixed bar stays behind the keyboard for the rest of the session (#9779).
+    it('settles on a timer instead', fakeAsync(() => {
+      willShow();
+
+      expect(rootVar('--keyboard-overlay-offset')).toBe('0px');
+
+      tick(400);
+      flushRender();
+
+      expect(rootVar('--keyboard-overlay-offset')).toBe(`${KEYBOARD_HEIGHT}px`);
+      expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it('does not settle twice when didShow does arrive', fakeAsync(() => {
+      willShow();
+      didShow();
+      flushRender();
+      tick(400);
+      flushRender();
+
+      expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it('drops the pending timer when the keyboard hides again', fakeAsync(() => {
+      willShow();
+      willHide();
+      tick(400);
+      flushRender();
+
+      expect(harness._isIosKeyboardSettled).toBe(false);
+      expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+    }));
+  });
+
+  // Moving between two fields fires willHide then willShow while the web view is
+  // still shrunken; re-measuring there subtracts the keyboard twice.
+  it('keeps the pre-keyboard baseline when focus moves to another field', () => {
+    willShow();
+    didShow();
+    willHide();
+    // The web view has not grown back yet — this is what iOS reports meanwhile.
+    setWindowHeights(BASE_HEIGHT - KEYBOARD_HEIGHT, BASE_HEIGHT - KEYBOARD_HEIGHT);
+    willShow();
+    didShow();
+
+    // Re-measuring at the second willShow would clamp the keyboard against the
+    // already-shrunken 464px and shrink the shell to 185.6px.
+    expect(rootVar('--keyboard-height')).toBe(`${KEYBOARD_HEIGHT}px`);
+    expect(harness.iosShellHeight()).toBe(
+      `calc(${BASE_HEIGHT - KEYBOARD_HEIGHT}px - var(--safe-area-top))`,
+    );
+  });
+
+  it('takes a fresh baseline once the web view has grown back', () => {
+    willShow();
+    didShow();
+    willHide();
+    didHide();
+    // A rotation while the keyboard was down: the old baseline must not survive.
+    setWindowHeights(600, 600);
+    willShow();
+    didShow();
+
+    expect(harness.iosShellHeight()).toBe(
+      `calc(${600 - KEYBOARD_HEIGHT}px - var(--safe-area-top))`,
+    );
   });
 
   // The point of the split: <html> carries only variables that change once per

--- a/src/app/core/theme/global-theme.service.spec.ts
+++ b/src/app/core/theme/global-theme.service.spec.ts
@@ -323,8 +323,7 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     _cssVarCache: Map<string, string>;
     _overlayContainer: { getContainerElement(): HTMLElement };
     _iosViewportVarTarget: HTMLElement | null;
-    _iosShellEl: HTMLElement | null;
-    _iosShellHeightCss: string;
+    iosShellHeight: WritableSignal<string | null>;
     _scrollActiveInputIntoView(): void;
   }
 
@@ -337,7 +336,6 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
   let root: HTMLElement;
   let body: HTMLElement;
   let overlayContainer: HTMLElement;
-  let shell: HTMLElement;
   let handlers: Record<string, KeyboardHandler>;
   let visualViewport: { height: number; addEventListener: jasmine.Spy };
   let setPropertySpy: jasmine.Spy;
@@ -381,7 +379,6 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     root = document.createElement('div');
     body = document.createElement('div');
     overlayContainer = document.createElement('div');
-    shell = document.createElement('div');
     handlers = {};
     resizeNotifications = 0;
     scrollIntoViewSpy = jasmine.createSpy('_scrollActiveInputIntoView');
@@ -423,12 +420,10 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
       body,
       addEventListener: () => undefined,
       removeEventListener: () => undefined,
-      querySelector: (selector: string) => (selector === '.app-container' ? shell : null),
     } as unknown as Document;
     harness._overlayContainer = { getContainerElement: () => overlayContainer };
     harness._iosViewportVarTarget = null;
-    harness._iosShellEl = null;
-    harness._iosShellHeightCss = '';
+    harness.iosShellHeight = signal<string | null>(null);
     harness._destroyRef = { onDestroy: () => undefined };
     harness._keyboardListenerHandles = [];
     harness._focusinListener = null;
@@ -490,7 +485,9 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     expect(rootVar('--keyboard-height')).toBe(`${KEYBOARD_HEIGHT}px`);
     expect(rootVar('--keyboard-overlay-offset')).toBe('0px');
     expect(overlayVar('--visual-viewport-height')).toBe(`${BASE_HEIGHT}px`);
-    expect(shell.style.height).toBe(`calc(${BASE_HEIGHT}px - var(--safe-area-top))`);
+    expect(harness.iosShellHeight()).toBe(
+      `calc(${BASE_HEIGHT}px - var(--safe-area-top))`,
+    );
   });
 
   it('follows the web view once it shrinks around the keyboard', () => {
@@ -501,7 +498,7 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     expect(overlayVar('--visual-viewport-height')).toBe(
       `${BASE_HEIGHT - KEYBOARD_HEIGHT}px`,
     );
-    expect(shell.style.height).toBe(
+    expect(harness.iosShellHeight()).toBe(
       `calc(${BASE_HEIGHT - KEYBOARD_HEIGHT}px - var(--safe-area-top))`,
     );
     // The shrunken web view already ends above the keyboard; offsetting the
@@ -563,8 +560,7 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     expect(rootVar('--keyboard-overlay-offset')).toBe('0px');
     expect(overlayVar('--visual-viewport-height')).toBe(`${BASE_HEIGHT}px`);
     // Handed back to the stylesheet, which sizes the shell without a keyboard.
-    expect(shell.style.height).toBe('');
-    expect(shell.style.minHeight).toBe('');
+    expect(harness.iosShellHeight()).toBeNull();
   });
 
   // The show animation fires a burst of visualViewport resizes, most of them on

--- a/src/app/core/theme/global-theme.service.ts
+++ b/src/app/core/theme/global-theme.service.ts
@@ -61,6 +61,7 @@ import { LS } from '../persistence/storage-keys.const';
 import { Log, PluginLog } from '../log';
 import { LayoutService } from '../../core-ui/layout/layout.service';
 import { sanitizeIosKeyboardHeight } from './sanitize-ios-keyboard-height.util';
+import { computeIosKeyboardViewportVars } from './ios-keyboard-viewport-vars.util';
 import { sanitizeSvgIconContent } from '../../util/sanitize-svg-icon.util';
 import { CustomThemeService, getRequiredThemeMode } from './custom-theme.service';
 
@@ -81,7 +82,6 @@ const CSS_VAR_SAFE_AREA_BOTTOM = '--safe-area-inset-bottom';
 const CSS_VAR_SAFE_AREA_LEFT = '--safe-area-inset-left';
 const CSS_VAR_SAFE_AREA_RIGHT = '--safe-area-inset-right';
 const CSS_VAR_SYSTEM_SURFACE = '--system-surface';
-const VIEWPORT_RESIZE_EPSILON_PX = 1;
 const DEFAULT_LIGHT_SYSTEM_SURFACE = '#f8f8f7';
 const DEFAULT_DARK_SYSTEM_SURFACE = '#131314';
 
@@ -212,6 +212,12 @@ export class GlobalThemeService {
   // had to correct it). Gates the measured-viewport override so well-behaved
   // keyboards keep their exact pre-existing behaviour (#8778).
   private _iosKeyboardFrameUnreliable = false;
+  // False until `keyboardDidShow`: the web view may still be resizing around the
+  // keyboard, so any layout derived from the reported frame would be a guess (#9779).
+  private _isIosKeyboardSettled = false;
+  // Last value written per CSS variable, so a repeated write (the keyboard
+  // animation fires many identical visualViewport resizes) costs nothing.
+  private readonly _rootCssVarCache = new Map<string, string>();
 
   private _isCustomWindowTitleBarEnabled(): boolean {
     // The main process (main-window.ts) force-disables the custom title bar on
@@ -708,17 +714,18 @@ export class GlobalThemeService {
       // the exact pre-existing behaviour, so this cannot regress them.
       this._iosKeyboardFrameUnreliable = keyboardHeight !== info.keyboardHeight;
       this._iosKeyboardHeight = keyboardHeight;
+      // The show animation is only starting — nothing about the web view's new
+      // size is known yet, see computeIosKeyboardViewportVars.
+      this._isIosKeyboardSettled = false;
       this.document.body.classList.add(BodyClass.isKeyboardVisible);
       // Set CSS variable for keyboard height to adjust layout
-      this.document.documentElement.style.setProperty(
-        CSS_VAR_KEYBOARD_HEIGHT,
-        `${keyboardHeight}px`,
-      );
+      this._setRootCssVar(CSS_VAR_KEYBOARD_HEIGHT, `${keyboardHeight}px`);
       this._updateIOSKeyboardViewportVars();
     }).then((handle) => this._keyboardListenerHandles.push(handle));
 
     // Use keyboardDidShow for scroll (after animation completes)
     Keyboard.addListener('keyboardDidShow', () => {
+      this._isIosKeyboardSettled = true;
       this._updateIOSKeyboardViewportVars();
       this._scrollActiveInputIntoView();
     }).then((handle) => this._keyboardListenerHandles.push(handle));
@@ -728,12 +735,10 @@ export class GlobalThemeService {
       this._iosKeyboardHeight = 0;
       this._iosViewportHeightBeforeKeyboard = 0;
       this._iosKeyboardFrameUnreliable = false;
+      this._isIosKeyboardSettled = false;
       this.document.body.classList.remove(BodyClass.isKeyboardVisible);
-      this.document.documentElement.style.setProperty(CSS_VAR_KEYBOARD_HEIGHT, '0px');
-      this.document.documentElement.style.setProperty(
-        CSS_VAR_KEYBOARD_OVERLAY_OFFSET,
-        '0px',
-      );
+      this._setRootCssVar(CSS_VAR_KEYBOARD_HEIGHT, '0px');
+      this._setRootCssVar(CSS_VAR_KEYBOARD_OVERLAY_OFFSET, '0px');
       this._updateIOSKeyboardViewportVars();
     }).then((handle) => this._keyboardListenerHandles.push(handle));
 
@@ -773,73 +778,49 @@ export class GlobalThemeService {
   }
 
   private _updateIOSKeyboardViewportVars(): void {
-    const root = this.document.documentElement;
-    const visualViewportHeight = window.visualViewport?.height;
-    const baseHeight = this._iosViewportHeightBeforeKeyboard || window.innerHeight;
-    const isKeyboardVisible = this._iosKeyboardHeight > 0;
-    const isVisualViewportAlreadyResized = this._isVisualViewportResizedForKeyboard(
-      isKeyboardVisible,
-      baseHeight,
-      visualViewportHeight,
+    const vars = computeIosKeyboardViewportVars({
+      keyboardHeight: this._iosKeyboardHeight,
+      baseHeight: this._iosViewportHeightBeforeKeyboard || window.innerHeight,
+      visualViewportHeight: window.visualViewport?.height,
+      isKeyboardSettled: this._isIosKeyboardSettled,
+      isKeyboardFrameUnreliable: this._iosKeyboardFrameUnreliable,
+    });
+
+    let hasChanged = this._setRootCssVar(
+      CSS_VAR_VISUAL_VIEWPORT_HEIGHT,
+      `${vars.visualViewportHeightPx}px`,
     );
-    const height = isKeyboardVisible
-      ? this._getKeyboardAdjustedViewportHeight(baseHeight, visualViewportHeight)
-      : (visualViewportHeight ?? window.innerHeight);
-
-    root.style.setProperty(CSS_VAR_VISUAL_VIEWPORT_HEIGHT, `${Math.max(0, height)}px`);
-    root.style.setProperty(
-      CSS_VAR_KEYBOARD_OVERLAY_OFFSET,
-      `${isKeyboardVisible && !isVisualViewportAlreadyResized ? this._iosKeyboardHeight : 0}px`,
-    );
-
-    // For a keyboard whose reported frame was implausible, once the viewport has
-    // actually shrunk its measured obscured area (`baseHeight -
-    // visualViewportHeight`) is a far more reliable keyboard height than the
-    // bogus plugin frame (#8778), and is correct under both `resize: 'native'`
-    // and non-resizing modes. Correct `--keyboard-height` to the measurement
-    // (still clamped as a safety net). Well-behaved keyboards skip this entirely
-    // and keep the plugin value set in keyboardWillShow — no behaviour change.
-    if (
-      this._iosKeyboardFrameUnreliable &&
-      this._isVisualViewportResizedForKeyboard(
-        isKeyboardVisible,
-        baseHeight,
-        visualViewportHeight,
-      )
-    ) {
-      root.style.setProperty(
-        CSS_VAR_KEYBOARD_HEIGHT,
-        `${sanitizeIosKeyboardHeight(baseHeight - visualViewportHeight, baseHeight)}px`,
-      );
-    }
-    this._notifyIOSViewportChange();
-  }
-
-  private _getKeyboardAdjustedViewportHeight(
-    baseHeight: number,
-    visualViewportHeight?: number,
-  ): number {
-    const keyboardAdjustedHeight = baseHeight - this._iosKeyboardHeight;
-
-    if (
-      this._isVisualViewportResizedForKeyboard(true, baseHeight, visualViewportHeight)
-    ) {
-      return visualViewportHeight;
+    hasChanged =
+      this._setRootCssVar(
+        CSS_VAR_KEYBOARD_OVERLAY_OFFSET,
+        `${vars.keyboardOverlayOffsetPx}px`,
+      ) || hasChanged;
+    if (vars.correctedKeyboardHeightPx !== null) {
+      hasChanged =
+        this._setRootCssVar(
+          CSS_VAR_KEYBOARD_HEIGHT,
+          `${vars.correctedKeyboardHeightPx}px`,
+        ) || hasChanged;
     }
 
-    return keyboardAdjustedHeight;
+    // Every notification costs a synthetic window resize, and each of those makes
+    // CdkTextareaAutosize drop its caches and re-measure and every connected CDK
+    // overlay reposition — app-wide layout work. The keyboard animation fires a
+    // burst of visualViewport resize events, most of which land on values we have
+    // already written, so only tell the app about the ones that moved something.
+    if (hasChanged) {
+      this._notifyIOSViewportChange();
+    }
   }
 
-  private _isVisualViewportResizedForKeyboard(
-    isKeyboardVisible: boolean,
-    baseHeight: number,
-    visualViewportHeight?: number,
-  ): visualViewportHeight is number {
-    return (
-      isKeyboardVisible &&
-      visualViewportHeight !== undefined &&
-      visualViewportHeight < baseHeight - VIEWPORT_RESIZE_EPSILON_PX
-    );
+  /** Writes a CSS variable on <html>; returns whether the value actually changed. */
+  private _setRootCssVar(name: string, value: string): boolean {
+    if (this._rootCssVarCache.get(name) === value) {
+      return false;
+    }
+    this._rootCssVarCache.set(name, value);
+    this.document.documentElement.style.setProperty(name, value);
+    return true;
   }
 
   private _notifyIOSViewportChange(): void {
@@ -934,9 +915,44 @@ export class GlobalThemeService {
     );
   }
 
+  /**
+   * Whether scrolling could bring this element into view at all.
+   *
+   * False only for an element sitting in a `position: fixed` container with no
+   * scrollable box in between — the global add-task bar, say: it moves with the
+   * viewport, so nothing can scroll it anywhere. An input inside a dialog keeps
+   * returning true, because the dialog's own scroll container can still lift it
+   * off the keyboard (#7388).
+   */
+  private _canScrollIntoView(el: HTMLElement): boolean {
+    let node: HTMLElement | null = el.parentElement;
+    while (node && node !== this.document.body) {
+      const style = window.getComputedStyle(node);
+      if (
+        node.scrollHeight > node.clientHeight &&
+        (style.overflowY === 'auto' || style.overflowY === 'scroll')
+      ) {
+        return true;
+      }
+      if (style.position === 'fixed') {
+        return false;
+      }
+      node = node.parentElement;
+    }
+    return true;
+  }
+
   private _scrollActiveInputIntoView(): void {
     const activeEl = this.document.activeElement as HTMLElement;
     if (activeEl && this._isInputElement(activeEl)) {
+      // Mid keyboard animation the fixed add-task bar can sit outside the
+      // shrinking viewport just long enough for `scrollIntoViewIfNeeded` to
+      // scroll the list behind it to an arbitrary offset — which is one of the
+      // ways the bar appears to jump around (#9779). Scrolling cannot move a
+      // fixed element anyway, so skip it there.
+      if (!this._canScrollIntoView(activeEl)) {
+        return;
+      }
       // scrollIntoViewIfNeeded is non-standard but well-supported in iOS WebView
       if ('scrollIntoViewIfNeeded' in activeEl) {
         (activeEl as any).scrollIntoViewIfNeeded(true);

--- a/src/app/core/theme/global-theme.service.ts
+++ b/src/app/core/theme/global-theme.service.ts
@@ -76,6 +76,16 @@ const NavigationBar = registerPlugin<NavigationBarPlugin>('NavigationBar');
 
 export type DarkModeCfg = 'dark' | 'light' | 'system';
 
+/**
+ * How long to wait for `keyboardDidShow` before settling anyway.
+ *
+ * Everything frame-derived — the overlay offset, the bogus-frame correction, the
+ * scroll — waits for that event, and iOS does drop it. Without this the fixed
+ * add-task bar would sit behind the keyboard for the rest of the session instead
+ * of for a few frames (#9779). Comfortably longer than the ~250ms show animation.
+ */
+const IOS_KEYBOARD_SETTLE_FALLBACK_MS = 400;
+
 const CSS_VAR_KEYBOARD_HEIGHT = '--keyboard-height';
 const CSS_VAR_KEYBOARD_OVERLAY_OFFSET = '--keyboard-overlay-offset';
 const CSS_VAR_VISUAL_VIEWPORT_HEIGHT = '--visual-viewport-height';
@@ -218,11 +228,16 @@ export class GlobalThemeService {
   // False until `keyboardDidShow`: the web view may still be resizing around the
   // keyboard, so any layout derived from the reported frame would be a guess (#9779).
   private _isIosKeyboardSettled = false;
+  private _iosKeyboardSettleTimeout: number | undefined;
   // Last value written per CSS variable, so a repeated write (the keyboard
   // animation fires many identical visualViewport resizes) costs nothing.
   private readonly _cssVarCache = new Map<string, string>();
-  // Where --visual-viewport-height goes; see _initIOSKeyboardHandling.
-  private _iosViewportVarTarget: HTMLElement | null = null;
+  // Where --visual-viewport-height goes; see _initIOSKeyboardHandling, which
+  // assigns it before the first update and before any listener is registered.
+  // Definitely assigned rather than nullable: a fallback to <html> here would be
+  // cached by _setCssVar and silently suppress the later write to the real
+  // target, leaving dialogs on the 100vh fallback for the session.
+  private _iosViewportVarTarget!: HTMLElement;
 
   /**
    * Height for the app shell while the iOS keyboard is open, as a CSS value, or
@@ -724,7 +739,10 @@ export class GlobalThemeService {
         const wasKeyboardVisible = this.document.body.classList.contains(
           BodyClass.isKeyboardVisible,
         );
-        if (!wasKeyboardVisible) {
+        // Also skipped while a baseline is still held: willHide clears the body
+        // class but not the baseline, so a focus move between two fields lands
+        // here with the web view still shrunken. Only keyboardDidHide clears it.
+        if (!wasKeyboardVisible && !this._iosViewportHeightBeforeKeyboard) {
           this._iosViewportHeightBeforeKeyboard = window.innerHeight;
         }
         // Some third-party keyboards (e.g. Sogou) report a bogus near-full-screen
@@ -747,6 +765,11 @@ export class GlobalThemeService {
         // would drop the fixed bar behind the keyboard until didShow arrives.
         if (!wasKeyboardVisible) {
           this._isIosKeyboardSettled = false;
+          window.clearTimeout(this._iosKeyboardSettleTimeout);
+          this._iosKeyboardSettleTimeout = window.setTimeout(
+            () => this._settleIosKeyboard(),
+            IOS_KEYBOARD_SETTLE_FALLBACK_MS,
+          );
         }
         this.document.body.classList.add(BodyClass.isKeyboardVisible);
         // Set CSS variable for keyboard height to adjust layout
@@ -761,30 +784,35 @@ export class GlobalThemeService {
 
     // Use keyboardDidShow for scroll (after animation completes)
     keyboard
-      .addListener('keyboardDidShow', () => {
-        this._isIosKeyboardSettled = true;
-        this._updateIOSKeyboardViewportVars();
-        // The shell height above is a signal binding, so the shell is still at
-        // its pre-keyboard height until change detection runs. Measuring here
-        // would find the input comfortably inside a viewport that is about to
-        // shrink, and skip the scroll that keeps it off the keyboard (#9779).
-        afterNextRender(() => this._scrollActiveInputIntoView(), {
-          injector: this._environmentInjector,
-        });
-      })
+      .addListener('keyboardDidShow', () => this._settleIosKeyboard())
       .then((handle) => this._keyboardListenerHandles.push(handle));
 
     keyboard
       .addListener('keyboardWillHide', () => {
         Log.log('iOS keyboard will hide');
         this._iosKeyboardHeight = 0;
-        this._iosViewportHeightBeforeKeyboard = 0;
         this._iosKeyboardFrameUnreliable = false;
         this._isIosKeyboardSettled = false;
+        window.clearTimeout(this._iosKeyboardSettleTimeout);
+        this._iosKeyboardSettleTimeout = undefined;
+        // _iosViewportHeightBeforeKeyboard deliberately survives: moving focus
+        // between two fields fires willHide then willShow, and the web view is
+        // still shrunken at that point, so re-snapshotting window.innerHeight
+        // there would subtract the keyboard a second time. keyboardDidHide,
+        // below, clears it once the web view is actually back to full size.
         this.document.body.classList.remove(BodyClass.isKeyboardVisible);
         const root = this.document.documentElement;
         this._setCssVar(root, CSS_VAR_KEYBOARD_HEIGHT, '0px');
         this._setCssVar(root, CSS_VAR_KEYBOARD_OVERLAY_OFFSET, '0px');
+        this._updateIOSKeyboardViewportVars();
+      })
+      .then((handle) => this._keyboardListenerHandles.push(handle));
+
+    keyboard
+      .addListener('keyboardDidHide', () => {
+        // The web view has finished growing back, so the next willShow can take
+        // a fresh baseline — and must, in case the device rotated meanwhile.
+        this._iosViewportHeightBeforeKeyboard = 0;
         this._updateIOSKeyboardViewportVars();
       })
       .then((handle) => this._keyboardListenerHandles.push(handle));
@@ -818,9 +846,29 @@ export class GlobalThemeService {
       if (this._iosViewportChangeRaf !== null) {
         window.cancelAnimationFrame(this._iosViewportChangeRaf);
       }
+      window.clearTimeout(this._iosKeyboardSettleTimeout);
       if (this._focusinListener) {
         this.document.removeEventListener('focusin', this._focusinListener);
       }
+    });
+  }
+
+  /**
+   * The web view has had its chance to resize around the keyboard, so everything
+   * frame-derived can act. Reached from `keyboardDidShow` or, if iOS drops it,
+   * from the fallback timer armed in `keyboardWillShow`.
+   */
+  private _settleIosKeyboard(): void {
+    window.clearTimeout(this._iosKeyboardSettleTimeout);
+    this._iosKeyboardSettleTimeout = undefined;
+    this._isIosKeyboardSettled = true;
+    this._updateIOSKeyboardViewportVars();
+    // The shell height is a signal binding, so the shell is still at its
+    // pre-keyboard height until change detection runs. Measuring here would find
+    // the input comfortably inside a viewport that is about to shrink, and skip
+    // the scroll that keeps it off the keyboard (#9779).
+    afterNextRender(() => this._scrollActiveInputIntoView(), {
+      injector: this._environmentInjector,
     });
   }
 
@@ -840,7 +888,7 @@ export class GlobalThemeService {
       // write on a 200-task list, on every frame of the keyboard animation
       // (#9779). Only overlay panes read this one, so it lives on their
       // container; the app shell gets a plain height below.
-      this._iosViewportVarTarget ?? root,
+      this._iosViewportVarTarget,
       CSS_VAR_VISUAL_VIEWPORT_HEIGHT,
       `${vars.visualViewportHeightPx}px`,
     );

--- a/src/app/core/theme/global-theme.service.ts
+++ b/src/app/core/theme/global-theme.service.ts
@@ -64,6 +64,7 @@ import { Log, PluginLog } from '../log';
 import { LayoutService } from '../../core-ui/layout/layout.service';
 import { sanitizeIosKeyboardHeight } from './sanitize-ios-keyboard-height.util';
 import { computeIosKeyboardViewportVars } from './ios-keyboard-viewport-vars.util';
+import { createOneShotSettle } from './ios-keyboard-settle.util';
 import { sanitizeSvgIconContent } from '../../util/sanitize-svg-icon.util';
 import { CustomThemeService, getRequiredThemeMode } from './custom-theme.service';
 
@@ -77,12 +78,10 @@ const NavigationBar = registerPlugin<NavigationBarPlugin>('NavigationBar');
 export type DarkModeCfg = 'dark' | 'light' | 'system';
 
 /**
- * How long to wait for `keyboardDidShow` before settling anyway.
+ * How long to wait for a `keyboardDid…` event before acting as if it arrived.
  *
- * Everything frame-derived — the overlay offset, the bogus-frame correction, the
- * scroll — waits for that event, and iOS does drop it. Without this the fixed
- * add-task bar would sit behind the keyboard for the rest of the session instead
- * of for a few frames (#9779). Comfortably longer than the ~250ms show animation.
+ * Comfortably longer than the keyboard animation, which iOS runs at ~250ms.
+ * See `createOneShotSettle` for why neither half of the pair may be trusted.
  */
 const IOS_KEYBOARD_SETTLE_FALLBACK_MS = 400;
 
@@ -228,7 +227,10 @@ export class GlobalThemeService {
   // False until `keyboardDidShow`: the web view may still be resizing around the
   // keyboard, so any layout derived from the reported frame would be a guess (#9779).
   private _isIosKeyboardSettled = false;
-  private _iosKeyboardSettleTimeout: number | undefined;
+  // iOS drops the `did` half of its keyboard animation pairs, so neither the
+  // settle nor the baseline reset may hang on one alone (#9779).
+  private readonly _iosShowSettle = createOneShotSettle(IOS_KEYBOARD_SETTLE_FALLBACK_MS);
+  private readonly _iosHideSettle = createOneShotSettle(IOS_KEYBOARD_SETTLE_FALLBACK_MS);
   // Last value written per CSS variable, so a repeated write (the keyboard
   // animation fires many identical visualViewport resizes) costs nothing.
   private readonly _cssVarCache = new Map<string, string>();
@@ -739,6 +741,9 @@ export class GlobalThemeService {
         const wasKeyboardVisible = this.document.body.classList.contains(
           BodyClass.isKeyboardVisible,
         );
+        // The keyboard is coming back, so the pending baseline reset from the
+        // willHide that preceded a focus move must not fire behind it.
+        this._iosHideSettle.cancel();
         // Also skipped while a baseline is still held: willHide clears the body
         // class but not the baseline, so a focus move between two fields lands
         // here with the web view still shrunken. Only keyboardDidHide clears it.
@@ -765,11 +770,7 @@ export class GlobalThemeService {
         // would drop the fixed bar behind the keyboard until didShow arrives.
         if (!wasKeyboardVisible) {
           this._isIosKeyboardSettled = false;
-          window.clearTimeout(this._iosKeyboardSettleTimeout);
-          this._iosKeyboardSettleTimeout = window.setTimeout(
-            () => this._settleIosKeyboard(),
-            IOS_KEYBOARD_SETTLE_FALLBACK_MS,
-          );
+          this._iosShowSettle.arm(() => this._settleIosKeyboard());
         }
         this.document.body.classList.add(BodyClass.isKeyboardVisible);
         // Set CSS variable for keyboard height to adjust layout
@@ -784,7 +785,7 @@ export class GlobalThemeService {
 
     // Use keyboardDidShow for scroll (after animation completes)
     keyboard
-      .addListener('keyboardDidShow', () => this._settleIosKeyboard())
+      .addListener('keyboardDidShow', () => this._iosShowSettle.run())
       .then((handle) => this._keyboardListenerHandles.push(handle));
 
     keyboard
@@ -793,13 +794,13 @@ export class GlobalThemeService {
         this._iosKeyboardHeight = 0;
         this._iosKeyboardFrameUnreliable = false;
         this._isIosKeyboardSettled = false;
-        window.clearTimeout(this._iosKeyboardSettleTimeout);
-        this._iosKeyboardSettleTimeout = undefined;
-        // _iosViewportHeightBeforeKeyboard deliberately survives: moving focus
-        // between two fields fires willHide then willShow, and the web view is
-        // still shrunken at that point, so re-snapshotting window.innerHeight
-        // there would subtract the keyboard a second time. keyboardDidHide,
-        // below, clears it once the web view is actually back to full size.
+        this._iosShowSettle.cancel();
+        // _iosViewportHeightBeforeKeyboard deliberately survives this event:
+        // moving focus between two fields fires willHide then willShow with the
+        // web view still shrunken, and re-snapshotting window.innerHeight there
+        // would subtract the keyboard a second time. It is cleared once the web
+        // view is actually back to full size instead.
+        this._iosHideSettle.arm(() => this._clearIosKeyboardBaseline());
         this.document.body.classList.remove(BodyClass.isKeyboardVisible);
         const root = this.document.documentElement;
         this._setCssVar(root, CSS_VAR_KEYBOARD_HEIGHT, '0px');
@@ -809,12 +810,7 @@ export class GlobalThemeService {
       .then((handle) => this._keyboardListenerHandles.push(handle));
 
     keyboard
-      .addListener('keyboardDidHide', () => {
-        // The web view has finished growing back, so the next willShow can take
-        // a fresh baseline — and must, in case the device rotated meanwhile.
-        this._iosViewportHeightBeforeKeyboard = 0;
-        this._updateIOSKeyboardViewportVars();
-      })
+      .addListener('keyboardDidHide', () => this._iosHideSettle.run())
       .then((handle) => this._keyboardListenerHandles.push(handle));
 
     // Also handle focus changes while keyboard is already visible
@@ -846,11 +842,21 @@ export class GlobalThemeService {
       if (this._iosViewportChangeRaf !== null) {
         window.cancelAnimationFrame(this._iosViewportChangeRaf);
       }
-      window.clearTimeout(this._iosKeyboardSettleTimeout);
+      this._iosShowSettle.cancel();
+      this._iosHideSettle.cancel();
       if (this._focusinListener) {
         this.document.removeEventListener('focusin', this._focusinListener);
       }
     });
+  }
+
+  /**
+   * The web view has finished growing back, so the next `keyboardWillShow` can
+   * take a fresh baseline — and must, in case the device rotated meanwhile.
+   */
+  private _clearIosKeyboardBaseline(): void {
+    this._iosViewportHeightBeforeKeyboard = 0;
+    this._updateIOSKeyboardViewportVars();
   }
 
   /**
@@ -859,8 +865,6 @@ export class GlobalThemeService {
    * from the fallback timer armed in `keyboardWillShow`.
    */
   private _settleIosKeyboard(): void {
-    window.clearTimeout(this._iosKeyboardSettleTimeout);
-    this._iosKeyboardSettleTimeout = undefined;
     this._isIosKeyboardSettled = true;
     this._updateIOSKeyboardViewportVars();
     // The shell height is a signal binding, so the shell is still at its

--- a/src/app/core/theme/global-theme.service.ts
+++ b/src/app/core/theme/global-theme.service.ts
@@ -1,4 +1,5 @@
 import {
+  afterNextRender,
   computed,
   DestroyRef,
   effect,
@@ -763,7 +764,13 @@ export class GlobalThemeService {
       .addListener('keyboardDidShow', () => {
         this._isIosKeyboardSettled = true;
         this._updateIOSKeyboardViewportVars();
-        this._scrollActiveInputIntoView();
+        // The shell height above is a signal binding, so the shell is still at
+        // its pre-keyboard height until change detection runs. Measuring here
+        // would find the input comfortably inside a viewport that is about to
+        // shrink, and skip the scroll that keeps it off the keyboard (#9779).
+        afterNextRender(() => this._scrollActiveInputIntoView(), {
+          injector: this._environmentInjector,
+        });
       })
       .then((handle) => this._keyboardListenerHandles.push(handle));
 

--- a/src/app/core/theme/global-theme.service.ts
+++ b/src/app/core/theme/global-theme.service.ts
@@ -52,8 +52,9 @@ import { IS_ANDROID_WEB_VIEW } from '../../util/is-android-web-view';
 import { androidInterface } from '../../features/android/android-interface';
 import { HttpClient } from '@angular/common/http';
 import { CapacitorPlatformService } from '../platform/capacitor-platform.service';
-import { Keyboard, KeyboardInfo } from '@capacitor/keyboard';
+import { Keyboard, KeyboardInfo, KeyboardPlugin } from '@capacitor/keyboard';
 import { PluginListenerHandle, registerPlugin } from '@capacitor/core';
+import { OverlayContainer } from '@angular/cdk/overlay';
 import { StatusBar, Style } from '@capacitor/status-bar';
 import { SafeArea } from 'capacitor-plugin-safe-area';
 import { patchCdkViewportForSafeArea } from './cdk-safe-area-viewport.util';
@@ -201,6 +202,7 @@ export class GlobalThemeService {
   private _environmentInjector = inject(EnvironmentInjector);
   private _destroyRef = inject(DestroyRef);
   private _inputIntentService = inject(InputIntentService);
+  private _overlayContainer = inject(OverlayContainer);
   private _hasInitialized = false;
   private _keyboardListenerHandles: PluginListenerHandle[] = [];
   private _focusinListener: ((event: FocusEvent) => void) | null = null;
@@ -217,7 +219,11 @@ export class GlobalThemeService {
   private _isIosKeyboardSettled = false;
   // Last value written per CSS variable, so a repeated write (the keyboard
   // animation fires many identical visualViewport resizes) costs nothing.
-  private readonly _rootCssVarCache = new Map<string, string>();
+  private readonly _cssVarCache = new Map<string, string>();
+  // Where --visual-viewport-height goes; see _initIOSKeyboardHandling.
+  private _iosViewportVarTarget: HTMLElement | null = null;
+  private _iosShellEl: HTMLElement | null = null;
+  private _iosShellHeightCss = '';
 
   private _isCustomWindowTitleBarEnabled(): boolean {
     // The main process (main-window.ts) force-disables the custom title bar on
@@ -679,10 +685,14 @@ export class GlobalThemeService {
    * Initialize iOS keyboard visibility tracking using Capacitor Keyboard plugin.
    * Adds/removes CSS classes when keyboard shows/hides.
    */
-  private _initIOSKeyboardHandling(): void {
+  private _initIOSKeyboardHandling(keyboard: KeyboardPlugin = Keyboard): void {
     // Hide the native iOS accessory bar (prev/next/Done) — no multi-field forms
     // benefit from it, and Done is redundant with the system dismiss gesture.
-    Keyboard.setAccessoryBarVisible({ isVisible: false });
+    keyboard.setAccessoryBarVisible({ isVisible: false });
+    // Resolved up front (this creates the container if CDK has not yet needed
+    // it) so a dialog opened while the keyboard is already up finds the
+    // variable in place.
+    this._iosViewportVarTarget = this._overlayContainer.getContainerElement();
     this._updateIOSKeyboardViewportVars();
 
     if (window.visualViewport) {
@@ -696,51 +706,74 @@ export class GlobalThemeService {
       );
     }
 
-    Keyboard.addListener('keyboardWillShow', (info: KeyboardInfo) => {
-      Log.log('iOS keyboard will show', info);
-      if (!this.document.body.classList.contains(BodyClass.isKeyboardVisible)) {
-        this._iosViewportHeightBeforeKeyboard = window.innerHeight;
-      }
-      // Some third-party keyboards (e.g. Sogou) report a bogus near-full-screen
-      // keyboard frame here; clamp it so it can't fling the fixed add-task bar
-      // to the top of the screen (#8778).
-      const referenceHeight = this._iosViewportHeightBeforeKeyboard || window.innerHeight;
-      const keyboardHeight = sanitizeIosKeyboardHeight(
-        info.keyboardHeight,
-        referenceHeight,
-      );
-      // Only a frame the clamp had to correct opts into the measured-viewport
-      // override in _updateIOSKeyboardViewportVars; well-behaved keyboards keep
-      // the exact pre-existing behaviour, so this cannot regress them.
-      this._iosKeyboardFrameUnreliable = keyboardHeight !== info.keyboardHeight;
-      this._iosKeyboardHeight = keyboardHeight;
-      // The show animation is only starting — nothing about the web view's new
-      // size is known yet, see computeIosKeyboardViewportVars.
-      this._isIosKeyboardSettled = false;
-      this.document.body.classList.add(BodyClass.isKeyboardVisible);
-      // Set CSS variable for keyboard height to adjust layout
-      this._setRootCssVar(CSS_VAR_KEYBOARD_HEIGHT, `${keyboardHeight}px`);
-      this._updateIOSKeyboardViewportVars();
-    }).then((handle) => this._keyboardListenerHandles.push(handle));
+    keyboard
+      .addListener('keyboardWillShow', (info: KeyboardInfo) => {
+        Log.log('iOS keyboard will show', info);
+        // Switching to the emoji panel or a taller third-party keyboard re-fires
+        // this while the keyboard is already up, and iOS then reports the already
+        // shrunken window — keeping the first measurement is what stops the
+        // keyboard being subtracted twice.
+        const wasKeyboardVisible = this.document.body.classList.contains(
+          BodyClass.isKeyboardVisible,
+        );
+        if (!wasKeyboardVisible) {
+          this._iosViewportHeightBeforeKeyboard = window.innerHeight;
+        }
+        // Some third-party keyboards (e.g. Sogou) report a bogus near-full-screen
+        // keyboard frame here; clamp it so it can't fling the fixed add-task bar
+        // to the top of the screen (#8778).
+        const referenceHeight =
+          this._iosViewportHeightBeforeKeyboard || window.innerHeight;
+        const keyboardHeight = sanitizeIosKeyboardHeight(
+          info.keyboardHeight,
+          referenceHeight,
+        );
+        // Only a frame the clamp had to correct opts into the measured-viewport
+        // override in _updateIOSKeyboardViewportVars; well-behaved keyboards keep
+        // the exact pre-existing behaviour, so this cannot regress them.
+        this._iosKeyboardFrameUnreliable = keyboardHeight !== info.keyboardHeight;
+        this._iosKeyboardHeight = keyboardHeight;
+        // The show animation is only starting — nothing about the web view's new
+        // size is known yet, see computeIosKeyboardViewportVars. A keyboard that
+        // is already up is not appearing from zero, though: unsettling it there
+        // would drop the fixed bar behind the keyboard until didShow arrives.
+        if (!wasKeyboardVisible) {
+          this._isIosKeyboardSettled = false;
+        }
+        this.document.body.classList.add(BodyClass.isKeyboardVisible);
+        // Set CSS variable for keyboard height to adjust layout
+        this._setCssVar(
+          this.document.documentElement,
+          CSS_VAR_KEYBOARD_HEIGHT,
+          `${keyboardHeight}px`,
+        );
+        this._updateIOSKeyboardViewportVars();
+      })
+      .then((handle) => this._keyboardListenerHandles.push(handle));
 
     // Use keyboardDidShow for scroll (after animation completes)
-    Keyboard.addListener('keyboardDidShow', () => {
-      this._isIosKeyboardSettled = true;
-      this._updateIOSKeyboardViewportVars();
-      this._scrollActiveInputIntoView();
-    }).then((handle) => this._keyboardListenerHandles.push(handle));
+    keyboard
+      .addListener('keyboardDidShow', () => {
+        this._isIosKeyboardSettled = true;
+        this._updateIOSKeyboardViewportVars();
+        this._scrollActiveInputIntoView();
+      })
+      .then((handle) => this._keyboardListenerHandles.push(handle));
 
-    Keyboard.addListener('keyboardWillHide', () => {
-      Log.log('iOS keyboard will hide');
-      this._iosKeyboardHeight = 0;
-      this._iosViewportHeightBeforeKeyboard = 0;
-      this._iosKeyboardFrameUnreliable = false;
-      this._isIosKeyboardSettled = false;
-      this.document.body.classList.remove(BodyClass.isKeyboardVisible);
-      this._setRootCssVar(CSS_VAR_KEYBOARD_HEIGHT, '0px');
-      this._setRootCssVar(CSS_VAR_KEYBOARD_OVERLAY_OFFSET, '0px');
-      this._updateIOSKeyboardViewportVars();
-    }).then((handle) => this._keyboardListenerHandles.push(handle));
+    keyboard
+      .addListener('keyboardWillHide', () => {
+        Log.log('iOS keyboard will hide');
+        this._iosKeyboardHeight = 0;
+        this._iosViewportHeightBeforeKeyboard = 0;
+        this._iosKeyboardFrameUnreliable = false;
+        this._isIosKeyboardSettled = false;
+        this.document.body.classList.remove(BodyClass.isKeyboardVisible);
+        const root = this.document.documentElement;
+        this._setCssVar(root, CSS_VAR_KEYBOARD_HEIGHT, '0px');
+        this._setCssVar(root, CSS_VAR_KEYBOARD_OVERLAY_OFFSET, '0px');
+        this._updateIOSKeyboardViewportVars();
+      })
+      .then((handle) => this._keyboardListenerHandles.push(handle));
 
     // Also handle focus changes while keyboard is already visible
     this._focusinListener = (event: FocusEvent): void => {
@@ -786,22 +819,34 @@ export class GlobalThemeService {
       isKeyboardFrameUnreliable: this._iosKeyboardFrameUnreliable,
     });
 
-    let hasChanged = this._setRootCssVar(
+    const root = this.document.documentElement;
+    let hasChanged = this._setCssVar(
+      // Not on <html>: a custom property there invalidates every element that
+      // could inherit it, which WebKit charges per node — measured at ~390ms per
+      // write on a 200-task list, on every frame of the keyboard animation
+      // (#9779). Only overlay panes read this one, so it lives on their
+      // container; the app shell gets a plain height below.
+      this._iosViewportVarTarget ?? root,
       CSS_VAR_VISUAL_VIEWPORT_HEIGHT,
       `${vars.visualViewportHeightPx}px`,
     );
     hasChanged =
-      this._setRootCssVar(
+      this._setCssVar(
+        root,
         CSS_VAR_KEYBOARD_OVERLAY_OFFSET,
         `${vars.keyboardOverlayOffsetPx}px`,
       ) || hasChanged;
     if (vars.correctedKeyboardHeightPx !== null) {
       hasChanged =
-        this._setRootCssVar(
+        this._setCssVar(
+          root,
           CSS_VAR_KEYBOARD_HEIGHT,
           `${vars.correctedKeyboardHeightPx}px`,
         ) || hasChanged;
     }
+    this._setIosShellHeight(
+      this._iosKeyboardHeight > 0 ? vars.visualViewportHeightPx : null,
+    );
 
     // Every notification costs a synthetic window resize, and each of those makes
     // CdkTextareaAutosize drop its caches and re-measure and every connected CDK
@@ -813,13 +858,54 @@ export class GlobalThemeService {
     }
   }
 
-  /** Writes a CSS variable on <html>; returns whether the value actually changed. */
-  private _setRootCssVar(name: string, value: string): boolean {
-    if (this._rootCssVarCache.get(name) === value) {
+  /**
+   * Sizes the app shell to the space left above the keyboard.
+   *
+   * A plain height on the one element that needs it, rather than a custom
+   * property the shell reads: the shell wraps the whole task list, so a
+   * variable it inherits costs a document-wide style recalc per write, while
+   * this costs one element plus the layout that has to happen anyway (#9779).
+   * Mirrors what `.app-container`'s stylesheet rule used to compute; passing
+   * null hands the element back to the stylesheet.
+   */
+  private _setIosShellHeight(visualViewportHeightPx: number | null): void {
+    const height =
+      visualViewportHeightPx === null
+        ? ''
+        : `calc(${visualViewportHeightPx}px - var(--safe-area-top))`;
+
+    if (!this._iosShellEl?.isConnected) {
+      this._iosShellEl = this.document.querySelector<HTMLElement>('.app-container');
+      // The remembered value describes the element we were writing to, so a
+      // different shell has to be read rather than assumed (a fresh one carries
+      // no inline height).
+      this._iosShellHeightCss = this._iosShellEl?.style.height ?? '';
+    }
+    const shell = this._iosShellEl;
+    if (!shell || height === this._iosShellHeightCss) {
+      return;
+    }
+    this._iosShellHeightCss = height;
+
+    if (height) {
+      shell.style.setProperty('height', height);
+      shell.style.setProperty('min-height', height);
+    } else {
+      shell.style.removeProperty('height');
+      shell.style.removeProperty('min-height');
+    }
+  }
+
+  /**
+   * Writes a CSS variable, deduped; returns whether the value actually changed.
+   * Each variable has exactly one target, so the cache keys on the name alone.
+   */
+  private _setCssVar(target: HTMLElement, name: string, value: string): boolean {
+    if (this._cssVarCache.get(name) === value) {
       return false;
     }
-    this._rootCssVarCache.set(name, value);
-    this.document.documentElement.style.setProperty(name, value);
+    this._cssVarCache.set(name, value);
+    target.style.setProperty(name, value);
     return true;
   }
 

--- a/src/app/core/theme/global-theme.service.ts
+++ b/src/app/core/theme/global-theme.service.ts
@@ -222,8 +222,15 @@ export class GlobalThemeService {
   private readonly _cssVarCache = new Map<string, string>();
   // Where --visual-viewport-height goes; see _initIOSKeyboardHandling.
   private _iosViewportVarTarget: HTMLElement | null = null;
-  private _iosShellEl: HTMLElement | null = null;
-  private _iosShellHeightCss = '';
+
+  /**
+   * Height for the app shell while the iOS keyboard is open, as a CSS value, or
+   * null to leave the sizing to the stylesheet. Bound by app.component rather
+   * than published as a custom property: the shell wraps the whole task list,
+   * and a variable it inherits costs a document-wide style recalc on every
+   * frame of the keyboard animation (#9779).
+   */
+  readonly iosShellHeight = signal<string | null>(null);
 
   private _isCustomWindowTitleBarEnabled(): boolean {
     // The main process (main-window.ts) force-disables the custom title bar on
@@ -844,8 +851,10 @@ export class GlobalThemeService {
           `${vars.correctedKeyboardHeightPx}px`,
         ) || hasChanged;
     }
-    this._setIosShellHeight(
-      this._iosKeyboardHeight > 0 ? vars.visualViewportHeightPx : null,
+    this.iosShellHeight.set(
+      this._iosKeyboardHeight > 0
+        ? `calc(${vars.visualViewportHeightPx}px - var(--safe-area-top))`
+        : null,
     );
 
     // Every notification costs a synthetic window resize, and each of those makes
@@ -855,44 +864,6 @@ export class GlobalThemeService {
     // already written, so only tell the app about the ones that moved something.
     if (hasChanged) {
       this._notifyIOSViewportChange();
-    }
-  }
-
-  /**
-   * Sizes the app shell to the space left above the keyboard.
-   *
-   * A plain height on the one element that needs it, rather than a custom
-   * property the shell reads: the shell wraps the whole task list, so a
-   * variable it inherits costs a document-wide style recalc per write, while
-   * this costs one element plus the layout that has to happen anyway (#9779).
-   * Mirrors what `.app-container`'s stylesheet rule used to compute; passing
-   * null hands the element back to the stylesheet.
-   */
-  private _setIosShellHeight(visualViewportHeightPx: number | null): void {
-    const height =
-      visualViewportHeightPx === null
-        ? ''
-        : `calc(${visualViewportHeightPx}px - var(--safe-area-top))`;
-
-    if (!this._iosShellEl?.isConnected) {
-      this._iosShellEl = this.document.querySelector<HTMLElement>('.app-container');
-      // The remembered value describes the element we were writing to, so a
-      // different shell has to be read rather than assumed (a fresh one carries
-      // no inline height).
-      this._iosShellHeightCss = this._iosShellEl?.style.height ?? '';
-    }
-    const shell = this._iosShellEl;
-    if (!shell || height === this._iosShellHeightCss) {
-      return;
-    }
-    this._iosShellHeightCss = height;
-
-    if (height) {
-      shell.style.setProperty('height', height);
-      shell.style.setProperty('min-height', height);
-    } else {
-      shell.style.removeProperty('height');
-      shell.style.removeProperty('min-height');
     }
   }
 

--- a/src/app/core/theme/ios-keyboard-css-contract.spec.ts
+++ b/src/app/core/theme/ios-keyboard-css-contract.spec.ts
@@ -1,0 +1,116 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { MatDialog } from '@angular/material/dialog';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { BodyClass } from '../../app.constants';
+
+@Component({ selector: 'keyboard-contract-dialog', template: '<p>dialog</p>' })
+class KeyboardContractDialogComponent {}
+
+/**
+ * The rendered half of #9779's split: GlobalThemeService writes
+ * `--visual-viewport-height` on the CDK overlay container instead of `<html>`,
+ * which only holds up if the rules that consume it sit inside that container
+ * and inherit it. The service spec pins where the value is written; this pins
+ * that writing it there still produces the layout the stylesheet promises.
+ *
+ * Uses a real MatDialog and the real injected OverlayContainer — the same
+ * element the service targets — against the real global stylesheet (karma
+ * builds `src/styles.scss` into the test bundle). It therefore fails if a
+ * selector, a variable name, or CDK's overlay structure moves.
+ */
+describe('iOS keyboard CSS contract', () => {
+  const VIEWPORT_HEIGHT_PX = 500;
+  const SAFE_AREA_TOP_PX = 44;
+  const SAFE_AREA_BOTTOM_PX = 34;
+  const KEYBOARD_OVERLAY_OFFSET_PX = 300;
+
+  let overlayContainer: HTMLElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [provideNoopAnimations()] });
+    document.body.classList.add(
+      BodyClass.isNativeMobile,
+      BodyClass.isIOS,
+      BodyClass.isKeyboardVisible,
+    );
+    overlayContainer = TestBed.inject(OverlayContainer).getContainerElement();
+    // Insets come from capacitor-plugin-safe-area on the device; scoping them to
+    // the overlay layer keeps the expected numbers independent of the runner.
+    overlayContainer.style.setProperty('--safe-area-top', `${SAFE_AREA_TOP_PX}px`);
+    overlayContainer.style.setProperty('--safe-area-bottom', `${SAFE_AREA_BOTTOM_PX}px`);
+  });
+
+  afterEach(() => {
+    TestBed.inject(MatDialog).closeAll();
+    TestBed.tick();
+    document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+    document.documentElement.style.removeProperty('--keyboard-overlay-offset');
+    document.body.classList.remove(
+      BodyClass.isNativeMobile,
+      BodyClass.isIOS,
+      BodyClass.isKeyboardVisible,
+    );
+  });
+
+  const openDialog = (): { pane: HTMLElement; wrapper: HTMLElement } => {
+    TestBed.inject(MatDialog).open(KeyboardContractDialogComponent);
+    TestBed.tick();
+    const pane = overlayContainer.querySelector<HTMLElement>('.mat-mdc-dialog-panel');
+    const wrapper = overlayContainer.querySelector<HTMLElement>(
+      '.cdk-global-overlay-wrapper',
+    );
+    if (!pane || !wrapper) {
+      throw new Error('CDK no longer nests the dialog panel in the overlay container');
+    }
+    return { pane, wrapper };
+  };
+
+  /** What GlobalThemeService._updateIOSKeyboardViewportVars() writes. */
+  const publishViewportHeight = (px: number): void =>
+    overlayContainer.style.setProperty('--visual-viewport-height', `${px}px`);
+
+  it('sizes a dialog panel from the overlay container variable', () => {
+    publishViewportHeight(VIEWPORT_HEIGHT_PX);
+
+    expect(getComputedStyle(openDialog().pane).maxHeight).toBe(
+      `${VIEWPORT_HEIGHT_PX - SAFE_AREA_TOP_PX - SAFE_AREA_BOTTOM_PX}px`,
+    );
+  });
+
+  it('falls back to the full window when nothing wrote the variable', () => {
+    expect(getComputedStyle(openDialog().pane).maxHeight).toBe(
+      `${window.innerHeight - SAFE_AREA_TOP_PX - SAFE_AREA_BOTTOM_PX}px`,
+    );
+  });
+
+  // This one stays on <html>: it changes at most once per open/close, and the
+  // add-task bar reads it from outside the overlay layer.
+  it('reserves keyboard space in the overlay wrapper from the root variable', () => {
+    document.documentElement.style.setProperty(
+      '--keyboard-overlay-offset',
+      `${KEYBOARD_OVERLAY_OFFSET_PX}px`,
+    );
+
+    expect(getComputedStyle(openDialog().wrapper).paddingBottom).toBe(
+      `${SAFE_AREA_BOTTOM_PX + KEYBOARD_OVERLAY_OFFSET_PX}px`,
+    );
+  });
+
+  // Why app-shell code takes the height from GlobalThemeService.iosShellHeight
+  // instead of this variable: outside the overlay layer it is still the 100vh
+  // default from _css-variables.scss.
+  it('does not reach elements outside the overlay container', () => {
+    publishViewportHeight(VIEWPORT_HEIGHT_PX);
+    const outside = document.createElement('div');
+    outside.style.setProperty('height', 'var(--visual-viewport-height)');
+    document.body.appendChild(outside);
+
+    try {
+      expect(getComputedStyle(outside).height).toBe(`${window.innerHeight}px`);
+    } finally {
+      outside.remove();
+    }
+  });
+});

--- a/src/app/core/theme/ios-keyboard-settle.util.spec.ts
+++ b/src/app/core/theme/ios-keyboard-settle.util.spec.ts
@@ -1,0 +1,85 @@
+import { fakeAsync, tick } from '@angular/core/testing';
+import { createOneShotSettle } from './ios-keyboard-settle.util';
+
+const TIMEOUT = 400;
+
+describe('createOneShotSettle()', () => {
+  let action: jasmine.Spy;
+
+  beforeEach(() => (action = jasmine.createSpy('action')));
+
+  it('runs the armed action when the did event arrives', () => {
+    const settle = createOneShotSettle(TIMEOUT);
+    settle.arm(action);
+
+    settle.run();
+
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  // The whole point: iOS drops the did event, and the released code then left
+  // the fixed bar behind the keyboard for the rest of the session (#9779).
+  it('runs it on the timeout when the did event never arrives', fakeAsync(() => {
+    const settle = createOneShotSettle(TIMEOUT);
+    settle.arm(action);
+
+    expect(action).not.toHaveBeenCalled();
+
+    tick(TIMEOUT);
+
+    expect(action).toHaveBeenCalledTimes(1);
+  }));
+
+  it('runs it once when the did event arrives late', fakeAsync(() => {
+    const settle = createOneShotSettle(TIMEOUT);
+    settle.arm(action);
+    tick(TIMEOUT);
+
+    settle.run();
+
+    expect(action).toHaveBeenCalledTimes(1);
+  }));
+
+  it('does not run it again on the timeout after the did event', fakeAsync(() => {
+    const settle = createOneShotSettle(TIMEOUT);
+    settle.arm(action);
+    settle.run();
+
+    tick(TIMEOUT);
+
+    expect(action).toHaveBeenCalledTimes(1);
+  }));
+
+  it('drops a cancelled action, timeout included', fakeAsync(() => {
+    const settle = createOneShotSettle(TIMEOUT);
+    settle.arm(action);
+
+    settle.cancel();
+    tick(TIMEOUT);
+    settle.run();
+
+    expect(action).not.toHaveBeenCalled();
+  }));
+
+  it('replaces an action that is armed again before it ran', fakeAsync(() => {
+    const settle = createOneShotSettle(TIMEOUT);
+    const replacement = jasmine.createSpy('replacement');
+    settle.arm(action);
+
+    settle.arm(replacement);
+    tick(TIMEOUT);
+
+    expect(action).not.toHaveBeenCalled();
+    expect(replacement).toHaveBeenCalledTimes(1);
+  }));
+
+  it('does nothing when nothing is armed', fakeAsync(() => {
+    const settle = createOneShotSettle(TIMEOUT);
+
+    expect(() => {
+      settle.run();
+      settle.cancel();
+      tick(TIMEOUT);
+    }).not.toThrow();
+  }));
+});

--- a/src/app/core/theme/ios-keyboard-settle.util.ts
+++ b/src/app/core/theme/ios-keyboard-settle.util.ts
@@ -1,0 +1,42 @@
+/**
+ * iOS brackets each keyboard animation with a `will…`/`did…` pair and drops the
+ * `did` half often enough that nothing may hang on it alone: with
+ * `keyboardDidShow` missing, the fixed add-task bar stayed behind the keyboard
+ * for the rest of the session rather than for a few frames (#9779).
+ *
+ * So the `will` event arms a one-shot action and the `did` event runs it — but
+ * a timeout runs it too, and whichever gets there first wins. Exactly once
+ * either way, so a late `did` after the timeout is a no-op.
+ */
+export interface OneShotSettle {
+  /** Animation starting: `action` runs on the next `run()`, or after the timeout. */
+  arm(action: () => void): void;
+  /** The `did` event arrived — run the armed action now, if it has not run. */
+  run(): void;
+  /** Animation superseded or cancelled — drop the armed action without running it. */
+  cancel(): void;
+}
+
+export const createOneShotSettle = (timeoutMs: number): OneShotSettle => {
+  let timeout: number | undefined;
+  let action: (() => void) | null = null;
+
+  /** Disarms and hands back whatever was armed, so every path runs at most once. */
+  const take = (): (() => void) | null => {
+    window.clearTimeout(timeout);
+    timeout = undefined;
+    const armed = action;
+    action = null;
+    return armed;
+  };
+
+  return {
+    arm: (next: () => void): void => {
+      take();
+      action = next;
+      timeout = window.setTimeout(() => take()?.(), timeoutMs);
+    },
+    run: (): void => take()?.(),
+    cancel: (): void => void take(),
+  };
+};

--- a/src/app/core/theme/ios-keyboard-viewport-vars.util.spec.ts
+++ b/src/app/core/theme/ios-keyboard-viewport-vars.util.spec.ts
@@ -107,6 +107,20 @@ describe('computeIosKeyboardViewportVars()', () => {
       ).toBe(BASE * 0.6);
     });
 
+    // The obscured area moves on every frame of the shrink, and --keyboard-height
+    // has to stay on :root for its non-overlay consumers — so correcting before
+    // the resize settles is a root write per animation frame (#9779).
+    it('holds the correction until the resize has settled', () => {
+      expect(
+        compute({
+          keyboardHeight: BASE * 0.6,
+          visualViewportHeight: BASE - 320,
+          isKeyboardFrameUnreliable: true,
+          isKeyboardSettled: false,
+        }).correctedKeyboardHeightPx,
+      ).toBeNull();
+    });
+
     it('leaves a well-behaved frame alone', () => {
       expect(
         compute({

--- a/src/app/core/theme/ios-keyboard-viewport-vars.util.spec.ts
+++ b/src/app/core/theme/ios-keyboard-viewport-vars.util.spec.ts
@@ -1,0 +1,129 @@
+import { computeIosKeyboardViewportVars } from './ios-keyboard-viewport-vars.util';
+
+const BASE = 800;
+const KEYBOARD = 300;
+
+const compute = (
+  overrides: Partial<Parameters<typeof computeIosKeyboardViewportVars>[0]> = {},
+): ReturnType<typeof computeIosKeyboardViewportVars> =>
+  computeIosKeyboardViewportVars({
+    keyboardHeight: KEYBOARD,
+    baseHeight: BASE,
+    visualViewportHeight: BASE,
+    isKeyboardSettled: false,
+    isKeyboardFrameUnreliable: false,
+    ...overrides,
+  });
+
+describe('computeIosKeyboardViewportVars()', () => {
+  it('reports the measured viewport and no offset while the keyboard is hidden', () => {
+    expect(
+      compute({ keyboardHeight: 0, visualViewportHeight: BASE, baseHeight: BASE }),
+    ).toEqual({
+      visualViewportHeightPx: BASE,
+      keyboardOverlayOffsetPx: 0,
+      correctedKeyboardHeightPx: null,
+    });
+  });
+
+  // #9779: predicting the shrink here lifts the fixed add-task bar by a whole
+  // keyboard height, and the measured resize a few frames later drops it back.
+  it('does not act on the reported frame before the show animation settles', () => {
+    expect(compute({ isKeyboardSettled: false })).toEqual({
+      visualViewportHeightPx: BASE,
+      keyboardOverlayOffsetPx: 0,
+      correctedKeyboardHeightPx: null,
+    });
+  });
+
+  it('follows the viewport once the web view has resized around the keyboard', () => {
+    expect(
+      compute({ visualViewportHeight: BASE - KEYBOARD, isKeyboardSettled: true }),
+    ).toEqual({
+      visualViewportHeightPx: BASE - KEYBOARD,
+      keyboardOverlayOffsetPx: 0,
+      correctedKeyboardHeightPx: null,
+    });
+  });
+
+  it('follows the viewport even mid-animation, before it settles', () => {
+    expect(
+      compute({ visualViewportHeight: BASE - KEYBOARD, isKeyboardSettled: false }),
+    ).toEqual({
+      visualViewportHeightPx: BASE - KEYBOARD,
+      keyboardOverlayOffsetPx: 0,
+      correctedKeyboardHeightPx: null,
+    });
+  });
+
+  it('offsets a settled keyboard that never resized the web view', () => {
+    expect(compute({ isKeyboardSettled: true })).toEqual({
+      visualViewportHeightPx: BASE - KEYBOARD,
+      keyboardOverlayOffsetPx: KEYBOARD,
+      correctedKeyboardHeightPx: null,
+    });
+  });
+
+  it('treats a sub-epsilon viewport difference as noise, not a resize', () => {
+    expect(
+      compute({ visualViewportHeight: BASE - 0.5, isKeyboardSettled: true }),
+    ).toEqual({
+      visualViewportHeightPx: BASE - KEYBOARD,
+      keyboardOverlayOffsetPx: KEYBOARD,
+      correctedKeyboardHeightPx: null,
+    });
+  });
+
+  it('has no viewport to follow when visualViewport is unsupported', () => {
+    expect(compute({ visualViewportHeight: undefined, isKeyboardSettled: true })).toEqual(
+      {
+        visualViewportHeightPx: BASE - KEYBOARD,
+        keyboardOverlayOffsetPx: KEYBOARD,
+        correctedKeyboardHeightPx: null,
+      },
+    );
+  });
+
+  describe('bogus keyboard frames (#8778)', () => {
+    it('corrects --keyboard-height to the measured obscured area', () => {
+      expect(
+        compute({
+          keyboardHeight: BASE * 0.6, // already clamped by the caller
+          visualViewportHeight: BASE - 320,
+          isKeyboardFrameUnreliable: true,
+          isKeyboardSettled: true,
+        }).correctedKeyboardHeightPx,
+      ).toBe(320);
+    });
+
+    it('keeps the clamp on the measured value', () => {
+      expect(
+        compute({
+          keyboardHeight: BASE * 0.6,
+          visualViewportHeight: 100,
+          isKeyboardFrameUnreliable: true,
+          isKeyboardSettled: true,
+        }).correctedKeyboardHeightPx,
+      ).toBe(BASE * 0.6);
+    });
+
+    it('leaves a well-behaved frame alone', () => {
+      expect(
+        compute({
+          visualViewportHeight: BASE - KEYBOARD,
+          isKeyboardFrameUnreliable: false,
+          isKeyboardSettled: true,
+        }).correctedKeyboardHeightPx,
+      ).toBeNull();
+    });
+
+    it('waits for a measurement before correcting anything', () => {
+      expect(
+        compute({
+          isKeyboardFrameUnreliable: true,
+          isKeyboardSettled: true,
+        }).correctedKeyboardHeightPx,
+      ).toBeNull();
+    });
+  });
+});

--- a/src/app/core/theme/ios-keyboard-viewport-vars.util.ts
+++ b/src/app/core/theme/ios-keyboard-viewport-vars.util.ts
@@ -1,0 +1,110 @@
+/**
+ * Pure computation behind the iOS keyboard layout CSS variables
+ * (`--visual-viewport-height`, `--keyboard-overlay-offset`, `--keyboard-height`).
+ *
+ * Kept out of GlobalThemeService so the ordering rules below — which are the
+ * whole reason the add-task bar does or does not jump when the keyboard opens
+ * (#9779) — are testable without a device.
+ */
+
+import { sanitizeIosKeyboardHeight } from './sanitize-ios-keyboard-height.util';
+
+/**
+ * Below this difference a smaller visual viewport is measurement noise (URL
+ * bar, rounding), not the keyboard.
+ */
+export const VIEWPORT_RESIZE_EPSILON_PX = 1;
+
+export interface IosKeyboardViewportInput {
+  /** Sanitized keyboard height from the Capacitor plugin; 0 while hidden. */
+  keyboardHeight: number;
+  /** Viewport height captured before the keyboard appeared; 0 when unknown. */
+  baseHeight: number;
+  /** `window.visualViewport.height`, or undefined where unsupported. */
+  visualViewportHeight?: number;
+  /**
+   * True once `keyboardDidShow` fired, i.e. the show animation finished and the
+   * web view has had its chance to resize.
+   */
+  isKeyboardSettled: boolean;
+  /** True when the plugin reported an implausible frame that had to be clamped (#8778). */
+  isKeyboardFrameUnreliable: boolean;
+}
+
+export interface IosKeyboardViewportVars {
+  visualViewportHeightPx: number;
+  keyboardOverlayOffsetPx: number;
+  /**
+   * Replacement for `--keyboard-height` when the plugin's frame was bogus and
+   * the measured obscured area is the better number; null leaves it untouched.
+   */
+  correctedKeyboardHeightPx: number | null;
+}
+
+/** True when the visual viewport has actually shrunk around the keyboard. */
+export const isVisualViewportResizedForKeyboard = (
+  isKeyboardVisible: boolean,
+  baseHeight: number,
+  visualViewportHeight?: number,
+): visualViewportHeight is number =>
+  isKeyboardVisible &&
+  visualViewportHeight !== undefined &&
+  visualViewportHeight < baseHeight - VIEWPORT_RESIZE_EPSILON_PX;
+
+export const computeIosKeyboardViewportVars = ({
+  keyboardHeight,
+  baseHeight,
+  visualViewportHeight,
+  isKeyboardSettled,
+  isKeyboardFrameUnreliable,
+}: IosKeyboardViewportInput): IosKeyboardViewportVars => {
+  const isKeyboardVisible = keyboardHeight > 0;
+  const isMeasured = isVisualViewportResizedForKeyboard(
+    isKeyboardVisible,
+    baseHeight,
+    visualViewportHeight,
+  );
+
+  if (!isKeyboardVisible) {
+    return {
+      visualViewportHeightPx: Math.max(0, visualViewportHeight ?? baseHeight),
+      keyboardOverlayOffsetPx: 0,
+      correctedKeyboardHeightPx: null,
+    };
+  }
+
+  if (isMeasured) {
+    return {
+      visualViewportHeightPx: Math.max(0, visualViewportHeight),
+      // The web view already shrank around the keyboard, so a fixed element at
+      // `bottom: 0` sits above it — offsetting again would move it twice (#8778).
+      keyboardOverlayOffsetPx: 0,
+      correctedKeyboardHeightPx: isKeyboardFrameUnreliable
+        ? sanitizeIosKeyboardHeight(baseHeight - visualViewportHeight, baseHeight)
+        : null,
+    };
+  }
+
+  // Keyboard up, viewport not (yet) shrunk. Under Capacitor's `resize: 'native'`
+  // — the mode this app configures — the shrink is still on its way, and acting
+  // on the plugin's frame here is a prediction: it lifts the fixed add-task bar
+  // by a whole keyboard height and shrinks the app shell, only for the measured
+  // resize a few frames later to undo both. With `transition: bottom` on the bar
+  // that prediction is what the user sees as the bar flying up and dropping back
+  // (#9779). So hold the measured values until the show animation is done; only
+  // a keyboard that has settled without resizing the web view (non-resizing iOS
+  // modes) gets the frame-derived offset it needs.
+  if (!isKeyboardSettled) {
+    return {
+      visualViewportHeightPx: Math.max(0, visualViewportHeight ?? baseHeight),
+      keyboardOverlayOffsetPx: 0,
+      correctedKeyboardHeightPx: null,
+    };
+  }
+
+  return {
+    visualViewportHeightPx: Math.max(0, baseHeight - keyboardHeight),
+    keyboardOverlayOffsetPx: keyboardHeight,
+    correctedKeyboardHeightPx: null,
+  };
+};

--- a/src/app/core/theme/ios-keyboard-viewport-vars.util.ts
+++ b/src/app/core/theme/ios-keyboard-viewport-vars.util.ts
@@ -79,9 +79,15 @@ export const computeIosKeyboardViewportVars = ({
       // The web view already shrank around the keyboard, so a fixed element at
       // `bottom: 0` sits above it — offsetting again would move it twice (#8778).
       keyboardOverlayOffsetPx: 0,
-      correctedKeyboardHeightPx: isKeyboardFrameUnreliable
-        ? sanitizeIosKeyboardHeight(baseHeight - visualViewportHeight, baseHeight)
-        : null,
+      // Settled only: the obscured area changes on every frame of the shrink, and
+      // `--keyboard-height` has to live on `:root` for its non-overlay consumers,
+      // so correcting mid-animation reintroduces the per-frame root write this
+      // all exists to avoid (#9779). The clamped frame from `keyboardWillShow`
+      // holds until then, which is the pre-#8778 behaviour and already safe.
+      correctedKeyboardHeightPx:
+        isKeyboardFrameUnreliable && isKeyboardSettled
+          ? sanitizeIosKeyboardHeight(baseHeight - visualViewportHeight, baseHeight)
+          : null,
     };
   }
 

--- a/src/app/features/bottom-panel/bottom-panel-container.component.ts
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.ts
@@ -475,6 +475,12 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     if ('visualViewport' in window && window.visualViewport) {
       window.visualViewport.addEventListener('resize', this._boundOnViewportResize);
     }
+    // Also the window event: on iOS the keyboard CSS variables can settle after
+    // the last visualViewport resize (GlobalThemeService only knows whether the
+    // web view resized once `keyboardDidShow` fired, #9779) and it announces
+    // that with a synthetic window resize. Without this the sheet would keep the
+    // offset it computed mid-animation.
+    window.addEventListener('resize', this._boundOnViewportResize);
 
     this._bodyClassObserver = new MutationObserver(() => this._onViewportResize());
     this._bodyClassObserver.observe(document.body, {
@@ -484,8 +490,9 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
   }
 
   private _removeKeyboardWatcher(): void {
-    if (typeof window !== 'undefined' && window.visualViewport) {
-      window.visualViewport.removeEventListener('resize', this._boundOnViewportResize);
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('resize', this._boundOnViewportResize);
+      window.visualViewport?.removeEventListener('resize', this._boundOnViewportResize);
     }
     this._bodyClassObserver?.disconnect();
     this._bodyClassObserver = null;

--- a/src/app/features/bottom-panel/bottom-panel-container.component.ts
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.ts
@@ -521,15 +521,23 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
 
     const windowHeight = window.innerHeight;
     const viewportHeight = window.visualViewport?.height ?? windowHeight;
-    const rootStyle = getComputedStyle(document.documentElement);
+
+    const container = this._getSheetContainer();
+    if (!container) return;
+
+    // Read the keyboard variables off the sheet itself, not <html>: the sheet is
+    // a CDK overlay, and --visual-viewport-height is set on the overlay
+    // container so writing it does not restyle the whole document (#9779).
+    // Inheritance makes this equivalent wherever a variable is set above.
+    const keyboardStyle = getComputedStyle(container);
     const cssVisualViewportHeight = this._parseCssPx(
-      rootStyle.getPropertyValue(CSS_VAR_VISUAL_VIEWPORT_HEIGHT),
+      keyboardStyle.getPropertyValue(CSS_VAR_VISUAL_VIEWPORT_HEIGHT),
     );
     const cssKeyboardHeight = this._parseCssPx(
-      rootStyle.getPropertyValue(CSS_VAR_KEYBOARD_HEIGHT),
+      keyboardStyle.getPropertyValue(CSS_VAR_KEYBOARD_HEIGHT),
     );
     const cssKeyboardOverlayOffset = this._parseCssPx(
-      rootStyle.getPropertyValue(CSS_VAR_KEYBOARD_OVERLAY_OFFSET),
+      keyboardStyle.getPropertyValue(CSS_VAR_KEYBOARD_OVERLAY_OFFSET),
     );
     const keyboardHeight = Math.max(windowHeight - viewportHeight, cssKeyboardHeight);
     const isIOS = document.body.classList.contains(BodyClass.isIOS);
@@ -537,9 +545,6 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     const isKeyboardVisible =
       document.body.classList.contains(BodyClass.isKeyboardVisible) ||
       keyboardHeight > KEYBOARD_DETECT_THRESHOLD;
-
-    const container = this._getSheetContainer();
-    if (!container) return;
 
     if (isKeyboardVisible) {
       this._captureKeyboardAdjustedStyles(container);

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { Store } from '@ngrx/store';
 import { MatDialog } from '@angular/material/dialog';
@@ -28,6 +28,7 @@ import { getDbDateStr } from '../../../util/get-db-date-str';
 import { TaskRepeatCfgService } from '../../task-repeat-cfg/task-repeat-cfg.service';
 import { SS } from '../../../core/persistence/storage-keys.const';
 import { BodyClass } from '../../../app.constants';
+import { IS_ANDROID_WEB_VIEW_TOKEN } from '../../../util/is-android-web-view';
 
 type ProjectServiceSignals = {
   list$: Observable<Project[]>;
@@ -1488,6 +1489,111 @@ describe('AddTaskBarComponent', () => {
 
       expect(noteEl.hasAttribute('placeholder')).toBe(false);
       expect(noteEl.getAttribute('aria-label')).toBe(emptyLabel);
+    });
+  });
+
+  // Only ever spied on elsewhere in this file, so the two paths below — one of
+  // them the blur → focus cycle the Android IME depends on — had no coverage.
+  describe('focusInput()', () => {
+    const getInput = (
+      f: ComponentFixture<AddTaskBarComponent>,
+    ): HTMLTextAreaElement =>
+      f.debugElement.nativeElement.querySelector('.main-input') as HTMLTextAreaElement;
+
+    it('focuses the field synchronously', () => {
+      fixture.detectChanges();
+      const input = getInput(fixture);
+      input.blur();
+
+      component.focusInput();
+
+      expect(document.activeElement).toBe(input);
+    });
+
+    it('selects the existing text when asked', () => {
+      fixture.detectChanges();
+      const input = getInput(fixture);
+      input.value = 'water the plants';
+      input.dispatchEvent(new Event('input'));
+
+      component.focusInput(true);
+
+      expect(input.selectionStart).toBe(0);
+      expect(input.selectionEnd).toBe('water the plants'.length);
+    });
+
+    // #9779: a second focus() on an already-focused field re-fires focusin, and
+    // the global handler scrolls it into view again mid keyboard animation.
+    it('does not re-focus a field that already took focus', fakeAsync(() => {
+      fixture.detectChanges();
+      const focusSpy = spyOn(getInput(fixture), 'focus').and.callThrough();
+
+      component.focusInput();
+      const callsBeforeRetry = focusSpy.calls.count();
+      tick(50);
+
+      expect(focusSpy.calls.count()).toBe(callsBeforeRetry);
+      flush();
+    }));
+
+    it('retries once when the web view dropped the focus', fakeAsync(() => {
+      fixture.detectChanges();
+      const input = getInput(fixture);
+
+      component.focusInput();
+      input.blur();
+      tick(50);
+
+      expect(document.activeElement).toBe(input);
+      flush();
+    }));
+
+    describe('on the Android web view', () => {
+      let androidFixture: ComponentFixture<AddTaskBarComponent>;
+
+      beforeEach(async () => {
+        TestBed.resetTestingModule();
+        await TestBed.configureTestingModule({
+          imports: [AddTaskBarComponent, NoopAnimationsModule, TranslateModule.forRoot()],
+          providers: [
+            { provide: TaskService, useValue: mockTaskService },
+            { provide: WorkContextService, useValue: mockWorkContextService },
+            { provide: ProjectService, useValue: mockProjectService },
+            { provide: TagService, useValue: mockTagService },
+            { provide: GlobalConfigService, useValue: mockGlobalConfigService },
+            { provide: DateTimeFormatService, useValue: mockDateTimeFormatService },
+            { provide: DateService, useValue: mockDateService },
+            { provide: Store, useValue: mockStore },
+            { provide: MatDialog, useValue: mockMatDialog },
+            { provide: SnackService, useValue: mockSnackService },
+            {
+              provide: AddTaskBarIssueSearchService,
+              useValue: mockAddTaskBarIssueSearchService,
+            },
+            { provide: IS_ANDROID_WEB_VIEW_TOKEN, useValue: true },
+          ],
+        }).compileComponents();
+        androidFixture = TestBed.createComponent(AddTaskBarComponent);
+        androidFixture.detectChanges();
+      });
+
+      // The IME only comes up reliably after this repeated cycle, so it stays
+      // exactly as it was while the other platforms moved to a guarded retry.
+      it('keeps the repeated blur to focus cycle that raises the IME', fakeAsync(() => {
+        const input = getInput(androidFixture);
+        const focusSpy = spyOn(input, 'focus').and.callThrough();
+
+        androidFixture.componentInstance.focusInput();
+        expect(focusSpy).toHaveBeenCalledTimes(1);
+
+        tick(0);
+        expect(focusSpy).toHaveBeenCalledTimes(2);
+
+        tick(200);
+        expect(focusSpy).toHaveBeenCalledTimes(3);
+        expect(document.activeElement).toBe(input);
+        flush();
+      }));
     });
   });
 });

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -1495,9 +1495,7 @@ describe('AddTaskBarComponent', () => {
   // Only ever spied on elsewhere in this file, so the two paths below — one of
   // them the blur → focus cycle the Android IME depends on — had no coverage.
   describe('focusInput()', () => {
-    const getInput = (
-      f: ComponentFixture<AddTaskBarComponent>,
-    ): HTMLTextAreaElement =>
+    const getInput = (f: ComponentFixture<AddTaskBarComponent>): HTMLTextAreaElement =>
       f.debugElement.nativeElement.querySelector('.main-input') as HTMLTextAreaElement;
 
     it('focuses the field synchronously', () => {

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -45,7 +45,7 @@ import {
   timeout,
   withLatestFrom,
 } from 'rxjs/operators';
-import { IS_ANDROID_WEB_VIEW } from '../../../util/is-android-web-view';
+import { IS_ANDROID_WEB_VIEW_TOKEN } from '../../../util/is-android-web-view';
 import { BehaviorSubject, combineLatest, from, Observable } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { DialogConfirmComponent } from '../../../ui/dialog-confirm/dialog-confirm.component';
@@ -331,6 +331,10 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
     this.highlightSegments();
     this.syncHighlightScroll();
   });
+
+  // Injected rather than read from the constant so the two focus paths below
+  // are reachable from tests (see IS_ANDROID_WEB_VIEW_TOKEN).
+  private readonly _isAndroidWebView = inject(IS_ANDROID_WEB_VIEW_TOKEN);
 
   private _focusTimeout?: number;
   private _autocompleteTimeout?: number;
@@ -1022,7 +1026,7 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
     document.body.focus();
     this.inputEl()?.nativeElement.focus();
 
-    if (IS_ANDROID_WEB_VIEW) {
+    if (this._isAndroidWebView) {
       // Unchanged: this web view needs the repeated blur → focus cycle to raise
       // the IME reliably, and it has no iOS focusin scroll handler to disturb.
       window.setTimeout(() => this.inputEl()?.nativeElement.focus());

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -1008,31 +1008,34 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
       window.clearTimeout(this._focusTimeout);
     }
 
-    document.body.focus();
-    this.inputEl()?.nativeElement.focus();
-    window.setTimeout(() => this.inputEl()?.nativeElement.focus());
+    const focus = (): void => {
+      const inputElement = this.inputEl()?.nativeElement;
+      if (!inputElement) {
+        return;
+      }
+      inputElement.focus();
+      if (selectAll) {
+        inputElement.select();
+      }
+    };
 
-    // Set new timeout
-    if (IS_ANDROID_WEB_VIEW) {
-      this._focusTimeout = window.setTimeout(() => {
-        document.body.focus();
-        this.inputEl()?.nativeElement.focus();
-        if (selectAll) {
-          this.inputEl()?.nativeElement.select();
-        }
+    document.body.focus();
+    focus();
+
+    // A web view can drop a focus() issued while the bar is still animating in,
+    // so retry once. Only when the field really did not take focus, though:
+    // re-focusing an already-focused input re-fires the global focusin handler,
+    // which re-runs its scroll-into-view in the middle of the keyboard
+    // animation — one of the sources of the jumping in #9779.
+    this._focusTimeout = window.setTimeout(
+      () => {
         this._focusTimeout = undefined;
-      }, 200);
-    } else {
-      this._focusTimeout = window.setTimeout(() => {
-        const inputElement = this.inputEl()?.nativeElement;
-        if (inputElement) {
-          inputElement.focus();
-          if (selectAll) {
-            inputElement.select();
-          }
+        if (document.activeElement !== this.inputEl()?.nativeElement) {
+          focus();
         }
-      }, 50);
-    }
+      },
+      IS_ANDROID_WEB_VIEW ? 200 : 50,
+    );
   }
 
   toggleNote(): void {

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -1020,22 +1020,34 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
     };
 
     document.body.focus();
-    focus();
+    this.inputEl()?.nativeElement.focus();
 
-    // A web view can drop a focus() issued while the bar is still animating in,
-    // so retry once. Only when the field really did not take focus, though:
-    // re-focusing an already-focused input re-fires the global focusin handler,
-    // which re-runs its scroll-into-view in the middle of the keyboard
-    // animation — one of the sources of the jumping in #9779.
-    this._focusTimeout = window.setTimeout(
-      () => {
+    if (IS_ANDROID_WEB_VIEW) {
+      // Unchanged: this web view needs the repeated blur → focus cycle to raise
+      // the IME reliably, and it has no iOS focusin scroll handler to disturb.
+      window.setTimeout(() => this.inputEl()?.nativeElement.focus());
+      this._focusTimeout = window.setTimeout(() => {
+        document.body.focus();
+        focus();
         this._focusTimeout = undefined;
-        if (document.activeElement !== this.inputEl()?.nativeElement) {
-          focus();
-        }
-      },
-      IS_ANDROID_WEB_VIEW ? 200 : 50,
-    );
+      }, 200);
+      return;
+    }
+
+    if (selectAll) {
+      this.inputEl()?.nativeElement.select();
+    }
+    // A web view can drop a focus() issued while the bar is still animating in,
+    // so retry once — but only when the field really did not take focus:
+    // re-focusing an already-focused input re-fires the global focusin handler,
+    // which re-runs its scroll-into-view in the middle of the iOS keyboard
+    // animation, one of the sources of the jumping in #9779.
+    this._focusTimeout = window.setTimeout(() => {
+      this._focusTimeout = undefined;
+      if (document.activeElement !== this.inputEl()?.nativeElement) {
+        focus();
+      }
+    }, 50);
   }
 
   toggleNote(): void {

--- a/src/styles/_css-variables.scss
+++ b/src/styles/_css-variables.scss
@@ -81,6 +81,12 @@
   // Keyboard height (set dynamically via JS)
   --keyboard-height: 0px;
   --keyboard-overlay-offset: 0px;
+  // Fallback only. On iOS the live value is written on `.cdk-overlay-container`,
+  // not here, because a custom property on :root restyles every element that
+  // could inherit it — the whole task list — on each frame of the keyboard
+  // animation (#9779). Rules outside the overlay layer therefore see 100vh:
+  // anything in the app shell that needs the live height gets it from
+  // GlobalThemeService (see `iosShellHeight`), not from this variable.
   --visual-viewport-height: 100vh;
 
   // -----------------------------


### PR DESCRIPTION
Fixes #9779 ("Performance Issue on iOS" — the add-task input is laggy and jumps around).

Two independent causes, both reproduced from the code rather than from a device.

## The jump

Under Capacitor's `resize: 'native'`, `keyboardWillShow` reports the keyboard height *before* the web view has resized around it. The app acted on that number immediately, lifting the fixed add-task bar by a whole keyboard height and shrinking the shell — then the measured resize a few frames later undid both. With `transition: bottom` on the bar, that prediction is exactly what the user sees as the bar flying up and dropping back.

Frame-derived values now wait for the measurement to settle. Two smaller contributors to the same symptom:

- `scrollIntoViewIfNeeded` was called on the focused input even when it sits in a `position: fixed` bar, where scrolling cannot move it — so it scrolled the task list behind it to an arbitrary offset instead.
- `focusInput()` re-focused an already-focused field on a 50ms retry, re-firing the global `focusin` handler and its scroll mid-animation. The retry now only fires if the field genuinely did not take focus. **The Android path is preserved verbatim** — that web view needs its blur→focus cycle.

## The lag

Writing a custom property to `:root` invalidates every element that could inherit it, and WebKit charges that per node, whether or not any rule consumes the variable. The keyboard animation did this every frame.

Measured on WebKit with a 200-task list (5,595 nodes):

| | before | after |
|---|---|---|
| WebKit, 200 tasks | 416.9 ms/frame | 1.1 ms/frame |
| Chromium, 200 tasks | 15.3 ms/frame | 0.04 ms/frame |

The cost breakdown showed it is the root write's inheritance invalidation, not layout: an unreferenced root custom property cost 1327 ms/write at that size, while an inline height on `.app-container` cost 0.1 ms. So `--visual-viewport-height` (the per-frame one) moved to the CDK overlay container, which is the only subtree that reads it, and the app shell height became a signal binding instead of a variable. `--keyboard-height` and `--keyboard-overlay-offset` stay on `:root` — they have consumers outside the overlay layer and change once per open/close, not per frame.

## Also fixed along the way

- **Both `keyboardDid…` events are now optional.** iOS drops them. `createOneShotSettle` states the rule once: the `will…` event arms a one-shot action, the `did…` event or a 400 ms timeout runs it, whichever is first, exactly once.
- **Field-to-field focus no longer subtracts the keyboard twice.** Moving between two inputs fires `willHide` then `willShow` while the web view is still shrunken, and the baseline was re-measured from that shrunken height — an 800 px shell became 185.6 px instead of 464 px.

## Verified

- Unit: 14,554 pass (+~100 new). Every fix is mutation-checked — reverting it fails a named spec.
- `ios-keyboard-css-contract.spec.ts` asserts the dialog sizing against the **real** stylesheet with a real `MatDialog` and the real injected `OverlayContainer`, so the variable-scoping change cannot silently stop reaching the panes.
- E2E (Playwright, incl. the WebKit smoke pass), `test:electron`, i18n and the production build all pass.

## Not verified

- **No iOS device run.** All keyboard timing is reasoned from the plugin contract and exercised against a fake plugin. This is the main gap.
- The `e2e/pwa/update-activation.spec.ts` failure seen on one run is being re-checked; this branch touches no service-worker, PWA or sync code, and that dialog fires from `InitialPwaUpdateCheckService` via a sync effect with an 8 s timeout.
- One review finding is deliberately left open: the synthetic resize is gated on whether our derived variables changed rather than on `visualViewport` itself, which narrows the signal in the settled non-resizing case. No reproduction, so no speculative fix.

## Risk

Everything here is presentation layer — no reducer, effect, persisted model, sync or op-log code — so the ceiling is wrong layout, not data loss. The one change that is **not** iOS-gated is `bottom-panel-container`, which now reads the keyboard variables off the sheet (a CDK overlay descendant, so inheritance makes it equivalent) instead of `<html>`. That path runs on Android, and no CI job exercises a real IME, so the bottom sheet with the keyboard up is the thing worth a manual look before this reaches the Play internal track.

https://claude.ai/code/session_01HohVQcY4jTvMAEstrETG1p
