### PR TITLE
feat(search): clearly highlight task after jumping to it from search #5476

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -269,7 +269,7 @@ export class AppComponent implements OnDestroy, AfterViewInit {
             focusItem: params.focusItem,
             url: window.location.pathname + window.location.search,
           });
-          this._focusElement(params.focusItem);
+          this._focusElement(params.focusItem, params.isFromSearch === 'true');
         }
       }),
     );
@@ -587,12 +587,19 @@ export class AppComponent implements OnDestroy, AfterViewInit {
    * since page load and animation time are not always equal
    * retrying until the rendered task row is available avoids missing focus targets
    */
-  private _focusElement(id: string): void {
+  private _focusElement(id: string, isFromSearch: boolean = false): void {
     recordSearchNavDebug('appComponent:focusElement', {
       taskId: id,
       url: window.location.pathname + window.location.search,
+      isFromSearch,
     });
     this.layoutService.focusTaskInViewWhenReady(id, (el) => {
+      // Only a search jump earns the attention highlight: `focusItem` is also set
+      // by reminder snacks, the tracked-task pill, issue creation and the calendar
+      // banner, where the user never asked "where is it". (#5476)
+      if (isFromSearch) {
+        this.layoutService.highlightTaskBriefly(el);
+      }
       recordSearchNavDebug('appComponent:focusElement:success', {
         taskId: id,
         url: window.location.pathname + window.location.search,

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -38,7 +38,6 @@ import { SyncTriggerService } from './imex/sync/sync-trigger.service';
 import { ActivatedRoute, RouterOutlet } from '@angular/router';
 import { concatMap, first, take } from 'rxjs/operators';
 
-import { IS_MOBILE } from './util/is-mobile';
 import { recordSearchNavDebug } from './util/search-nav-debug';
 import { warpAnimation, warpInAnimation } from './ui/animations/warp.ani';
 import {
@@ -599,12 +598,6 @@ export class AppComponent implements OnDestroy, AfterViewInit {
         url: window.location.pathname + window.location.search,
         matchedElementId: el.id,
       });
-      if (el && IS_MOBILE) {
-        el.classList.add('mobile-highlight-searched-item');
-        el.addEventListener('blur', () =>
-          el.classList.remove('mobile-highlight-searched-item'),
-        );
-      }
     });
   }
 }

--- a/src/app/core-ui/layout/layout.service.spec.ts
+++ b/src/app/core-ui/layout/layout.service.spec.ts
@@ -345,6 +345,7 @@ describe('LayoutService', () => {
       setTimeout(() => {
         expect(scrollContainer.scrollTop).toBe(20);
         expect(taskElement.focus).toHaveBeenCalledWith({ preventScroll: true });
+        expect(taskElement.classList.contains('highlight-searched-item')).toBeTrue();
         document.body.removeChild(scrollContainer);
         done();
       }, 400);
@@ -363,6 +364,33 @@ describe('LayoutService', () => {
 
       expect(onSuccess).not.toHaveBeenCalled();
       expect(onFailure).toHaveBeenCalledTimes(1);
+    }));
+  });
+
+  describe('highlightTaskBriefly', () => {
+    it('should add the highlight class and remove it after the duration', fakeAsync(() => {
+      const el = document.createElement('div');
+
+      service.highlightTaskBriefly(el);
+      expect(el.classList.contains('highlight-searched-item')).toBeTrue();
+
+      tick(3000);
+      expect(el.classList.contains('highlight-searched-item')).toBeFalse();
+    }));
+
+    it('should move the highlight to the latest element when re-triggered', fakeAsync(() => {
+      const first = document.createElement('div');
+      const second = document.createElement('div');
+
+      service.highlightTaskBriefly(first);
+      tick(1000);
+      service.highlightTaskBriefly(second);
+
+      expect(first.classList.contains('highlight-searched-item')).toBeFalse();
+      expect(second.classList.contains('highlight-searched-item')).toBeTrue();
+
+      tick(3000);
+      expect(second.classList.contains('highlight-searched-item')).toBeFalse();
     }));
   });
 });

--- a/src/app/core-ui/layout/layout.service.spec.ts
+++ b/src/app/core-ui/layout/layout.service.spec.ts
@@ -345,7 +345,7 @@ describe('LayoutService', () => {
       setTimeout(() => {
         expect(scrollContainer.scrollTop).toBe(20);
         expect(taskElement.focus).toHaveBeenCalledWith({ preventScroll: true });
-        expect(taskElement.classList.contains('highlight-searched-item')).toBeTrue();
+        expect(taskElement.classList.contains('highlight-searched-task')).toBeTrue();
         document.body.removeChild(scrollContainer);
         done();
       }, 400);
@@ -372,10 +372,10 @@ describe('LayoutService', () => {
       const el = document.createElement('div');
 
       service.highlightTaskBriefly(el);
-      expect(el.classList.contains('highlight-searched-item')).toBeTrue();
+      expect(el.classList.contains('highlight-searched-task')).toBeTrue();
 
       tick(3000);
-      expect(el.classList.contains('highlight-searched-item')).toBeFalse();
+      expect(el.classList.contains('highlight-searched-task')).toBeFalse();
     }));
 
     it('should move the highlight to the latest element when re-triggered', fakeAsync(() => {
@@ -386,11 +386,11 @@ describe('LayoutService', () => {
       tick(1000);
       service.highlightTaskBriefly(second);
 
-      expect(first.classList.contains('highlight-searched-item')).toBeFalse();
-      expect(second.classList.contains('highlight-searched-item')).toBeTrue();
+      expect(first.classList.contains('highlight-searched-task')).toBeFalse();
+      expect(second.classList.contains('highlight-searched-task')).toBeTrue();
 
       tick(3000);
-      expect(second.classList.contains('highlight-searched-item')).toBeFalse();
+      expect(second.classList.contains('highlight-searched-task')).toBeFalse();
     }));
   });
 });

--- a/src/app/core-ui/layout/layout.service.spec.ts
+++ b/src/app/core-ui/layout/layout.service.spec.ts
@@ -345,7 +345,10 @@ describe('LayoutService', () => {
       setTimeout(() => {
         expect(scrollContainer.scrollTop).toBe(20);
         expect(taskElement.focus).toHaveBeenCalledWith({ preventScroll: true });
-        expect(taskElement.classList.contains('highlight-searched-task')).toBeTrue();
+        // The reveal itself never highlights: `focusItem` is set by every
+        // navigation caller, and only a search jump earns the attention
+        // outline, so the caller opts in via `highlightTaskBriefly`. (#5476)
+        expect(taskElement.classList.contains('highlight-searched-task')).toBeFalse();
         document.body.removeChild(scrollContainer);
         done();
       }, 400);

--- a/src/app/core-ui/layout/layout.service.ts
+++ b/src/app/core-ui/layout/layout.service.ts
@@ -199,7 +199,6 @@ export class LayoutService {
 
     const el = this.focusTaskInViewIfPossible(taskId);
     if (el) {
-      this.highlightTaskBriefly(el);
       onSuccess?.(el);
       return;
     }
@@ -216,14 +215,18 @@ export class LayoutService {
   }
 
   /**
-   * Draws a temporary attention highlight on a task revealed by navigation
-   * (global search, notifications, tracked-task pill), so it stays findable
-   * even after the focus outline is gone. Mirrors the note reveal in
-   * NotesComponent, but deliberately uses its own class name: the note reveal
-   * strips `.highlight-searched-item` from every element in the document, and
-   * `focusItem` is a query param shared by tasks and notes, so a note reveal
-   * would otherwise cut a live task highlight short. Only one task is
-   * highlighted at a time. (#5476)
+   * Draws a temporary attention highlight on a task revealed by a SEARCH jump,
+   * so it stays findable even after the focus outline is gone. Deliberately not
+   * called from the reveal itself: `focusItem` is set by every navigation caller
+   * (reminder snacks, tracked-task pill, issue creation, calendar banner), and
+   * only search implies the user asked where the task is — so the callers opt in
+   * via `isFromSearch`.
+   *
+   * Mirrors the note reveal in NotesComponent, but deliberately uses its own
+   * class name: the note reveal strips `.highlight-searched-item` from every
+   * element in the document, and `focusItem` is a query param shared by tasks
+   * and notes, so a note reveal would otherwise cut a live task highlight short.
+   * Only one task is highlighted at a time. (#5476)
    */
   highlightTaskBriefly(el: HTMLElement): void {
     if (this._pendingTaskHighlightTimeout) {

--- a/src/app/core-ui/layout/layout.service.ts
+++ b/src/app/core-ui/layout/layout.service.ts
@@ -44,7 +44,7 @@ export class LayoutService {
   private static readonly _TASK_FOCUS_RETRY_DELAY = 250;
   private static readonly _TASK_FOCUS_MAX_RETRIES = 16;
   private static readonly _TASK_HIGHLIGHT_DURATION = 3000;
-  private static readonly _TASK_HIGHLIGHT_CLASS = 'highlight-searched-item';
+  private static readonly _TASK_HIGHLIGHT_CLASS = 'highlight-searched-task';
 
   private _store$ = inject<Store<LayoutState>>(Store);
   private _breakPointObserver = inject(BreakpointObserver);
@@ -219,7 +219,11 @@ export class LayoutService {
    * Draws a temporary attention highlight on a task revealed by navigation
    * (global search, notifications, tracked-task pill), so it stays findable
    * even after the focus outline is gone. Mirrors the note reveal in
-   * NotesComponent. Only one task is highlighted at a time. (#5476)
+   * NotesComponent, but deliberately uses its own class name: the note reveal
+   * strips `.highlight-searched-item` from every element in the document, and
+   * `focusItem` is a query param shared by tasks and notes, so a note reveal
+   * would otherwise cut a live task highlight short. Only one task is
+   * highlighted at a time. (#5476)
    */
   highlightTaskBriefly(el: HTMLElement): void {
     if (this._pendingTaskHighlightTimeout) {

--- a/src/app/core-ui/layout/layout.service.ts
+++ b/src/app/core-ui/layout/layout.service.ts
@@ -43,12 +43,16 @@ export class LayoutService {
   private static readonly _TASK_ACTION_DELAY = 50;
   private static readonly _TASK_FOCUS_RETRY_DELAY = 250;
   private static readonly _TASK_FOCUS_MAX_RETRIES = 16;
+  private static readonly _TASK_HIGHLIGHT_DURATION = 3000;
+  private static readonly _TASK_HIGHLIGHT_CLASS = 'highlight-searched-item';
 
   private _store$ = inject<Store<LayoutState>>(Store);
   private _breakPointObserver = inject(BreakpointObserver);
   private _previouslyFocusedElement: HTMLElement | null = null;
   private _pendingFocusTaskId: string | null = null; // store new task id until user closes the bar
   private _pendingTaskRevealTimeout?: number;
+  private _pendingTaskHighlightTimeout?: number;
+  private _highlightedTaskEl: HTMLElement | null = null;
 
   // Signal to trigger sidebar focus
   private _focusSideNavTrigger = signal(0);
@@ -195,6 +199,7 @@ export class LayoutService {
 
     const el = this.focusTaskInViewIfPossible(taskId);
     if (el) {
+      this.highlightTaskBriefly(el);
       onSuccess?.(el);
       return;
     }
@@ -208,6 +213,29 @@ export class LayoutService {
       this._pendingTaskRevealTimeout = undefined;
       this.focusTaskInViewWhenReady(taskId, onSuccess, onFailure, retriesLeft - 1);
     }, LayoutService._TASK_FOCUS_RETRY_DELAY);
+  }
+
+  /**
+   * Draws a temporary attention highlight on a task revealed by navigation
+   * (global search, notifications, tracked-task pill), so it stays findable
+   * even after the focus outline is gone. Mirrors the note reveal in
+   * NotesComponent. Only one task is highlighted at a time. (#5476)
+   */
+  highlightTaskBriefly(el: HTMLElement): void {
+    if (this._pendingTaskHighlightTimeout) {
+      window.clearTimeout(this._pendingTaskHighlightTimeout);
+      this._pendingTaskHighlightTimeout = undefined;
+    }
+    this._highlightedTaskEl?.classList.remove(LayoutService._TASK_HIGHLIGHT_CLASS);
+    el.classList.add(LayoutService._TASK_HIGHLIGHT_CLASS);
+    this._highlightedTaskEl = el;
+    this._pendingTaskHighlightTimeout = window.setTimeout(() => {
+      this._pendingTaskHighlightTimeout = undefined;
+      el.classList.remove(LayoutService._TASK_HIGHLIGHT_CLASS);
+      if (this._highlightedTaskEl === el) {
+        this._highlightedTaskEl = null;
+      }
+    }, LayoutService._TASK_HIGHLIGHT_DURATION);
   }
 
   private _runForTaskElement(

--- a/src/app/core-ui/navigate-to-task/navigate-to-task.service.spec.ts
+++ b/src/app/core-ui/navigate-to-task/navigate-to-task.service.spec.ts
@@ -88,7 +88,10 @@ describe('NavigateToTaskService', () => {
     const dateService = jasmine.createSpyObj('DateService', ['isToday', 'todayStr']);
     dateService.todayStr.and.returnValue(TODAY_STR);
     dateService.isToday.and.returnValue(false);
-    layoutService = jasmine.createSpyObj('LayoutService', ['focusTaskInViewWhenReady']);
+    layoutService = jasmine.createSpyObj('LayoutService', [
+      'focusTaskInViewWhenReady',
+      'highlightTaskBriefly',
+    ]);
 
     const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
     routerSpy.navigate.and.resolveTo(true);
@@ -405,6 +408,72 @@ describe('NavigateToTaskService', () => {
       [`/project/${INBOX_PROJECT.id}/tasks`],
       jasmine.anything(),
     );
+  });
+
+  /**
+   * The attention highlight is scoped to navigations the user asked for, i.e.
+   * global search. Every other caller of `navigate()` — the tracked-task pill,
+   * the "go to task" snack actions, issue creation and the calendar banner —
+   * must keep the plain focus behavior. (#5476)
+   */
+  describe('search intent (#5476)', () => {
+    it('carries isFromSearch into the route-change query params when set', async () => {
+      const task = createTask({ id: 's1', projectId: 'p1', tagIds: [] });
+      setNavigatedTask(task, [createProject('p1', ['s1'])]);
+
+      await service.navigate('s1', false, { isFromSearch: true });
+
+      expect(router.navigate).toHaveBeenCalledWith(
+        ['/project/p1/tasks'],
+        jasmine.objectContaining({
+          queryParams: jasmine.objectContaining({ focusItem: 's1', isFromSearch: true }),
+        }),
+      );
+    });
+
+    it('omits isFromSearch for every other caller', async () => {
+      const task = createTask({ id: 's2', projectId: 'p1', tagIds: [] });
+      setNavigatedTask(task, [createProject('p1', ['s2'])]);
+
+      await service.navigate('s2');
+
+      const queryParams = (
+        router.navigate.calls.mostRecent().args[1] as {
+          queryParams: Record<string, unknown>;
+        }
+      ).queryParams;
+      expect(queryParams.focusItem).toBe('s2');
+      expect('isFromSearch' in queryParams).toBeFalse();
+    });
+
+    it('highlights the revealed row on a same-context search jump', async () => {
+      router.url = '/project/p1/tasks';
+      const task = createTask({ id: 's3', projectId: 'p1', tagIds: [] });
+      setNavigatedTask(task, [createProject('p1', ['s3'])]);
+      const el = document.createElement('div');
+      layoutService.focusTaskInViewWhenReady.and.callFake((_taskId, onSuccess) =>
+        onSuccess?.(el),
+      );
+
+      await service.navigate('s3', false, { isFromSearch: true });
+
+      expect(layoutService.highlightTaskBriefly).toHaveBeenCalledOnceWith(el);
+    });
+
+    it('does not highlight a same-context jump from any other caller', async () => {
+      router.url = '/project/p1/tasks';
+      const task = createTask({ id: 's4', projectId: 'p1', tagIds: [] });
+      setNavigatedTask(task, [createProject('p1', ['s4'])]);
+      const el = document.createElement('div');
+      layoutService.focusTaskInViewWhenReady.and.callFake((_taskId, onSuccess) =>
+        onSuccess?.(el),
+      );
+
+      await service.navigate('s4');
+
+      expect(layoutService.focusTaskInViewWhenReady).toHaveBeenCalled();
+      expect(layoutService.highlightTaskBriefly).not.toHaveBeenCalled();
+    });
   });
 
   describe('collapsed parent (#8780)', () => {

--- a/src/app/core-ui/navigate-to-task/navigate-to-task.service.ts
+++ b/src/app/core-ui/navigate-to-task/navigate-to-task.service.ts
@@ -42,7 +42,17 @@ export class NavigateToTaskService {
   private _currentTaskId = this._store.selectSignal(selectCurrentTaskId);
   private _projectState = this._store.selectSignal(selectProjectFeatureState);
 
-  async navigate(taskId: string, isArchiveTask: boolean = false): Promise<void> {
+  /**
+   * @param isFromSearch the user navigated here from global search, i.e. asked
+   * "where is this?" — the only caller that earns the attention highlight on the
+   * revealed row. Threaded through as a query param on the route-change branch
+   * so the destination view can honour it too. (#5476)
+   */
+  async navigate(
+    taskId: string,
+    isArchiveTask: boolean = false,
+    { isFromSearch = false }: { isFromSearch?: boolean } = {},
+  ): Promise<void> {
     try {
       const task = await this._taskService.getByIdFromEverywhere(taskId);
       if (!task) {
@@ -84,7 +94,7 @@ export class NavigateToTaskService {
           currentUrl: this._router.url,
           location,
         });
-        this._focusTaskElement(taskId);
+        this._focusTaskElement(taskId, isFromSearch);
         return;
       }
 
@@ -94,6 +104,9 @@ export class NavigateToTaskService {
       // branch above; every location we route to here is one the task renders in
       // — either it already lists the task, or the repair above just added it.
       const queryParams: SearchQueryParams = { focusItem: taskId };
+      if (isFromSearch) {
+        queryParams.isFromSearch = true;
+      }
       if (isArchiveTask) {
         queryParams.dateStr = await this._getArchivedDate(task);
       } else {
@@ -303,7 +316,7 @@ export class NavigateToTaskService {
     return task.dueDay === this._dateService.todayStr();
   }
 
-  private _focusTaskElement(taskId: string): void {
+  private _focusTaskElement(taskId: string, isFromSearch: boolean = false): void {
     // KNOWN GAP: this branch gets the collapsed-parent reveal above and nothing
     // else. The other containers that can drop a row from the DOM — customizer
     // group, section, and the done/overdue/later panels — are opened by
@@ -334,10 +347,14 @@ export class NavigateToTaskService {
     //
     // Never swallow silently: if the task never becomes focusable in the current
     // context, surface the error instead of leaving the user on the wrong view.
-    this._layoutService.focusTaskInViewWhenReady(taskId, undefined, () => {
-      recordSearchNavDebug('navigateToTask:focusFailed', { taskId });
-      this._showNavErrorSnack();
-    });
+    this._layoutService.focusTaskInViewWhenReady(
+      taskId,
+      isFromSearch ? (el) => this._layoutService.highlightTaskBriefly(el) : undefined,
+      () => {
+        recordSearchNavDebug('navigateToTask:focusFailed', { taskId });
+        this._showNavErrorSnack();
+      },
+    );
   }
 
   private _isInBacklog(task: Task): boolean {

--- a/src/app/features/tasks/task/_task-base.scss
+++ b/src/app/features/tasks/task/_task-base.scss
@@ -42,7 +42,7 @@
     outline: none;
   }
 
-  &.highlight-searched-item {
+  &.highlight-searched-task {
     z-index: var(--z-focus-host);
   }
 }
@@ -117,9 +117,10 @@
 
   // Temporary attention highlight for a task revealed via navigation, e.g. from
   // a search result (LayoutService.highlightTaskBriefly, #5476). An outline, so
-  // it stays clearly visible even once the focus border above is gone.
-  :host.highlight-searched-item .inner-wrapper > & {
-    border-radius: var(--task-border-radius);
+  // it stays clearly visible even once the focus border above is gone, and it
+  // traces whatever radius the box already has — no border-radius of its own, so
+  // nothing can leak into the sub-task boxes (which are deliberately square).
+  :host.highlight-searched-task .inner-wrapper > & {
     outline: 2px solid var(--c-accent);
   }
 
@@ -197,7 +198,7 @@
 
   // Same leak as above for the temporary search highlight: without this, a
   // highlighted parent would draw the outline around every subtask box too.
-  :host.highlight-searched-item & .inner-wrapper > .box {
+  :host.highlight-searched-task & .inner-wrapper > .box {
     outline: none;
   }
 }

--- a/src/app/features/tasks/task/_task-base.scss
+++ b/src/app/features/tasks/task/_task-base.scss
@@ -41,6 +41,10 @@
     z-index: var(--z-focus-host);
     outline: none;
   }
+
+  &.highlight-searched-item {
+    z-index: var(--z-focus-host);
+  }
 }
 
 .inner-wrapper {
@@ -109,6 +113,14 @@
     border-color: var(--palette-primary-400);
     border-width: 1px;
     border-style: solid !important;
+  }
+
+  // Temporary attention highlight for a task revealed via navigation, e.g. from
+  // a search result (LayoutService.highlightTaskBriefly, #5476). An outline, so
+  // it stays clearly visible even once the focus border above is gone.
+  :host.highlight-searched-item .inner-wrapper > & {
+    border-radius: var(--task-border-radius);
+    outline: 2px solid var(--c-accent);
   }
 
   :host.isCurrent.isCurrent.isCurrent.isCurrent.isCurrent & {
@@ -181,6 +193,12 @@
     @include lightTheme {
       border-color: var(--extra-border-color);
     }
+  }
+
+  // Same leak as above for the temporary search highlight: without this, a
+  // highlighted parent would draw the outline around every subtask box too.
+  :host.highlight-searched-item & .inner-wrapper > .box {
+    outline: none;
   }
 }
 

--- a/src/app/features/work-view/work-view.component.spec.ts
+++ b/src/app/features/work-view/work-view.component.spec.ts
@@ -468,9 +468,12 @@ describe('WorkViewComponent', () => {
     // The focus retry loop keeps rescheduling for ~5s; without an explicit
     // destroy those timers outlive the spec and run against a reset MockStore.
     let fixture: ComponentFixture<WorkViewComponent> | undefined;
+    /** Containers appended to the document by the success-branch spec. */
+    const revealContainers: HTMLElement[] = [];
     afterEach(() => {
       fixture?.destroy();
       fixture = undefined;
+      revealContainers.splice(0).forEach((el) => el.remove());
       // The panel signals persist to localStorage, and the component seeds them
       // from it at construction — a spec that left one collapsed would decide
       // the starting state of every later one under randomized spec order.
@@ -853,6 +856,42 @@ describe('WorkViewComponent', () => {
       expect(toggleGroupExpansion.calls.count()).toBe(callsAfterGivingUp);
       discardPeriodicTasks();
     }));
+
+    /**
+     * The success branch of the reveal — the one that scrolls, focuses and
+     * highlights. Every spec above stops in the retry/expansion path, which
+     * never reaches it, so the highlight needs a container that actually holds
+     * a rendered row. (#5476)
+     */
+    it('scrolls to, focuses and highlights the row once it is rendered', () => {
+      const { cmp } = setup({
+        focusItem: 'wanted',
+        undone: [buildTask('wanted')],
+      });
+      const highlightTaskBriefly = spyOn(
+        TestBed.inject(LayoutService),
+        'highlightTaskBriefly',
+      );
+
+      // A real element: the reveal only accepts a row that is in the document
+      // and has a non-zero height (_isTaskElementReady).
+      const container = document.createElement('div');
+      container.style.height = '100px';
+      container.style.overflow = 'auto';
+      const row = document.createElement('div');
+      row.id = 't-wanted';
+      row.style.height = '400px';
+      container.appendChild(row);
+      document.body.appendChild(container);
+      revealContainers.push(container);
+      spyOn(row, 'focus');
+
+      // Mirrors the split pane rendering: the setter replays the pending reveal.
+      cmp.splitTopElRef = new ElementRef(container);
+
+      expect(row.focus).toHaveBeenCalledOnceWith({ preventScroll: true });
+      expect(highlightTaskBriefly).toHaveBeenCalledOnceWith(row);
+    });
 
     it('does not touch any container without a focusItem', () => {
       const { toggleGroupExpansion, updateSection } = setup({

--- a/src/app/features/work-view/work-view.component.spec.ts
+++ b/src/app/features/work-view/work-view.component.spec.ts
@@ -129,6 +129,7 @@ const configureWorkViewTestBed = (
           isXs: signal(false),
           isWorkViewScrolled: { set: () => {} },
           showAddTaskBar: () => {},
+          highlightTaskBriefly: () => {},
         },
       },
       {

--- a/src/app/features/work-view/work-view.component.spec.ts
+++ b/src/app/features/work-view/work-view.component.spec.ts
@@ -484,6 +484,8 @@ describe('WorkViewComponent', () => {
 
     const setup = (opts: {
       focusItem?: string;
+      /** Marks the `focusItem` as search-originated, as `navigate()` does. */
+      isFromSearch?: boolean;
       queryParams$?: Observable<Record<string, string>>;
       doneTasks?: TaskWithSubTasks[];
       overdueTasks?: TaskWithSubTasks[];
@@ -526,7 +528,13 @@ describe('WorkViewComponent', () => {
         },
         queryParams$:
           opts.queryParams$ ??
-          (opts.focusItem ? of({ focusItem: opts.focusItem }) : undefined),
+          (opts.focusItem
+            ? of(
+                (opts.isFromSearch
+                  ? { focusItem: opts.focusItem, isFromSearch: 'true' }
+                  : { focusItem: opts.focusItem }) as Record<string, string>,
+              )
+            : undefined),
         isTodayList: opts.isTodayList,
         embedPluginId: opts.embedPluginId,
       });
@@ -858,16 +866,14 @@ describe('WorkViewComponent', () => {
     }));
 
     /**
-     * The success branch of the reveal — the one that scrolls, focuses and
-     * highlights. Every spec above stops in the retry/expansion path, which
-     * never reaches it, so the highlight needs a container that actually holds
-     * a rendered row. (#5476)
+     * The success branch of the reveal — the one that scrolls, focuses and (for
+     * a search jump) highlights. Every spec above stops in the retry/expansion
+     * path, which never reaches it, so this needs a container that actually
+     * holds a rendered row. (#5476)
      */
-    it('scrolls to, focuses and highlights the row once it is rendered', () => {
-      const { cmp } = setup({
-        focusItem: 'wanted',
-        undone: [buildTask('wanted')],
-      });
+    const revealRenderedRow = (
+      cmp: WorkViewComponent,
+    ): { row: HTMLElement; highlightTaskBriefly: jasmine.Spy } => {
       const highlightTaskBriefly = spyOn(
         TestBed.inject(LayoutService),
         'highlightTaskBriefly',
@@ -888,9 +894,34 @@ describe('WorkViewComponent', () => {
 
       // Mirrors the split pane rendering: the setter replays the pending reveal.
       cmp.splitTopElRef = new ElementRef(container);
+      return { row, highlightTaskBriefly };
+    };
+
+    it('scrolls to, focuses and highlights the row of a search jump', () => {
+      const { cmp } = setup({
+        focusItem: 'wanted',
+        isFromSearch: true,
+        undone: [buildTask('wanted')],
+      });
+
+      const { row, highlightTaskBriefly } = revealRenderedRow(cmp);
 
       expect(row.focus).toHaveBeenCalledOnceWith({ preventScroll: true });
       expect(highlightTaskBriefly).toHaveBeenCalledOnceWith(row);
+    });
+
+    it('focuses but does not highlight a focusItem from any other caller', () => {
+      // `focusItem` is also set by reminder snacks, the tracked-task pill, issue
+      // creation and the calendar banner — none of those asked for attention.
+      const { cmp } = setup({
+        focusItem: 'wanted',
+        undone: [buildTask('wanted')],
+      });
+
+      const { row, highlightTaskBriefly } = revealRenderedRow(cmp);
+
+      expect(row.focus).toHaveBeenCalledOnceWith({ preventScroll: true });
+      expect(highlightTaskBriefly).not.toHaveBeenCalled();
     });
 
     it('does not touch any container without a focusItem', () => {

--- a/src/app/features/work-view/work-view.component.ts
+++ b/src/app/features/work-view/work-view.component.ts
@@ -375,6 +375,12 @@ export class WorkViewComponent implements OnInit, OnDestroy {
 
   private _subs: Subscription = new Subscription();
   private _pendingFocusItemTaskId: string | null = null;
+  /**
+   * Whether the pending reveal came from global search. Kept as a field rather
+   * than a parameter because the `splitTopEl` setter replays the reveal without
+   * going through the query params again. (#5476)
+   */
+  private _isPendingFocusItemFromSearch = false;
   private _pendingFocusItemTimeout?: number;
   private _splitTopElement?: HTMLElement;
   private _switchListAnimationTimeout?: number;
@@ -489,6 +495,7 @@ export class WorkViewComponent implements OnInit, OnDestroy {
             splitInputPos: this.splitInputPos,
           });
           this._pendingFocusItemTaskId = params.focusItem;
+          this._isPendingFocusItemFromSearch = params.isFromSearch === 'true';
           this._focusItemInWorkViewWhenReady(params.focusItem);
         } else {
           // Cancel the chain too, not just the marker: a still-running loop
@@ -499,6 +506,7 @@ export class WorkViewComponent implements OnInit, OnDestroy {
             this._pendingFocusItemTimeout = undefined;
           }
           this._pendingFocusItemTaskId = null;
+          this._isPendingFocusItemFromSearch = false;
         }
         // NOTE: otherwise this is not triggered right away
         this._cd.detectChanges();
@@ -675,7 +683,12 @@ export class WorkViewComponent implements OnInit, OnDestroy {
       const centeredTop = relativeTop - containerCenterOffset + elementCenterOffset;
       container.scrollTop = Math.max(centeredTop, 0);
       el.focus({ preventScroll: true });
-      this.layoutService.highlightTaskBriefly(el);
+      // Search only: every other `focusItem` caller (reminder snacks, tracked-task
+      // pill, issue creation, calendar banner) navigates without the user having
+      // asked where the task is. (#5476)
+      if (this._isPendingFocusItemFromSearch) {
+        this.layoutService.highlightTaskBriefly(el);
+      }
       recordSearchNavDebug('workView:focusSuccess', {
         taskId,
         selectedTaskId: this.selectedTaskId(),
@@ -696,6 +709,7 @@ export class WorkViewComponent implements OnInit, OnDestroy {
         });
       }, 0);
       this._pendingFocusItemTaskId = null;
+      this._isPendingFocusItemFromSearch = false;
       return;
     }
 
@@ -704,6 +718,7 @@ export class WorkViewComponent implements OnInit, OnDestroy {
       // setter replay the whole loop on every later context change, re-opening
       // containers the user has since collapsed by hand.
       this._pendingFocusItemTaskId = null;
+      this._isPendingFocusItemFromSearch = false;
       return;
     }
 

--- a/src/app/features/work-view/work-view.component.ts
+++ b/src/app/features/work-view/work-view.component.ts
@@ -675,6 +675,7 @@ export class WorkViewComponent implements OnInit, OnDestroy {
       const centeredTop = relativeTop - containerCenterOffset + elementCenterOffset;
       container.scrollTop = Math.max(centeredTop, 0);
       el.focus({ preventScroll: true });
+      this.layoutService.highlightTaskBriefly(el);
       recordSearchNavDebug('workView:focusSuccess', {
         taskId,
         selectedTaskId: this.selectedTaskId(),

--- a/src/app/features/worklog/worklog-task-row/worklog-task-row.component.scss
+++ b/src/app/features/worklog/worklog-task-row/worklog-task-row.component.scss
@@ -2,6 +2,20 @@
   display: table-row;
 }
 
+// Temporary attention highlight for a row revealed by a search jump into the
+// archive (LayoutService.highlightTaskBriefly, #5476). The task list draws an
+// outline, but these rows are `display: table-row` inside a `border-collapse`
+// table, where the History view already rings the focused row with a box-shadow
+// and explicitly turns the outline off (history.component.scss) — so match that
+// technique here rather than the task list's.
+:host.highlight-searched-task {
+  box-shadow: 0 0 0 2px var(--c-accent);
+  border-radius: var(--card-border-radius);
+  // above the neighbouring rows' collapsed borders, so the ring is not clipped
+  position: relative;
+  z-index: 1;
+}
+
 td {
   text-align: left;
   white-space: normal;

--- a/src/app/features/worklog/worklog-task-row/worklog-task-row.component.scss
+++ b/src/app/features/worklog/worklog-task-row/worklog-task-row.component.scss
@@ -8,12 +8,13 @@
 // table, where the History view already rings the focused row with a box-shadow
 // and explicitly turns the outline off (history.component.scss) — so match that
 // technique here rather than the task list's.
+// Deliberately unpositioned: on WebKit a positioned `display: table-row` drops
+// its box-shadow entirely, which would take the History focus ring down with it
+// for as long as the class is on. That ring sets no `position` either and still
+// paints unclipped over the neighbouring cells' collapsed borders.
 :host.highlight-searched-task {
   box-shadow: 0 0 0 2px var(--c-accent);
   border-radius: var(--card-border-radius);
-  // above the neighbouring rows' collapsed borders, so the ring is not clipped
-  position: relative;
-  z-index: 1;
 }
 
 td {

--- a/src/app/pages/search-page/search-page.component.spec.ts
+++ b/src/app/pages/search-page/search-page.component.spec.ts
@@ -359,7 +359,11 @@ describe('SearchPageComponent', () => {
       isArchiveTask: true,
     } as SearchItem;
     component.navigateToItem(item);
-    expect(navigateToTaskServiceSpy.navigate).toHaveBeenCalledWith('nav-1', true);
+    // The search flag is what earns the revealed row its attention highlight —
+    // no other caller of navigate() sets it. (#5476)
+    expect(navigateToTaskServiceSpy.navigate).toHaveBeenCalledWith('nav-1', true, {
+      isFromSearch: true,
+    });
   });
 
   it('should reset form value on clearSearch', fakeAsync(() => {

--- a/src/app/pages/search-page/search-page.component.ts
+++ b/src/app/pages/search-page/search-page.component.ts
@@ -328,7 +328,9 @@ export class SearchPageComponent implements OnInit {
         }
       });
     } else {
-      this._navigateToTaskService.navigate(item.id, item.isArchiveTask).then(() => {});
+      this._navigateToTaskService
+        .navigate(item.id, item.isArchiveTask, { isFromSearch: true })
+        .then(() => {});
     }
   }
 

--- a/src/app/pages/search-page/search-page.model.ts
+++ b/src/app/pages/search-page/search-page.model.ts
@@ -34,4 +34,13 @@ export interface SearchQueryParams {
   focusItem: string;
   dateStr?: string;
   isInBacklog?: boolean;
+  /**
+   * Set only when the navigation started from global search, i.e. when the user
+   * asked "where is this?". The reveal paths draw their attention highlight off
+   * this, never off `focusItem` alone — every other caller of
+   * `NavigateToTaskService.navigate()` (reminder snacks, tracked-task pill,
+   * issue creation, calendar banner) sets `focusItem` without anyone having
+   * asked for attention. (#5476)
+   */
+  isFromSearch?: boolean;
 }


### PR DESCRIPTION
## Problem

Fixes #5476 (the "highlight it very clearly" part).

When jumping to a task from global search, the app already scrolls to and focuses the task (added in #7283 and hardened in #9590/#9595). But the only visual marker is the regular 1px focus border, which is exactly the "very thin border … very hard to see" the issue complains about — and it disappears the moment the task loses focus, e.g. on the first click anywhere else.

On mobile it is worse: `AppComponent` added a `mobile-highlight-searched-item` class, but its only style rules were removed in #9272, so the class has been dead ever since and mobile users get no visible marker at all.

## Solution

Draw a temporary (3s) accent-colored outline on a task revealed **by a global search jump**, mirroring the note reveal highlight in `NotesComponent` (same duration, own class name — see below).

- `LayoutService.highlightTaskBriefly(el)` adds the class and removes it after 3s; only one task is highlighted at a time, and a re-trigger moves the highlight instead of racing timeouts.
- **Scoped to search, not to `focusItem`.** `focusItem` is set by every caller of `NavigateToTaskService.navigate()` — the tracked-task pill, the "go to task" snack actions, issue creation, the calendar banner — and none of those is a "where is it?" question, so none of them should grab attention. The intent is threaded from the only search-originated caller (`SearchPageComponent.navigateToItem`) as an `isFromSearch` option on `navigate()`, carried as its own query param on the route-change branch, and honoured in both reveal paths: the `focusItem` handler in `AppComponent` (which also covers the same-context branch in `NavigateToTaskService`) and `WorkViewComponent`'s own reveal loop. Every other caller keeps the plain focus behavior it has today.
- `_task-base.scss` styles `:host.highlight-searched-task` with a 2px `var(--c-accent)` outline (an outline, so it stays visible independently of the focus border), plus the same subtask leak guard the focus border needs so a highlighted parent doesn't outline every subtask box. The class name is deliberately **not** the note reveal's `highlight-searched-item`: `NotesComponent` strips that class from every element in the document whenever it reveals a note, and `focusItem` is a query param shared by tasks and notes, so sharing the name would let a note reveal cut a live task highlight short.
- The rule sets no `border-radius` of its own, so nothing leaks into the deliberately square subtask boxes; the outline traces whatever radius the box already has.
- Removes the dead `mobile-highlight-searched-item` code from `AppComponent`; the highlight now applies on all platforms.

No new settings, no synced state touched, no template changes to the hot-path task component — just one static CSS rule pair and an out-of-change-detection class toggle on a single element.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). (no setting/shortcut/API changed — per `docs/documentation-guide.md` no wiki note covers this behavior)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Verification

- `npm run checkFile` on every touched `.ts`/`.scss` file — pass
- `npm run lint:css-vars` — pass (all referenced custom properties resolve)
- `npm run test:file src/app/core-ui/layout/layout.service.spec.ts` — 16/16
- `npm run test:file src/app/core-ui/navigate-to-task/navigate-to-task.service.spec.ts` — 26/26 (4 new: the query param is carried only when set; same-context highlight only for a search jump)
- `npm run test:file src/app/features/work-view/work-view.component.spec.ts` — 36/36 (the reveal's success branch, highlight and no-highlight)
- `npm run test:file src/app/pages/search-page/search-page.component.spec.ts` — 31/31
- `npx tsc --noEmit -p src/tsconfig.app.json` — clean
- Full `npm run lint && npm test` via the pre-push hook — 14607 passing
- Rendered check in a real browser (throwaway Playwright spec, light + dark × 1280 and 380 wide): the search jump outlines the row in both themes and survives losing focus; sibling subtask boxes compute `outline: none`; a `focusItem` navigation without the search flag focuses the row and draws nothing. Painted outline edges measure 392 → 1148 (386 → 1154 with the row also selected) inside a scroller at 260 → 1280 at desktop width, and 6 → 374 inside 0 → 380 at 380px, with `document.scrollWidth` never exceeding the viewport — nothing clipped.

Note: I did not tackle option 3 from the issue (auto-opening the task detail panel) — that changes navigation behavior for everyone and the comments suggest gating it behind a setting, which felt like a separate product call. This PR keeps to the leanest slice: the task you searched for is now clearly and durably marked once revealed.
