### PR TITLE
fix(schedule): defer initial scroll until route-enter animation finishes

### DIFF
--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -1359,5 +1359,29 @@ describe('ScheduleComponent', () => {
       // hundreds of pixels. What is left here is sub-pixel rounding.
       expect(Math.abs(scaledWrapper.scrollTop - plainTop)).toBeLessThan(2);
     });
+
+    it('defers scrolling until a running animation on the host finishes', async () => {
+      const host = fixture.nativeElement as HTMLElement;
+      const scrollIntoViewSpy = spyOn(HTMLElement.prototype, 'scrollIntoView');
+
+      // A transformed element's painted bounds count toward its ancestors'
+      // scrollable-overflow region, so calling scrollIntoView while warpRoute
+      // is still scaling this host can nudge .route-wrapper (and further out)
+      // to a transient scroll offset -- setting `transform` directly (as the
+      // test above does) can't reproduce that because it creates no
+      // Animation for getAnimations() to see. This exercises the real thing
+      // via the Web Animations API instead.
+      const anim = host.animate(
+        [{ transform: 'scale(1.2)' }, { transform: 'scale(1)' }],
+        30,
+      );
+
+      component['_scrollAnchorToTop']('current-time');
+      expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+
+      await anim.finished;
+      await Promise.resolve(); // flush the .then(scroll) microtask
+      expect(scrollIntoViewSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/features/schedule/schedule/schedule.component.spec.ts
+++ b/src/app/features/schedule/schedule/schedule.component.spec.ts
@@ -1380,7 +1380,11 @@ describe('ScheduleComponent', () => {
       expect(scrollIntoViewSpy).not.toHaveBeenCalled();
 
       await anim.finished;
-      await Promise.resolve(); // flush the .then(scroll) microtask
+      // Promise.all([...catch]).then(scroll) is more than one microtask hop
+      // past `finished` resolving, and the hop count isn't a stable contract
+      // to pin a single `await Promise.resolve()` against. A macrotask
+      // flushes the whole microtask queue first regardless of hop count.
+      await new Promise((r) => setTimeout(r));
       expect(scrollIntoViewSpy).toHaveBeenCalled();
     });
   });

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -419,8 +419,31 @@ export class ScheduleComponent {
     const element = this._elRef.nativeElement.querySelector(
       `#${elementId}`,
     ) as HTMLElement | null;
+    if (!element) return;
 
-    element?.scrollIntoView({ block: 'start', inline: 'start', behavior: 'instant' });
+    const scroll = (): void =>
+      element.scrollIntoView({ block: 'start', inline: 'start', behavior: 'instant' });
+
+    // scrollIntoView resolves *this* element's target position in layout
+    // coordinates, so the scale(1.2) transform above can't skew that part.
+    // But it also walks every scrollable ancestor to bring the target into
+    // view, and a transformed element's *painted* bounds count toward its
+    // ancestors' scrollable-overflow region -- so while warpRoute is still
+    // scaling this component's host, .route-wrapper (and potentially further
+    // out) briefly reads as having real overflow to scroll, gets nudged to a
+    // transient scrollLeft/scrollTop to satisfy the 'start' alignment, and
+    // only settles back to 0 once the transform reaches scale(1). For the
+    // ~duration of the enter animation this visibly shifts the app shell
+    // (magic-side-nav included) instead of just the schedule view.
+    // Wait out any animation still running on this host before scrolling.
+    const running = this._elRef.nativeElement
+      .getAnimations()
+      .filter((a) => a.playState === 'running');
+    if (running.length === 0) {
+      scroll();
+      return;
+    }
+    Promise.all(running.map((a) => a.finished.catch(() => undefined))).then(scroll);
   }
 
   selectTimeView(view: 'week' | 'month' | 'day'): void {

--- a/src/app/features/schedule/schedule/schedule.component.ts
+++ b/src/app/features/schedule/schedule/schedule.component.ts
@@ -429,13 +429,14 @@ export class ScheduleComponent {
     // But it also walks every scrollable ancestor to bring the target into
     // view, and a transformed element's *painted* bounds count toward its
     // ancestors' scrollable-overflow region -- so while warpRoute is still
-    // scaling this component's host, .route-wrapper (and potentially further
-    // out) briefly reads as having real overflow to scroll, gets nudged to a
-    // transient scrollLeft/scrollTop to satisfy the 'start' alignment, and
-    // only settles back to 0 once the transform reaches scale(1). For the
-    // ~duration of the enter animation this visibly shifts the app shell
-    // (magic-side-nav included) instead of just the schedule view.
-    // Wait out any animation still running on this host before scrolling.
+    // scaling this component's host, .route-wrapper briefly reads as having
+    // real overflow to scroll, gets nudged to a transient scrollLeft/scrollTop
+    // to satisfy the 'start' alignment, and only settles back to 0 once the
+    // transform reaches scale(1). .route-wrapper's own overflow: hidden stops
+    // that nudge from reaching .main-content or anything further out (the
+    // nav, the header), but for the ~duration of the enter animation it
+    // visibly shifts the routed view itself. Wait out any animation still
+    // running on this host before scrolling.
     const running = this._elRef.nativeElement
       .getAnimations()
       .filter((a) => a.playState === 'running');


### PR DESCRIPTION
## Problem

Opening the Schedule view briefly shifts its own content out of place: the
day/week grid ends up scrolled to the wrong position for the ~duration of
the route-enter animation, before settling.

`ScheduleComponent._scrollAnchorToTop()` calls `scrollIntoView()` on the
current-time anchor right after entering the route, while the route-enter
animation (`warpRoute`, `scale(1.2) → scale(1)`) is still running on the
component's host element.

`scrollIntoView()` resolves the target's position in layout coordinates, so
the scale itself isn't the problem — but it also walks every scrollable
ancestor to bring the target into view, and a transformed element's
*painted* bounds count toward its ancestors' scrollable-overflow region.
While the host is still scaled, `.route-wrapper` briefly reads as having
real overflow, gets nudged to a transient scroll offset to satisfy
`block: 'start'`/`inline: 'start'`, and only settles back to `0` once the
transform reaches `scale(1)`. `.route-wrapper` is itself `overflow: hidden`,
so this nudge is contained to the routed view — confirmed with an
instrumented run against the real Electron app: `.route-wrapper.scrollTop`
moves to 75 and decays back to 0, while `magic-side-nav`'s position,
`.main-content`, `.app-container`, and `document.scrollingElement` never
move at all.

## Solution

Before scrolling, check `getAnimations()` on the component's host for any
still-`running` animations and, if there are any, wait for them to finish
(`Promise.all(...finished)`) before calling `scrollIntoView()`. No-op when
nothing is running, so the common case is unaffected.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Testing

- Added a regression test using the real Web Animations API
  (`element.animate(...)`) to verify `scrollIntoView` is deferred until the
  host's running animation finishes, and fires once it does. A plain
  `transform` CSS assignment can't reproduce this because it creates no
  `Animation` for `getAnimations()` to observe.
- `schedule.component.spec.ts`: 74/74 passing.
- Full local unit suite (`npm test`) green.
- Instrumented the real Electron app (Playwright `_electron`, pointed at
  `electron/main.js`) to sample `.route-wrapper`/`.main-content`/
  `.app-container`/`magic-side-nav` geometry across the route-enter
  animation, on the pre-fix commit — see Problem above for the numbers.

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). *(not applicable — internal bug fix, no user-facing behavior to document)*
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
