### PR TITLE
Limit Docker logs in E2E workflows to prevent log overflow

### DIFF
--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -167,8 +167,8 @@ jobs:
       - name: Print Docker Logs on Failure
         if: ${{ failure() }}
         run: |
-          echo "=== WebDAV Logs ==="
-          docker compose logs webdav
+          echo "=== WebDAV Logs (last 400 lines) ==="
+          docker compose logs --tail=400 webdav
 
       - name: Stop Docker Services
         if: always()
@@ -242,8 +242,12 @@ jobs:
       - name: Print Docker Logs on Failure
         if: ${{ failure() }}
         run: |
-          echo "=== SuperSync Logs ==="
-          docker compose -f docker-compose.yaml -f docker-compose.supersync.yaml logs supersync webdav
+          # Bounded on purpose: the container runs with NODE_ENV=development, so Prisma
+          # logs every query. An unbounded dump was ~13k lines and pushed the Playwright
+          # failure out of the log tail the GitHub API and `gh run view --log-failed`
+          # return, leaving the actual failure unreadable.
+          echo "=== SuperSync Logs (last 400 lines per container) ==="
+          docker compose -f docker-compose.yaml -f docker-compose.supersync.yaml logs --tail=400 supersync webdav
 
       - name: Stop Docker Services
         if: always()

--- a/.github/workflows/e2e-sync-pr.yml
+++ b/.github/workflows/e2e-sync-pr.yml
@@ -190,8 +190,12 @@ jobs:
       - name: Print Docker Logs on Failure
         if: ${{ failure() }}
         run: |
-          echo "=== SuperSync Logs ==="
-          docker compose -f docker-compose.yaml -f docker-compose.supersync.yaml logs supersync webdav
+          # Bounded on purpose: the container runs with NODE_ENV=development, so Prisma
+          # logs every query. An unbounded dump was ~13k lines and pushed the Playwright
+          # failure out of the log tail the GitHub API and `gh run view --log-failed`
+          # return, leaving the actual failure unreadable.
+          echo "=== SuperSync Logs (last 400 lines per container) ==="
+          docker compose -f docker-compose.yaml -f docker-compose.supersync.yaml logs --tail=400 supersync webdav
 
       - name: Stop Docker Services
         if: always()
@@ -253,8 +257,8 @@ jobs:
       - name: Print Docker Logs on Failure
         if: ${{ failure() }}
         run: |
-          echo "=== WebDAV Logs ==="
-          docker compose logs webdav
+          echo "=== WebDAV Logs (last 400 lines) ==="
+          docker compose logs --tail=400 webdav
 
       - name: Stop Docker Services
         if: always()


### PR DESCRIPTION
## Problem

E2E test failures in the SuperSync workflows produce excessive Docker logs (~13k lines) because the container runs with `NODE_ENV=development`, causing Prisma to log every database query. This unbounded log output pushes the actual test failure out of the GitHub Actions log tail, making failures unreadable via the GitHub API and `gh run view --log-failed`.

## Solution

Add `--tail=400` flag to all `docker compose logs` commands in E2E workflows to limit output to the last 400 lines per container. This preserves enough context for debugging while keeping logs manageable and ensuring the actual failure remains visible.

Changes made:
- **e2e-scheduled.yml**: Limited WebDAV logs (line 170) and SuperSync logs (line 245) to last 400 lines
- **e2e-sync-pr.yml**: Limited SuperSync logs (line 193) and WebDAV logs (line 260) to last 400 lines
- Added explanatory comments in SuperSync log sections documenting the rationale for the bounded output

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] No documentation changes needed (workflow configuration only)
- [x] No code files modified
- [x] No tests affected
- [x] CI configuration change only

https://claude.ai/code/session_01TDABxhcjB5hqtPTAhcnYfh