### PR TITLE
fix(theme): stop transformed background image from leaving body scrolled

### DIFF
--- a/e2e/tests/app-features/background-blur-body-overflow.spec.ts
+++ b/e2e/tests/app-features/background-blur-body-overflow.spec.ts
@@ -1,67 +1,97 @@
 import { expect, test } from '../../fixtures/test.fixture';
 
 /**
- * Bug: `.bg-image` (app.component.scss) is `position: absolute` relative to
- * `body` (page.scss: `body { position: absolute }`), and gets
- * `transform: scale(1.12)` when blurred (`.is-blurred`). That doesn't change
- * its layout size, but it does expand its *painted* bounds -- and a
+ * Bug: `.bg-image` (app.component.scss) is `position: absolute`, and its
+ * containing block is `body` (page.scss: `body { position: absolute }`) --
+ * there's nothing between the two to clip it (`app-root` sits in between in
+ * the DOM and is `overflow: hidden`, but that clip doesn't apply: an abspos
+ * descendant whose containing block is an *ancestor* of the clipping box
+ * escapes it entirely). `.is-blurred` scales this element -- that doesn't
+ * change its layout size, but it does expand its *painted* bounds, and a
  * transformed descendant's painted bounds count toward its containing
- * block's scrollable-overflow region. `.app-container` (the next element
- * down) has `overflow: visible`, so that overflow isn't clipped there and
- * bubbles up to `body`, which is `overflow: hidden` but still ends up with
- * real, permanent scrollable overflow the entire time a blurred background
- * is active -- independent of any route or animation.
+ * block's scrollable-overflow region -- so `body` ends up with real,
+ * permanent scrollable overflow the entire time the background is
+ * transformed, independent of any route or animation.
  *
  * This is silent on its own, but any `scrollIntoView()` call anywhere in the
  * app whose ancestor walk reaches `body` (e.g. ScheduleComponent's
  * current-time anchor) can then nudge `body.scrollLeft`/`scrollTop`, and
  * since the overflow is a static style (not an animation), nothing ever
  * resets it back to 0 -- the app shell stays visibly shifted until restart.
+ *
+ * "Blurred" is the common trigger (the app's own `.is-blurred` class), but
+ * not the only one: the built-in `velvet` theme applies its own
+ * `transform: scale(1.06)` to `.bg-image` for every dark-theme wallpaper,
+ * blur setting aside (velvet.css) -- covered by the second test below.
  */
 type StoreLike = {
   dispatch: (action: unknown) => void;
 };
 
-test.describe('Background image blur', () => {
-  test('does not leave <body> with real scrollable overflow', async ({
+const setBackground = (
+  page: import('@playwright/test').Page,
+  blur: number,
+): Promise<boolean> =>
+  expect
+    .poll(() =>
+      page.evaluate((blurPx) => {
+        const store = (window as unknown as { __e2eTestHelpers?: { store?: StoreLike } })
+          .__e2eTestHelpers?.store;
+        if (!store) return false;
+        store.dispatch({
+          type: '[Global Config] Update Global Config Section',
+          sectionKey: 'misc',
+          sectionCfg: {
+            backgroundImageLight: 'e2e-test-bg.png',
+            backgroundImageDark: 'e2e-test-bg.png',
+            backgroundImageBlur: blurPx,
+          },
+          isSkipSnack: true,
+        });
+        return true;
+      }, blur),
+    )
+    .toBe(true);
+
+const expectNoRealBodyOverflow = async (
+  page: import('@playwright/test').Page,
+): Promise<void> => {
+  const overflow = await page.evaluate(() => ({
+    scrollWidth: document.body.scrollWidth,
+    clientWidth: document.body.clientWidth,
+    scrollHeight: document.body.scrollHeight,
+    clientHeight: document.body.clientHeight,
+  }));
+
+  expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth);
+  expect(overflow.scrollHeight).toBeLessThanOrEqual(overflow.clientHeight);
+};
+
+test.describe('Background image transform', () => {
+  test('blurred background does not leave <body> with real scrollable overflow', async ({
     page,
     workViewPage,
   }) => {
     await workViewPage.waitForTaskList();
-
-    await expect
-      .poll(() =>
-        page.evaluate(() => {
-          const store = (
-            window as unknown as { __e2eTestHelpers?: { store?: StoreLike } }
-          ).__e2eTestHelpers?.store;
-          if (!store) return false;
-          store.dispatch({
-            type: '[Global Config] Update Global Config Section',
-            sectionKey: 'misc',
-            sectionCfg: {
-              backgroundImageLight: 'e2e-test-bg.png',
-              backgroundImageDark: 'e2e-test-bg.png',
-              backgroundImageBlur: 20,
-            },
-            isSkipSnack: true,
-          });
-          return true;
-        }),
-      )
-      .toBe(true);
-
+    await setBackground(page, 20);
     // Wait for the blurred background to actually be in the DOM.
     await expect(page.locator('.bg-image.is-blurred')).toBeVisible();
+    await expectNoRealBodyOverflow(page);
+  });
 
-    const overflow = await page.evaluate(() => ({
-      scrollWidth: document.body.scrollWidth,
-      clientWidth: document.body.clientWidth,
-      scrollHeight: document.body.scrollHeight,
-      clientHeight: document.body.clientHeight,
-    }));
-
-    expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth);
-    expect(overflow.scrollHeight).toBeLessThanOrEqual(overflow.clientHeight);
+  test('velvet theme scales the background at blur 0, still no real <body> overflow', async ({
+    page,
+    workViewPage,
+  }) => {
+    await workViewPage.waitForTaskList();
+    await page.evaluate(() => {
+      localStorage.setItem('DARK_MODE', 'dark');
+      localStorage.setItem('CUSTOM_THEME', 'builtin:velvet');
+    });
+    await page.reload();
+    await workViewPage.waitForTaskList();
+    await setBackground(page, 0);
+    await expect(page.locator('.bg-image')).toBeVisible();
+    await expectNoRealBodyOverflow(page);
   });
 });

--- a/e2e/tests/app-features/background-blur-body-overflow.spec.ts
+++ b/e2e/tests/app-features/background-blur-body-overflow.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '../../fixtures/test.fixture';
+
+/**
+ * Bug: `.bg-image` (app.component.scss) is `position: absolute` relative to
+ * `body` (page.scss: `body { position: absolute }`), and gets
+ * `transform: scale(1.12)` when blurred (`.is-blurred`). That doesn't change
+ * its layout size, but it does expand its *painted* bounds -- and a
+ * transformed descendant's painted bounds count toward its containing
+ * block's scrollable-overflow region. `.app-container` (the next element
+ * down) has `overflow: visible`, so that overflow isn't clipped there and
+ * bubbles up to `body`, which is `overflow: hidden` but still ends up with
+ * real, permanent scrollable overflow the entire time a blurred background
+ * is active -- independent of any route or animation.
+ *
+ * This is silent on its own, but any `scrollIntoView()` call anywhere in the
+ * app whose ancestor walk reaches `body` (e.g. ScheduleComponent's
+ * current-time anchor) can then nudge `body.scrollLeft`/`scrollTop`, and
+ * since the overflow is a static style (not an animation), nothing ever
+ * resets it back to 0 -- the app shell stays visibly shifted until restart.
+ */
+type StoreLike = {
+  dispatch: (action: unknown) => void;
+};
+
+test.describe('Background image blur', () => {
+  test('does not leave <body> with real scrollable overflow', async ({
+    page,
+    workViewPage,
+  }) => {
+    await workViewPage.waitForTaskList();
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const store = (
+            window as unknown as { __e2eTestHelpers?: { store?: StoreLike } }
+          ).__e2eTestHelpers?.store;
+          if (!store) return false;
+          store.dispatch({
+            type: '[Global Config] Update Global Config Section',
+            sectionKey: 'misc',
+            sectionCfg: {
+              backgroundImageLight: 'e2e-test-bg.png',
+              backgroundImageDark: 'e2e-test-bg.png',
+              backgroundImageBlur: 20,
+            },
+            isSkipSnack: true,
+          });
+          return true;
+        }),
+      )
+      .toBe(true);
+
+    // Wait for the blurred background to actually be in the DOM.
+    await expect(page.locator('.bg-image.is-blurred')).toBeVisible();
+
+    const overflow = await page.evaluate(() => ({
+      scrollWidth: document.body.scrollWidth,
+      clientWidth: document.body.clientWidth,
+      scrollHeight: document.body.scrollHeight,
+      clientHeight: document.body.clientHeight,
+    }));
+
+    expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth);
+    expect(overflow.scrollHeight).toBeLessThanOrEqual(overflow.clientHeight);
+  });
+});

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -218,7 +218,24 @@ mat-sidenav {
 }
 
 .bg-image {
-  position: absolute;
+  // `fixed`, not `absolute`: `body` is itself `position: absolute` (page.scss),
+  // so an absolutely-positioned `.bg-image` is sized/positioned relative to
+  // it. `.is-blurred` below scales this element -- that doesn't change its
+  // layout size, but it does expand its *painted* bounds, and a transformed
+  // descendant's painted bounds count toward its containing block's
+  // scrollable-overflow region. `.app-container` (the next element down) is
+  // `overflow: visible`, so that overflow isn't clipped there and used to
+  // bubble up to `body` (`overflow: hidden`, but still scrollable) -- giving
+  // `body` real, permanent scrollable overflow for as long as a blurred
+  // background is active. Any scrollIntoView() elsewhere whose ancestor walk
+  // reached `body` could then nudge body.scrollLeft/scrollTop, and since that
+  // overflow is a static style rather than an animation, nothing ever
+  // resets it -- the whole app shell stayed visibly shifted until restart.
+  // `position: fixed` anchors this to the viewport instead, which is excluded
+  // from any ancestor's scrollable-overflow accounting (no ancestor between
+  // here and the viewport sets transform/filter/contain, which would
+  // otherwise create a new containing block for fixed descendants).
+  position: fixed;
   inset: 0;
   pointer-events: none;
   width: 100%;

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -219,22 +219,20 @@ mat-sidenav {
 
 .bg-image {
   // `fixed`, not `absolute`: `body` is itself `position: absolute` (page.scss),
-  // so an absolutely-positioned `.bg-image` is sized/positioned relative to
-  // it. `.is-blurred` below scales this element -- that doesn't change its
-  // layout size, but it does expand its *painted* bounds, and a transformed
-  // descendant's painted bounds count toward its containing block's
-  // scrollable-overflow region. `.app-container` (the next element down) is
-  // `overflow: visible`, so that overflow isn't clipped there and used to
-  // bubble up to `body` (`overflow: hidden`, but still scrollable) -- giving
-  // `body` real, permanent scrollable overflow for as long as a blurred
-  // background is active. Any scrollIntoView() elsewhere whose ancestor walk
-  // reached `body` could then nudge body.scrollLeft/scrollTop, and since that
-  // overflow is a static style rather than an animation, nothing ever
-  // resets it -- the whole app shell stayed visibly shifted until restart.
-  // `position: fixed` anchors this to the viewport instead, which is excluded
-  // from any ancestor's scrollable-overflow accounting (no ancestor between
-  // here and the viewport sets transform/filter/contain, which would
-  // otherwise create a new containing block for fixed descendants).
+  // so an absolutely-positioned `.bg-image` was sized/positioned relative to
+  // it, and `.is-blurred` below scales it -- same transformed-descendant/
+  // scrollable-overflow mechanism as #9837's ScheduleComponent warpRoute fix
+  // (see that PR / schedule.component.ts for the full writeup), except this
+  // one is a static style
+  // rather than an animation, so `body`'s resulting overflow never settles
+  // back down: any scrollIntoView() elsewhere whose ancestor walk reached
+  // `body` (`.app-container` in between is `overflow: visible`, so it didn't
+  // stop there) could leave the whole app shell visibly shifted until
+  // restart. `position: fixed` anchors this to the viewport instead, which
+  // is excluded from any ancestor's scrollable-overflow accounting (no
+  // ancestor between here and the viewport sets transform/filter/contain,
+  // which would otherwise create a new containing block for fixed
+  // descendants).
   position: fixed;
   inset: 0;
   pointer-events: none;
@@ -242,7 +240,6 @@ mat-sidenav {
   height: 100%;
   background-size: cover !important;
   background-position: center !important;
-  background-attachment: fixed;
 
   &.is-blurred {
     transform: scale(1.12);

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -219,19 +219,23 @@ mat-sidenav {
 
 .bg-image {
   // `fixed`, not `absolute`: `body` is itself `position: absolute` (page.scss),
-  // so an absolutely-positioned `.bg-image` was sized/positioned relative to
-  // it, and `.is-blurred` below scales it -- same transformed-descendant/
-  // scrollable-overflow mechanism as #9837's ScheduleComponent warpRoute fix
-  // (see that PR / schedule.component.ts for the full writeup), except this
-  // one is a static style
-  // rather than an animation, so `body`'s resulting overflow never settles
-  // back down: any scrollIntoView() elsewhere whose ancestor walk reached
-  // `body` (`.app-container` in between is `overflow: visible`, so it didn't
-  // stop there) could leave the whole app shell visibly shifted until
-  // restart. `position: fixed` anchors this to the viewport instead, which
-  // is excluded from any ancestor's scrollable-overflow accounting (no
-  // ancestor between here and the viewport sets transform/filter/contain,
-  // which would otherwise create a new containing block for fixed
+  // so an absolutely-positioned `.bg-image` was sized/positioned directly
+  // against it -- nothing in between (app-root does sit in the DOM between
+  // the two and is `overflow: hidden`, but that doesn't clip an abspos
+  // descendant whose containing block is an ancestor of the clipping box).
+  // `.is-blurred` below scales this element -- that doesn't change its
+  // layout size, but it does expand its *painted* bounds, and those count
+  // toward its containing block's scrollable-overflow region (same
+  // transformed-descendant mechanism as #9873/#9837). Unlike a transform
+  // tied to a route-enter animation, this one is a static style, so `body`'s
+  // resulting overflow never settles back down: any scrollIntoView()
+  // elsewhere whose ancestor walk reached `body` (`.app-container`, a real
+  // DOM ancestor of most scroll targets, is `overflow: visible`, so it
+  // didn't stop there) could leave the whole app shell visibly shifted
+  // until restart. `position: fixed` anchors this to the viewport instead,
+  // which is excluded from any ancestor's scrollable-overflow accounting
+  // (no ancestor between here and the viewport sets transform/filter/
+  // contain, which would otherwise create a new containing block for fixed
   // descendants).
   position: fixed;
   inset: 0;

--- a/src/styles/page.scss
+++ b/src/styles/page.scss
@@ -121,6 +121,12 @@ body {
   width: 100%;
   height: 100%;
 
+  // Stays untransformed by design (#9874): a transform/scale added here would
+  // expand this layer's painted bounds without changing its layout size, and
+  // since `.app-container` between here and `body` is `overflow: visible`,
+  // that overflow would bubble up and give `body` real, permanent scrollable
+  // overflow -- the same bug `.bg-image` had (app.component.scss). If this
+  // ever needs a transform, give it `position: fixed` like `.bg-image` too.
   &:before {
     display: none;
     transition: 1s opacity;

--- a/src/styles/page.scss
+++ b/src/styles/page.scss
@@ -121,12 +121,14 @@ body {
   width: 100%;
   height: 100%;
 
-  // Stays untransformed by design (#9874): a transform/scale added here would
-  // expand this layer's painted bounds without changing its layout size, and
-  // since `.app-container` between here and `body` is `overflow: visible`,
-  // that overflow would bubble up and give `body` real, permanent scrollable
-  // overflow -- the same bug `.bg-image` had (app.component.scss). If this
-  // ever needs a transform, give it `position: fixed` like `.bg-image` too.
+  // Stays untransformed by design (#9874): this is positioned directly
+  // against `body` (its containing block, since `body` is `position:
+  // absolute` above) -- there's nothing between the two to clip it. A
+  // transform/scale added here would expand this layer's painted bounds
+  // without changing its layout size, feeding that straight into `body`'s
+  // scrollable-overflow region -- the same bug `.bg-image` had
+  // (app.component.scss). If this ever needs a transform, give it
+  // `position: fixed` like `.bg-image` too.
   &:before {
     display: none;
     transition: 1s opacity;


### PR DESCRIPTION
Fixes #9873

## Problem

With a custom background image + blur enabled, the app shell (sidebar included) can end up permanently shifted/cut off after any `scrollIntoView()` call whose ancestor walk reaches `body` — e.g. `ScheduleComponent`'s current-time anchor, though it's not specific to Schedule. Resizing the window or switching views doesn't fix it; only a full app restart clears it. Found while investigating #9837.

`.bg-image` (`app.component.scss`) is `position: absolute` relative to `body` (`body` itself is `position: absolute`, `page.scss`), and `.is-blurred` adds `transform: scale(1.12)` to hide the blur edge. That doesn't change `.bg-image`'s layout size, but it does expand its *painted* bounds — and a transformed descendant's painted bounds count toward its containing block's scrollable-overflow region. `.app-container` (the next element down) is `overflow: visible`, so that overflow isn't clipped there and bubbles up to `body` (`overflow: hidden`, but still scrollable) — giving `body` real, permanent scrollable overflow for as long as a blurred background image is active, independent of any route or animation.

Any `scrollIntoView()` call anywhere in the app whose ancestor walk reaches `body` can then nudge `body.scrollLeft`/`scrollTop`. Since this overflow is a static style rather than an animation, nothing ever resets it back to `0` — unlike a transform tied to a route-enter animation (which self-corrects once the animation finishes and its overflow shrinks back down), this one just sits there until the process restarts and repaints from `scrollLeft: 0`.

## Solution

`position: fixed` anchors `.bg-image` to the viewport instead of `body`. Fixed-position elements are excluded from any ancestor's scrollable-overflow accounting, unless something between them and the viewport establishes a new containing block for fixed descendants (`transform`/`filter`/`contain`/etc.) — verified nothing in this chain (`app-root`, `.app-frame`, `body`, `html`) does.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Testing

- Added an E2E regression test asserting `document.body` never gains real scrollable overflow (`scrollWidth`/`scrollHeight` beyond `clientWidth`/`clientHeight`) while a blurred background image is configured — reproduces reliably pre-fix (`scrollWidth: 1357` vs `clientWidth: 1280`), passes post-fix.
- Manually verified stacking/paint order is unaffected: `position: fixed` (unlike `absolute`) always creates a new stacking context, so checked visually with the `liquid-glass` builtin theme (translucent panels) that the background still renders behind all UI, not on top of it.
- `npm run checkFile` on both changed files.

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). *(not applicable — internal bug fix, no user-facing behavior to document)*
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

