### PR TITLE
fix(duration): parse bare integers as minutes, not hours

### DIFF
--- a/src/app/ui/duration/duration-input.util.spec.ts
+++ b/src/app/ui/duration/duration-input.util.spec.ts
@@ -135,14 +135,14 @@ describe('processDurationInput', () => {
       expect(result.shouldUpdate).toBe(false);
     });
 
-    it('should treat plain numbers up to and including 8 as hours', () => {
+    it('should treat plain integers as minutes', () => {
       const result = processDurationInput('8');
       expect(result.isValid).toBe(true);
-      expect(result.milliseconds).toBe(8 * 60 * 60 * 1000);
+      expect(result.milliseconds).toBe(8 * 60 * 1000);
       expect(result.shouldUpdate).toBe(true);
     });
 
-    it('should treat plain numbers larger than 8 as minutes', () => {
+    it('should treat larger plain integers as minutes', () => {
       const result = processDurationInput('15');
       expect(result.isValid).toBe(true);
       expect(result.milliseconds).toBe(15 * 60 * 1000);

--- a/src/app/ui/duration/duration-input.util.ts
+++ b/src/app/ui/duration/duration-input.util.ts
@@ -19,7 +19,7 @@ export const processDurationInput = (
       // Allow fractional hours with or without h specifier
       /^\d*[.,]\d+h?$/i,
 
-      // Allow integer numbers without specifier (treated as hours if <= 8 or fractional, else as minutes)
+      // Allow integer numbers without specifier (treated as minutes; fractional treated as hours)
       /^\d+$/,
 
       // Allow full duration as hh:mm or h:mm

--- a/src/app/ui/duration/string-to-ms.pipe.spec.ts
+++ b/src/app/ui/duration/string-to-ms.pipe.spec.ts
@@ -58,13 +58,13 @@ describe('stringToMs', () => {
   });
 
   it('should interpret numbers without unit', () => {
-    // Case: integer (greater 8) missing all units => treat as minutes
+    // Integers to minutes
     expect(stringToMs('10')).toBe(10 * 60 * 1000);
+    expect(stringToMs('8')).toBe(8 * 60 * 1000);
+    expect(stringToMs('5')).toBe(5 * 60 * 1000);
+    expect(stringToMs('1')).toBe(1 * 60 * 1000);
 
-    // Case: integer (less or equal 8) missing all units => treat as hours
-    expect(stringToMs('8')).toBe(8 * 60 * 60 * 1000);
-
-    // Case: fractional missing all units => treat as hours
+    // Fractional to hours
     expect(stringToMs('.5')).toBe(30 * 60 * 1000);
     expect(stringToMs('1.5')).toBe((60 + 30) * 60 * 1000);
     // eslint-disable-next-line no-mixed-operators

--- a/src/app/ui/duration/string-to-ms.pipe.ts
+++ b/src/app/ui/duration/string-to-ms.pipe.ts
@@ -23,11 +23,9 @@ export const stringToMs = (strValue: string, args?: unknown): number => {
       case 'h':
         return amount * 1000 * 60 * 60;
       case '':
-        if (simpleFormatMatch[1].includes('.') || amount <= 8) {
-          // treat all fractional values and integers <= 8 as hours
+        if (simpleFormatMatch[1].includes('.')) {
           return amount * 1000 * 60 * 60;
         } else {
-          // treat integers > 8 as minutes
           return amount * 1000 * 60;
         }
     }


### PR DESCRIPTION
## Summary
- Bare numbers without a unit suffix (e.g. `5`) were treated as hours when ≤ 8 and minutes when > 8
- Now bare integers always parse as minutes — `5` → 5m, `8` → 8m
- Fractional values (e.g. `1.5`) still parse as hours, which is the natural reading
- Users who want hours can type `5h`

| Input | Before | After |
|-------|--------|-------|
| `1` | 1h | **1m** |
| `5` | 5h | **5m** |
| `8` | 8h | **8m** |
| `9` | 9m | 9m |
| `1.5` | 1h 30m | 1h 30m |

## Test plan
- [x] `string-to-ms.pipe.spec.ts` — 25/25 pass
- [x] `duration-input.util.spec.ts` — 29/29 pass
- [x] `input-duration.directive.spec.ts` — 19/19 pass
- [x] Visual: typed `5` in duration input, shows `5m` on blur (not `5h`)
- [x] Visual: typed `1.5`, still shows `1h 30m`

Closes #9609