### PR TITLE
fix(tasks): open notes section directly from the task notes icon

### DIFF
--- a/docs/wiki/4.10-Task-Notes.md
+++ b/docs/wiki/4.10-Task-Notes.md
@@ -16,7 +16,7 @@ Task notes support both planning and execution, with different emphasis in each 
 
 **Execution phase:** During work, notes act as a **dynamic working document**. In focus mode, you can view and edit the task’s notes in place, so you can update them in real time without leaving the task context. You can add checklists, capture decisions, or jot down next steps as you go. The inline markdown editor supports both structured checklists (which the app can treat as a checklist in the UI) and free-form content, so you can mix lists and prose as needed.
 
-When a task’s notes are recognized as a checklist, the task shows a small progress indicator (for example `2/5`) in its controls, so you can see at a glance how far along the checklist is without opening the task. The indicator switches to a completed state once every item is checked, and clicking it opens the task’s notes.
+When a task’s notes are recognized as a checklist, the task shows a small progress indicator (for example `2/5`) in its controls, so you can see at a glance how far along the checklist is without opening the task. The indicator switches to a completed state once every item is checked, and clicking it opens the task’s notes. A task with plain (non-checklist) notes shows a notes icon in the same place, and clicking that opens the task’s notes directly as well.
 
 While viewing a checklist in the notes editor you can manage it directly with the **checklist actions** menu (the list icon next to the editor controls) to **Check all**, **Uncheck all**, or **Clear completed** items in one step. These actions only appear when the notes are recognized as a checklist.
 

--- a/e2e/tests/task-detail/notes-btn-opens-notes-9850.spec.ts
+++ b/e2e/tests/task-detail/notes-btn-opens-notes-9850.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '../../fixtures/test.fixture';
+import { cssSelectors } from '../../constants/selectors';
+
+const { DETAIL_PANEL, DETAIL_PANEL_BTN } = cssSelectors;
+
+/**
+ * Issue #9850: on a phone the notes icon on a task row opened the detail panel
+ * bottom sheet with every section collapsed, so reaching the note took a second
+ * tap on "Notes". The icon now opens the panel with the notes section expanded
+ * (the same target the checklist badge and the N shortcut use).
+ *
+ * Run: npm run e2e:file e2e/tests/task-detail/notes-btn-opens-notes-9850.spec.ts -- --retries=0
+ */
+
+// Below the 600px breakpoint the detail panel renders as the mobile bottom sheet.
+const PHONE = { width: 480, height: 800 };
+const NOTE_TEXT = 'Note reachable in one tap 9850';
+
+test.describe('Notes icon opens the notes section (#9850)', () => {
+  test('should expand the notes section when tapping the notes icon on a phone', async ({
+    page,
+    workViewPage,
+    taskPage,
+  }) => {
+    await workViewPage.waitForTaskList();
+    await workViewPage.addTask('Task with a note');
+
+    const task = taskPage.getTaskByText('Task with a note').first();
+    await taskPage.openTaskDetail(task);
+
+    const detailPanel = page.locator(DETAIL_PANEL);
+    const noteMarkdown = detailPanel.locator('inline-markdown').first();
+    // On desktop a fresh task already shows the notes section expanded, so the
+    // note can be typed through the inline editor; blur persists it.
+    await noteMarkdown.locator('.markdown-parsed').click();
+    const textarea = noteMarkdown.locator('textarea');
+    await textarea.fill(NOTE_TEXT);
+    await textarea.press('Tab');
+    await expect(noteMarkdown).toContainText(NOTE_TEXT);
+
+    // Close the panel again; on desktop the row button shows the close icon.
+    await task.locator(DETAIL_PANEL_BTN).click();
+    await expect(detailPanel).not.toBeVisible();
+
+    await page.setViewportSize(PHONE);
+
+    await task.locator(DETAIL_PANEL_BTN).click();
+    await expect(detailPanel).toBeVisible();
+    // Before the fix the notes section stayed collapsed in the bottom sheet.
+    // mat-expansion-panel keeps collapsed content in the DOM (hidden, height 0),
+    // so check the expanded state itself, not just that the text exists.
+    const notesItem = detailPanel.locator('task-detail-item', {
+      has: page.locator('inline-markdown'),
+    });
+    await expect(notesItem.locator('mat-expansion-panel')).toHaveClass(/mat-expanded/);
+    await expect(notesItem.locator('inline-markdown')).toBeVisible();
+    await expect(notesItem.locator('inline-markdown')).toContainText(NOTE_TEXT);
+  });
+});

--- a/src/app/features/tasks/task/task-shortcuts.spec.ts
+++ b/src/app/features/tasks/task/task-shortcuts.spec.ts
@@ -1,4 +1,4 @@
-import { signal } from '@angular/core';
+import { signal, WritableSignal } from '@angular/core';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { Location } from '@angular/common';
 import { MatDialog, MatDialogState } from '@angular/material/dialog';
@@ -16,7 +16,12 @@ import { ProjectService } from '../../project/project.service';
 import { TaskRepeatCfgService } from '../../task-repeat-cfg/task-repeat-cfg.service';
 import { TaskAttachmentService } from '../task-attachment/task-attachment.service';
 import { TaskFocusService } from '../task-focus.service';
-import { DEFAULT_TASK, HideSubTasksMode, TaskWithSubTasks } from '../task.model';
+import {
+  DEFAULT_TASK,
+  HideSubTasksMode,
+  TaskDetailTargetPanel,
+  TaskWithSubTasks,
+} from '../task.model';
 import { TaskService } from '../task.service';
 import { WorkContextService } from '../../work-context/work-context.service';
 import { TaskComponent } from './task.component';
@@ -77,6 +82,7 @@ describe('TaskComponent shortcut handling', () => {
         'getByIdWithSubTaskData$',
         'focusTaskById',
         'scheduleTask',
+        'markIssueUpdatesAsRead',
       ],
       {
         currentTaskId: signal<string | null>(null),
@@ -770,6 +776,97 @@ describe('TaskComponent shortcut handling', () => {
 
         expectScheduledForToday();
       }));
+    });
+  });
+
+  describe('detail panel toggle button (#9850)', () => {
+    const setTask = (overrides: Partial<TaskWithSubTasks>): void => {
+      fixture.componentRef.setInput('task', {
+        ...createTopLevelTask('Task'),
+        ...overrides,
+      });
+      fixture.componentRef.setInput('isInSubTaskList', false);
+      fixture.detectChanges();
+    };
+    const selectedTaskId = (): WritableSignal<string | null> =>
+      taskServiceSpy.selectedTaskId as unknown as WritableSignal<string | null>;
+    const isXs = (): WritableSignal<boolean> =>
+      TestBed.inject(LayoutService).isXs as unknown as WritableSignal<boolean>;
+
+    it('opens the notes section directly when the task has notes', () => {
+      setTask({ notes: 'some notes' });
+
+      component.onToggleDetailPanelBtnClick();
+
+      expect(taskServiceSpy.setSelectedId).toHaveBeenCalledWith(
+        'top-1',
+        TaskDetailTargetPanel.Notes,
+      );
+    });
+
+    it('opens the notes section on mobile, where the bug was reported', () => {
+      isXs().set(true);
+      setTask({ notes: 'some notes' });
+
+      component.onToggleDetailPanelBtnClick();
+
+      expect(taskServiceSpy.setSelectedId).toHaveBeenCalledWith(
+        'top-1',
+        TaskDetailTargetPanel.Notes,
+      );
+    });
+
+    it('prefers the notes section for an issue-linked task that has notes', () => {
+      setTask({ notes: 'some notes', issueId: 'GH-1', issueType: 'GITHUB' });
+
+      component.onToggleDetailPanelBtnClick();
+
+      expect(taskServiceSpy.setSelectedId).toHaveBeenCalledWith(
+        'top-1',
+        TaskDetailTargetPanel.Notes,
+      );
+    });
+
+    it('opens the default panel for an issue-linked task without notes', () => {
+      setTask({ notes: '', issueId: 'GH-1', issueType: 'GITHUB' });
+
+      component.onToggleDetailPanelBtnClick();
+
+      expect(taskServiceSpy.setSelectedId).toHaveBeenCalledWith(
+        'top-1',
+        TaskDetailTargetPanel.Default,
+      );
+    });
+
+    it('opens the default panel and clears the badge in the issue-updated state', () => {
+      setTask({ notes: 'some notes', issueId: 'GH-1', issueWasUpdated: true });
+
+      component.onToggleDetailPanelBtnClick();
+
+      expect(taskServiceSpy.markIssueUpdatesAsRead).toHaveBeenCalledWith('top-1');
+      expect(taskServiceSpy.setSelectedId).toHaveBeenCalledWith(
+        'top-1',
+        TaskDetailTargetPanel.Default,
+      );
+    });
+
+    it('closes the panel when it is already open for this task', () => {
+      setTask({ notes: 'some notes' });
+      selectedTaskId().set('top-1');
+
+      component.onToggleDetailPanelBtnClick();
+
+      expect(taskServiceSpy.setSelectedId).toHaveBeenCalledWith(null);
+    });
+
+    it('closes the panel on mobile where the icon stays "chat" while open', () => {
+      isXs().set(true);
+      setTask({ notes: 'some notes' });
+      selectedTaskId().set('top-1');
+
+      component.onToggleDetailPanelBtnClick();
+
+      expect(taskServiceSpy.setSelectedId).toHaveBeenCalledWith(null);
     });
   });
 });

--- a/src/app/features/tasks/task/task.component.ts
+++ b/src/app/features/tasks/task/task.component.ts
@@ -1033,10 +1033,22 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     if (task.issueWasUpdated) {
       this._taskService.markIssueUpdatesAsRead(task.id);
     }
-    this.toggleShowDetailPanel(ev);
+    // In its plain 'chat' state the button reads as a notes indicator (it also
+    // shows for issue-linked tasks without notes, hence the notes guard), so
+    // land on the notes section — expanded and scrolled into view — rather
+    // than the collapsed accordion; on mobile that used to cost a second tap
+    // on "Note" (#9850).
+    const targetPanel =
+      this.toggleButtonIcon() === 'chat' && task.notes
+        ? TaskDetailTargetPanel.Notes
+        : TaskDetailTargetPanel.Default;
+    this.toggleShowDetailPanel(ev, targetPanel);
   }
 
-  toggleShowDetailPanel(ev?: MouseEvent): void {
+  toggleShowDetailPanel(
+    ev?: MouseEvent,
+    targetPanel: TaskDetailTargetPanel = TaskDetailTargetPanel.Default,
+  ): void {
     const isInTaskDetailPanel =
       this._elementRef.nativeElement.closest('task-detail-panel');
     if (isInTaskDetailPanel && !this._wasClickedInDoubleClickRange) {
@@ -1051,7 +1063,7 @@ export class TaskComponent implements OnDestroy, AfterViewInit {
     if (this.isSelected()) {
       this._taskService.setSelectedId(null);
     } else {
-      this._taskService.setSelectedId(this.task().id);
+      this._taskService.setSelectedId(this.task().id, targetPanel);
     }
     if (ev) {
       ev.preventDefault();


### PR DESCRIPTION
## Summary

Closes #9850 (part 1).

The 'chat' notes indicator on a task row opened the detail panel with the default target. On mobile the bottom sheet then showed every section collapsed, so reaching the note took a second tap on "Note". The button's notes state now routes through `TaskDetailTargetPanel.Notes`, the target the checklist badge and the `N` shortcut already use, which expands the notes section and scrolls it into view.

- The 'update' and 'close' states of the button, and issue-linked tasks without notes, keep the default panel.
- On desktop the notes section was already expanded for tasks with notes. The only change there is that the panel focuses and scrolls to the notes item instead of the first item, matching the `N` shortcut.
- No template, signal, or subscription changes in the hot-path task component.
- Part 2 of the issue (live-preview markdown editor) is declined as a duplicate of #6656 / #5765.

## Tests

- 7 unit tests in `task-shortcuts.spec.ts` covering notes, mobile, issue-linked with/without notes, issue-updated, and close-while-open. Three fail on the unpatched component.
- New e2e `notes-btn-opens-notes-9850.spec.ts` drives the phone bottom sheet and asserts the notes `mat-expansion-panel` is expanded. Fails unpatched, passes patched.
- 22 related e2e tests (focus mode, reminders, task detail, panel focus sync, subtask from panel, mobile resize) pass.

## Known pre-existing quirk (not changed)

`setCurrentTask` moves the selection to the newly tracked task but keeps the current `taskDetailTargetPanel`, so a lingering Notes target can expand an empty notes section for the next task. This has existed since v18.10.0 for the checklist badge; left as is to keep the diff minimal.

https://claude.ai/code/session_01GbydaU6CJEfVfHxajFSrwr
