### PR TITLE
feat(automations): add keyboard shortcut trigger

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -476,8 +476,7 @@ PluginAPI.registerShortcut({
   },
 });
 
-// Removes it again. Registering the same id replaces the existing entry, so
-// this is only needed when a shortcut disappears for good.
+// Removes it again.
 PluginAPI.unregisterShortcut('my-shortcut');
 ```
 
@@ -797,8 +796,8 @@ navigation helpers, persistence helpers, counters, action dispatch, `registerHoo
 and `registerWorkContextHeaderButton()`. Callback-heavy registration methods such as
 `registerHeaderButton()`, `registerMenuEntry()`, `registerSidePanelButton()`,
 `registerShortcut()`/`unregisterShortcut()`, and `registerConfigHandler()` must be
-registered from host-side `plugin.js` code. APIs not injected into the iframe are unavailable, even if
-they exist on the host-side plugin bridge.
+called from host-side `plugin.js` code. APIs not injected into the iframe are
+unavailable, even if they exist on the host-side plugin bridge.
 
 `executeNodeScript()` is proxied through the host bridge for iframe plugins when
 the desktop app grants the plugin `nodeExecution` permission.

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -469,13 +469,21 @@ PluginAPI.registerSidePanelButton({
 
 ```javascript
 PluginAPI.registerShortcut({
-  keys: 'ctrl+shift+p',
+  id: 'my-shortcut', // optional, derived from the label when omitted
   label: 'My Plugin Shortcut',
-  action: () => {
+  onExec: () => {
     console.log('Shortcut triggered');
   },
 });
+
+// Removes it again. Registering the same id replaces the existing entry, so
+// this is only needed when a shortcut disappears for good.
+PluginAPI.unregisterShortcut('my-shortcut');
 ```
+
+Plugins do not pick the key combination: the shortcut shows up under **Plugin
+Shortcuts** in the keyboard settings, where the user assigns one. The binding is
+stored per shortcut id, so keep the id stable across app starts.
 
 #### Hooks
 
@@ -788,8 +796,8 @@ The iframe can use the injected task/project/tag APIs, dialog and notification A
 navigation helpers, persistence helpers, counters, action dispatch, `registerHook()`,
 and `registerWorkContextHeaderButton()`. Callback-heavy registration methods such as
 `registerHeaderButton()`, `registerMenuEntry()`, `registerSidePanelButton()`,
-`registerShortcut()`, and `registerConfigHandler()` must be registered from
-host-side `plugin.js` code. APIs not injected into the iframe are unavailable, even if
+`registerShortcut()`/`unregisterShortcut()`, and `registerConfigHandler()` must be
+registered from host-side `plugin.js` code. APIs not injected into the iframe are unavailable, even if
 they exist on the host-side plugin bridge.
 
 `executeNodeScript()` is proxied through the host bridge for iframe plugins when

--- a/docs/wiki/3.01-API.md
+++ b/docs/wiki/3.01-API.md
@@ -87,6 +87,7 @@ development guide live in `packages/plugin-api/src/types.ts` and
 **Registration (main plugin context only; not in iframe):**
 
 - `registerHeaderButton(config)`, `registerMenuEntry(config)`, `registerShortcut(config)`, `registerSidePanelButton(config)`, `registerHook(hook, handler)`.
+- `unregisterShortcut(shortcutId)` — Removes a shortcut the plugin registered. Registering the same id again replaces the existing entry, so this is only needed when a shortcut goes away for good. The key the user assigned stays in the keyboard settings and applies again if the same id comes back.
 
 **Persistence:**
 

--- a/docs/wiki/3.03-Keyboard-Shortcuts.md
+++ b/docs/wiki/3.03-Keyboard-Shortcuts.md
@@ -172,7 +172,7 @@ If `xdg-open` does not reach the app, confirm the desktop entry registers the sc
 
 ## Plugin Shortcuts
 
-Plugins can add their own shortcuts. They are listed under **Plugin Shortcuts** in the keyboard settings as `<shortcut label> (<plugin id>)` and ship without a default binding, so they do nothing until a key is assigned. They are matched after all built-in shortcuts, so an existing binding wins over a plugin one.
+Plugins can add their own shortcuts. They are listed under **Plugin Shortcuts** in the keyboard settings as `<shortcut label> (<plugin id>)` and ship without a default binding, so they do nothing until a key is assigned. They are matched after all built-in shortcuts, and matching does not stop there: a combination already used by a built-in shortcut triggers both, so pick a free one. Held keys do not repeat — a plugin shortcut runs once per press.
 
 The bundled **Automations** plugin uses this for its _Keyboard Shortcut_ trigger: every enabled rule with that trigger appears as its own entry, named after the rule. Pressing the assigned key runs that rule's actions against the task row currently focused — without a focused task, only task-independent actions (create task, snack, dialog, webhook) do anything. Disabling or deleting a rule removes its entry again; renaming a rule keeps the assigned key.
 

--- a/docs/wiki/3.03-Keyboard-Shortcuts.md
+++ b/docs/wiki/3.03-Keyboard-Shortcuts.md
@@ -170,6 +170,12 @@ If `xdg-open` does not reach the app, confirm the desktop entry registers the sc
 
 > **Packaging note:** the `.deb`/`.rpm` packages register the scheme at install time. With the **AppImage** you must integrate it into your desktop first (e.g. via AppImageLauncher), otherwise nothing registers the scheme. **Flatpak/Snap** register it via their own packaged desktop file, so `xdg-mime query` resolves to that id rather than a plain `superproductivity.desktop`.
 
+## Plugin Shortcuts
+
+Plugins can add their own shortcuts. They are listed under **Plugin Shortcuts** in the keyboard settings as `<shortcut label> (<plugin id>)` and ship without a default binding, so they do nothing until a key is assigned. They are matched after all built-in shortcuts, so an existing binding wins over a plugin one.
+
+The bundled **Automations** plugin uses this for its _Keyboard Shortcut_ trigger: every enabled rule with that trigger appears as its own entry, named after the rule. Pressing the assigned key runs that rule's actions against the task row currently focused — without a focused task, only task-independent actions (create task, snack, dialog, webhook) do anything. Disabling or deleting a rule removes its entry again; renaming a rule keeps the assigned key.
+
 ## Configurable Vs Reserved
 
 All shortcuts listed in [[3.02-Settings-and-Preferences]] are user-configurable. Users can:

--- a/docs/wiki/3.03-Keyboard-Shortcuts.md
+++ b/docs/wiki/3.03-Keyboard-Shortcuts.md
@@ -174,7 +174,7 @@ If `xdg-open` does not reach the app, confirm the desktop entry registers the sc
 
 Plugins can add their own shortcuts. They are listed under **Plugin Shortcuts** in the keyboard settings as `<shortcut label> (<plugin id>)` and ship without a default binding, so they do nothing until a key is assigned. They are matched after all built-in shortcuts, and matching does not stop there: a combination already used by a built-in shortcut triggers both, so pick a free one. Held keys do not repeat — a plugin shortcut runs once per press.
 
-The bundled **Automations** plugin uses this for its _Keyboard Shortcut_ trigger: every enabled rule with that trigger appears as its own entry, named after the rule. Pressing the assigned key runs that rule's actions against the task row currently focused — without a focused task, only task-independent actions (create task, snack, dialog, webhook) do anything. Disabling or deleting a rule removes its entry again; renaming a rule keeps the assigned key.
+The bundled **Automations** plugin uses this for its _Keyboard Shortcut_ trigger: every enabled rule with that trigger appears as its own entry, named after the rule. Pressing the assigned key runs that rule's actions against the task row currently focused — without a focused task, only task-independent actions (create task, snack, dialog, webhook) do anything.
 
 ## Configurable Vs Reserved
 

--- a/electron/indicator.test.cjs
+++ b/electron/indicator.test.cjs
@@ -1,5 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
 const path = require('node:path');
 const Module = require('node:module');
 
@@ -17,12 +18,42 @@ let traySetTitleCalls = [];
 let traySetToolTipCalls = [];
 let ipcHandlers = new Map();
 let nextNativeImageIsEmpty = false;
+let templateImages = [];
 let beforeQuitHandler = () => {};
 let mockIsTrayShowCurrentTask = false;
 let mockIsTrayShowCurrentCountdown = false;
 
 const resetModule = () => {
   delete require.cache[indicatorModulePath];
+};
+
+// Width/height from the PNG IHDR chunk so tests see the real asset sizes;
+// paths that don't exist on disk (the '/icons/' fixtures) fall back to 16px.
+const readPngSize = (iconPath) => {
+  if (!fs.existsSync(iconPath)) {
+    return { width: 16, height: 16 };
+  }
+  const header = Buffer.alloc(24);
+  const fd = fs.openSync(iconPath, 'r');
+  fs.readSync(fd, header, 0, 24, 0);
+  fs.closeSync(fd);
+  return { width: header.readUInt32BE(16), height: header.readUInt32BE(20) };
+};
+
+const createFakeNativeImage = (iconPath, size) => {
+  const image = {
+    iconPath,
+    kind: 'native-image',
+    isTemplate: false,
+    isEmpty: () => nextNativeImageIsEmpty,
+    getSize: () => size,
+    resize: ({ width, height }) => createFakeNativeImage(iconPath, { width, height }),
+    setTemplateImage: (value) => {
+      image.isTemplate = value;
+      templateImages.push(image);
+    },
+  };
+  return image;
 };
 
 const installMocks = () => {
@@ -72,12 +103,7 @@ const installMocks = () => {
         nativeImage: {
           createFromPath: (iconPath) => {
             createdFromPath.push(iconPath);
-            return {
-              iconPath,
-              kind: 'native-image',
-              isEmpty: () => nextNativeImageIsEmpty,
-              setTemplateImage: () => {},
-            };
+            return createFakeNativeImage(iconPath, readPngSize(iconPath));
           },
         },
       };
@@ -149,6 +175,7 @@ test.beforeEach(() => {
   traySetToolTipCalls = [];
   ipcHandlers = new Map();
   nextNativeImageIsEmpty = false;
+  templateImages = [];
   beforeQuitHandler = () => {};
   mockIsTrayShowCurrentTask = false;
   mockIsTrayShowCurrentCountdown = false;
@@ -290,6 +317,51 @@ test('non-Linux platforms keep the running progress animation', () => {
     traySetImageCalls.at(-1).iconPath,
     /\/icons\/indicator\/running-anim-l\/3\.png$/,
   );
+});
+
+// The static stopped/running icons are rendered at 24px so GNOME doesn't
+// upscale them (#8484), but the progress-animation frames are 16px. macOS draws
+// a template image at its native point size, so without normalizing the menu
+// bar icon shrinks (and the title text jumps) the moment tracking starts.
+test('macOS hands the tray 16pt template images regardless of source asset size', () => {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: 'darwin',
+  });
+  const { initIndicator } = loadIndicatorModule();
+
+  initIndicator({
+    showApp: () => {},
+    quitApp: () => {},
+    ICONS_FOLDER: path.resolve(__dirname, 'assets/icons') + '/',
+    forceDarkTray: false,
+    app: { on: () => {} },
+  });
+
+  const currentTaskUpdated = ipcHandlers.get('CURRENT_TASK_UPDATED');
+  currentTaskUpdated(
+    {},
+    { id: 'T1', title: 'Task', timeSpent: 5 * 60000, timeEstimate: 25 * 60000 },
+    false,
+    0,
+    false,
+    0,
+    undefined,
+  );
+
+  const trayImages = [createdTrayArgs[0][0], ...traySetImageCalls];
+  // Sanity check: the fixture really covers both source sizes.
+  const sourceSizes = new Set(createdFromPath.map((p) => readPngSize(p).width));
+  assert.deepEqual(
+    [...sourceSizes].sort((a, b) => a - b),
+    [16, 24],
+  );
+
+  for (const image of trayImages) {
+    assert.equal(image.kind, 'native-image', image.iconPath);
+    assert.deepEqual(image.getSize(), { width: 16, height: 16 }, image.iconPath);
+    assert.equal(image.isTemplate, true, `not a template image: ${image.iconPath}`);
+  }
 });
 
 test('initIndicator falls back to icon path if NativeImage creation is empty', () => {

--- a/electron/indicator.ts
+++ b/electron/indicator.ts
@@ -573,6 +573,12 @@ function getRunningIconPath(progress?: number): string {
 
 let curIco: string | undefined;
 
+// macOS draws a menu bar image at its native point size (16pt is Electron's
+// recommendation). The static stopped/running icons are rendered at 24px so
+// GNOME doesn't upscale them (#8484) while the progress-animation frames are
+// 16px, so without normalizing the icon shrinks the moment tracking starts.
+const MAC_TRAY_ICON_SIZE = 16;
+
 // GNOME AppIndicator can fall back to a generic "three dots" icon for
 // sandboxed Electron apps when given only a file path. Passing a NativeImage
 // keeps the actual pixel data attached to the tray item.
@@ -584,13 +590,19 @@ const getTrayImage = (icoPath: string): string | Electron.NativeImage => {
     return icoPath;
   }
 
-  const image = nativeImage.createFromPath(icoPath);
+  let image = nativeImage.createFromPath(icoPath);
   if (image.isEmpty()) {
     log('Tray icon NativeImage is empty, falling back to icon path:', icoPath);
     return icoPath;
   }
 
   if (IS_MAC) {
+    const { width, height } = image.getSize();
+    if (width !== MAC_TRAY_ICON_SIZE || height !== MAC_TRAY_ICON_SIZE) {
+      // resize() re-derives every scale factor from the source, so the @2x
+      // representation survives and the icon stays crisp on retina displays.
+      image = image.resize({ width: MAC_TRAY_ICON_SIZE, height: MAC_TRAY_ICON_SIZE });
+    }
     image.setTemplateImage(true);
   }
 

--- a/packages/plugin-api/src/types.ts
+++ b/packages/plugin-api/src/types.ts
@@ -529,10 +529,11 @@ export interface PluginAPI {
   ): void;
 
   /**
-   * Remove a shortcut this plugin registered before. Registering the same id
-   * again replaces the existing entry, so this is only needed when a shortcut
-   * disappears for good. The user's key binding is kept in the keyboard
-   * settings, so re-registering the same id restores it.
+   * Remove a shortcut this plugin registered before, by the id it was
+   * registered with (when `id` was omitted there, that is the sanitized label).
+   * Registering the same id again replaces the existing entry, so this is only
+   * needed when a shortcut disappears for good. The user's key binding is kept
+   * in the keyboard settings, so re-registering the same id restores it.
    */
   unregisterShortcut(shortcutId: string): void;
 

--- a/packages/plugin-api/src/types.ts
+++ b/packages/plugin-api/src/types.ts
@@ -528,6 +528,14 @@ export interface PluginAPI {
     shortcutCfg: Omit<PluginShortcutCfg, 'pluginId'> & { id?: string },
   ): void;
 
+  /**
+   * Remove a shortcut this plugin registered before. Registering the same id
+   * again replaces the existing entry, so this is only needed when a shortcut
+   * disappears for good. The user's key binding is kept in the keyboard
+   * settings, so re-registering the same id restores it.
+   */
+  unregisterShortcut(shortcutId: string): void;
+
   registerSidePanelButton(sidePanelBtnCfg: Omit<PluginSidePanelBtnCfg, 'pluginId'>): void;
 
   /**

--- a/packages/plugin-dev/automations/src/app/components/RuleEditor.tsx
+++ b/packages/plugin-dev/automations/src/app/components/RuleEditor.tsx
@@ -50,6 +50,7 @@ export function RuleEditor(props: RuleEditorProps) {
     'taskStarted',
     'taskStopped',
     'timeBased',
+    'shortcut',
   ];
 
   const isTimeBased = () => localRule().trigger.type === 'timeBased';
@@ -180,6 +181,21 @@ export function RuleEditor(props: RuleEditorProps) {
               ))}
             </select>
           </label>
+
+          {localRule().trigger.type === 'shortcut' && (
+            <p>
+              <small>
+                Save the rule, then assign a key in <em>Settings &gt; Keyboard Shortcuts</em>, where
+                it is listed as
+                <strong>
+                  {' '}
+                  {localRule().name.trim() || 'Unnamed automation rule'} (automations)
+                </strong>
+                . Actions apply to the task row you currently have focused; without a focused task
+                only task-independent actions (create task, snack, dialog, webhook) do anything.
+              </small>
+            </p>
+          )}
 
           {localRule().trigger.type === 'timeBased' && (
             <>

--- a/packages/plugin-dev/automations/src/app/components/RuleEditor.tsx
+++ b/packages/plugin-dev/automations/src/app/components/RuleEditor.tsx
@@ -186,13 +186,9 @@ export function RuleEditor(props: RuleEditorProps) {
             <p>
               <small>
                 Save the rule, then assign a key in <em>Settings &gt; Keyboard Shortcuts</em>, where
-                it is listed as
-                <strong>
-                  {' '}
-                  {localRule().name.trim() || 'Unnamed automation rule'} (automations)
-                </strong>
-                . Actions apply to the task row you currently have focused; without a focused task
-                only task-independent actions (create task, snack, dialog, webhook) do anything.
+                it is listed by its rule name under <em>automations</em>. Actions apply to the task
+                row you currently have focused; without a focused task only task-independent actions
+                (create task, snack, dialog, webhook) do anything.
               </small>
             </p>
           )}

--- a/packages/plugin-dev/automations/src/core/automation-manager.spec.ts
+++ b/packages/plugin-dev/automations/src/core/automation-manager.spec.ts
@@ -392,6 +392,63 @@ describe('AutomationManager', () => {
       );
     });
 
+    it('should not rate-limit shortcut rules, so rapid presses raise no dialog', async () => {
+      mockRuleRegistry.getEnabledRules.mockResolvedValue([
+        {
+          id: 'r1',
+          name: 'Tag focused task',
+          trigger: { type: 'shortcut' },
+          conditions: [],
+          actions: [],
+          isEnabled: true,
+        },
+      ]);
+      mockRateLimiter.check.mockReturnValue(false);
+
+      await manager.runShortcutRule('r1');
+
+      expect(mockRateLimiter.check).not.toHaveBeenCalled();
+      expect(mockPlugin.openDialog).not.toHaveBeenCalled();
+      expect(mockActionExecutor.executeAll).toHaveBeenCalled();
+    });
+
+    it('should do nothing when the conditions of a shortcut rule do not match', async () => {
+      mockRuleRegistry.getEnabledRules.mockResolvedValue([
+        {
+          id: 'r1',
+          name: 'Tag focused task',
+          trigger: { type: 'shortcut' },
+          conditions: [{ type: 'hasTag', value: 'urgent' }],
+          actions: [],
+          isEnabled: true,
+        },
+      ]);
+      mockConditionEvaluator.allConditionsMatch.mockResolvedValue(false);
+
+      await manager.runShortcutRule('r1');
+
+      expect(mockActionExecutor.executeAll).not.toHaveBeenCalled();
+    });
+
+    it('should release the shortcut of a disabled shortcut rule', async () => {
+      const rule = {
+        id: 'r1',
+        name: 'Tag focused task',
+        trigger: { type: 'shortcut' },
+        conditions: [],
+        actions: [],
+        isEnabled: true,
+      };
+      mockRuleRegistry.getRules.mockResolvedValue([rule]);
+      await manager.saveRule(rule);
+
+      mockRuleRegistry.getRules.mockResolvedValue([{ ...rule, isEnabled: false }]);
+      await manager.toggleRuleStatus('r1', false);
+
+      expect(mockRuleRegistry.toggleRuleStatus).toHaveBeenCalledWith('r1', false);
+      expect(mockPlugin.unregisterShortcut).toHaveBeenCalledWith('r1');
+    });
+
     it('should release the shortcut of a deleted shortcut rule', async () => {
       const rule = {
         id: 'r1',

--- a/packages/plugin-dev/automations/src/core/automation-manager.spec.ts
+++ b/packages/plugin-dev/automations/src/core/automation-manager.spec.ts
@@ -6,7 +6,7 @@ import { ConditionEvaluator } from './condition-evaluator';
 import { ActionExecutor } from './action-executor';
 import { RateLimiter } from './rate-limiter';
 import { globalRegistry } from './registry';
-import { TaskEvent } from '../types';
+import { AutomationRule, TaskEvent } from '../types';
 import { DataCache } from './data-cache';
 
 // Mock dependencies
@@ -293,15 +293,18 @@ describe('AutomationManager', () => {
   });
 
   describe('shortcut trigger', () => {
+    const shortcutRule = (overrides: Partial<AutomationRule> = {}): AutomationRule => ({
+      id: 'r1',
+      name: 'Tag focused task',
+      trigger: { type: 'shortcut' },
+      conditions: [],
+      actions: [],
+      isEnabled: true,
+      ...overrides,
+    });
+
     it('should run the shortcut rule the pressed shortcut belongs to', async () => {
-      const rule = {
-        id: 'r1',
-        name: 'Tag focused task',
-        trigger: { type: 'shortcut' },
-        conditions: [],
-        actions: [{ type: 'addTag', value: 'urgent' }],
-        isEnabled: true,
-      };
+      const rule = shortcutRule({ actions: [{ type: 'addTag', value: 'urgent' }] });
       mockRuleRegistry.getEnabledRules.mockResolvedValue([rule]);
       const focusedTask = { id: 't1', title: 'Focused' };
       (mockPlugin.getFocusedTask as Mock).mockResolvedValue(focusedTask);
@@ -315,14 +318,9 @@ describe('AutomationManager', () => {
     });
 
     it('should run a shortcut rule without a task when nothing is focused', async () => {
-      const rule = {
-        id: 'r1',
-        name: 'Ping',
-        trigger: { type: 'shortcut' },
-        conditions: [],
+      const rule = shortcutRule({
         actions: [{ type: 'webhook', value: 'https://example.com' }],
-        isEnabled: true,
-      };
+      });
       mockRuleRegistry.getEnabledRules.mockResolvedValue([rule]);
 
       await manager.runShortcutRule('r1');
@@ -334,15 +332,7 @@ describe('AutomationManager', () => {
     });
 
     it('should still run the rule when the focused task cannot be read', async () => {
-      const rule = {
-        id: 'r1',
-        name: 'Ping',
-        trigger: { type: 'shortcut' },
-        conditions: [],
-        actions: [],
-        isEnabled: true,
-      };
-      mockRuleRegistry.getEnabledRules.mockResolvedValue([rule]);
+      mockRuleRegistry.getEnabledRules.mockResolvedValue([shortcutRule()]);
       (mockPlugin.getFocusedTask as Mock).mockRejectedValue(new Error('nope'));
 
       await manager.runShortcutRule('r1');
@@ -355,14 +345,7 @@ describe('AutomationManager', () => {
 
     it('should not run a rule whose trigger is not a shortcut', async () => {
       mockRuleRegistry.getEnabledRules.mockResolvedValue([
-        {
-          id: 'r1',
-          name: 'Other',
-          trigger: { type: 'taskCreated' },
-          conditions: [],
-          actions: [],
-          isEnabled: true,
-        },
+        shortcutRule({ trigger: { type: 'taskCreated' } }),
       ]);
 
       await manager.runShortcutRule('r1');
@@ -373,15 +356,29 @@ describe('AutomationManager', () => {
       );
     });
 
+    it('should not rate-limit shortcut rules, so rapid presses raise no dialog', async () => {
+      mockRuleRegistry.getEnabledRules.mockResolvedValue([shortcutRule()]);
+      mockRateLimiter.check.mockReturnValue(false);
+
+      await manager.runShortcutRule('r1');
+
+      expect(mockRateLimiter.check).not.toHaveBeenCalled();
+      expect(mockActionExecutor.executeAll).toHaveBeenCalled();
+    });
+
+    it('should do nothing when the conditions of a shortcut rule do not match', async () => {
+      mockRuleRegistry.getEnabledRules.mockResolvedValue([
+        shortcutRule({ conditions: [{ type: 'hasTag', value: 'urgent' }] }),
+      ]);
+      mockConditionEvaluator.allConditionsMatch.mockResolvedValue(false);
+
+      await manager.runShortcutRule('r1');
+
+      expect(mockActionExecutor.executeAll).not.toHaveBeenCalled();
+    });
+
     it('should register the shortcut of a newly saved shortcut rule', async () => {
-      const rule = {
-        id: 'r1',
-        name: 'Tag focused task',
-        trigger: { type: 'shortcut' },
-        conditions: [],
-        actions: [],
-        isEnabled: true,
-      };
+      const rule = shortcutRule();
       mockRuleRegistry.getRules.mockResolvedValue([rule]);
 
       await manager.saveRule(rule);
@@ -392,72 +389,8 @@ describe('AutomationManager', () => {
       );
     });
 
-    it('should not rate-limit shortcut rules, so rapid presses raise no dialog', async () => {
-      mockRuleRegistry.getEnabledRules.mockResolvedValue([
-        {
-          id: 'r1',
-          name: 'Tag focused task',
-          trigger: { type: 'shortcut' },
-          conditions: [],
-          actions: [],
-          isEnabled: true,
-        },
-      ]);
-      mockRateLimiter.check.mockReturnValue(false);
-
-      await manager.runShortcutRule('r1');
-
-      expect(mockRateLimiter.check).not.toHaveBeenCalled();
-      expect(mockPlugin.openDialog).not.toHaveBeenCalled();
-      expect(mockActionExecutor.executeAll).toHaveBeenCalled();
-    });
-
-    it('should do nothing when the conditions of a shortcut rule do not match', async () => {
-      mockRuleRegistry.getEnabledRules.mockResolvedValue([
-        {
-          id: 'r1',
-          name: 'Tag focused task',
-          trigger: { type: 'shortcut' },
-          conditions: [{ type: 'hasTag', value: 'urgent' }],
-          actions: [],
-          isEnabled: true,
-        },
-      ]);
-      mockConditionEvaluator.allConditionsMatch.mockResolvedValue(false);
-
-      await manager.runShortcutRule('r1');
-
-      expect(mockActionExecutor.executeAll).not.toHaveBeenCalled();
-    });
-
-    it('should release the shortcut of a disabled shortcut rule', async () => {
-      const rule = {
-        id: 'r1',
-        name: 'Tag focused task',
-        trigger: { type: 'shortcut' },
-        conditions: [],
-        actions: [],
-        isEnabled: true,
-      };
-      mockRuleRegistry.getRules.mockResolvedValue([rule]);
-      await manager.saveRule(rule);
-
-      mockRuleRegistry.getRules.mockResolvedValue([{ ...rule, isEnabled: false }]);
-      await manager.toggleRuleStatus('r1', false);
-
-      expect(mockRuleRegistry.toggleRuleStatus).toHaveBeenCalledWith('r1', false);
-      expect(mockPlugin.unregisterShortcut).toHaveBeenCalledWith('r1');
-    });
-
-    it('should release the shortcut of a deleted shortcut rule', async () => {
-      const rule = {
-        id: 'r1',
-        name: 'Tag focused task',
-        trigger: { type: 'shortcut' },
-        conditions: [],
-        actions: [],
-        isEnabled: true,
-      };
+    it('should release the shortcut when a rule mutation removes it from the list', async () => {
+      const rule = shortcutRule();
       mockRuleRegistry.getRules.mockResolvedValue([rule]);
       await manager.saveRule(rule);
 

--- a/packages/plugin-dev/automations/src/core/automation-manager.spec.ts
+++ b/packages/plugin-dev/automations/src/core/automation-manager.spec.ts
@@ -59,11 +59,18 @@ describe('AutomationManager', () => {
       },
       openDialog: vi.fn(),
       showSnack: vi.fn(),
+      getFocusedTask: vi.fn().mockResolvedValue(null),
+      registerShortcut: vi.fn(),
+      unregisterShortcut: vi.fn(),
     } as unknown as PluginAPI;
 
     // Setup mocks
     mockRuleRegistry = {
+      getRules: vi.fn().mockResolvedValue([]),
       getEnabledRules: vi.fn().mockResolvedValue([]),
+      addOrUpdateRule: vi.fn(),
+      addRules: vi.fn(),
+      deleteRule: vi.fn(),
       toggleRuleStatus: vi.fn(),
     };
     (RuleRegistry as unknown as Mock).mockImplementation(function () {
@@ -282,6 +289,126 @@ describe('AutomationManager', () => {
       );
       expect(mockPlugin.openDialog).toHaveBeenCalled(); // Should ask user
       expect(mockActionExecutor.executeAll).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('shortcut trigger', () => {
+    it('should run the shortcut rule the pressed shortcut belongs to', async () => {
+      const rule = {
+        id: 'r1',
+        name: 'Tag focused task',
+        trigger: { type: 'shortcut' },
+        conditions: [],
+        actions: [{ type: 'addTag', value: 'urgent' }],
+        isEnabled: true,
+      };
+      mockRuleRegistry.getEnabledRules.mockResolvedValue([rule]);
+      const focusedTask = { id: 't1', title: 'Focused' };
+      (mockPlugin.getFocusedTask as Mock).mockResolvedValue(focusedTask);
+
+      await manager.runShortcutRule('r1');
+
+      expect(mockActionExecutor.executeAll).toHaveBeenCalledWith(rule.actions, {
+        type: 'shortcut',
+        task: focusedTask,
+      });
+    });
+
+    it('should run a shortcut rule without a task when nothing is focused', async () => {
+      const rule = {
+        id: 'r1',
+        name: 'Ping',
+        trigger: { type: 'shortcut' },
+        conditions: [],
+        actions: [{ type: 'webhook', value: 'https://example.com' }],
+        isEnabled: true,
+      };
+      mockRuleRegistry.getEnabledRules.mockResolvedValue([rule]);
+
+      await manager.runShortcutRule('r1');
+
+      expect(mockActionExecutor.executeAll).toHaveBeenCalledWith(rule.actions, {
+        type: 'shortcut',
+        task: undefined,
+      });
+    });
+
+    it('should still run the rule when the focused task cannot be read', async () => {
+      const rule = {
+        id: 'r1',
+        name: 'Ping',
+        trigger: { type: 'shortcut' },
+        conditions: [],
+        actions: [],
+        isEnabled: true,
+      };
+      mockRuleRegistry.getEnabledRules.mockResolvedValue([rule]);
+      (mockPlugin.getFocusedTask as Mock).mockRejectedValue(new Error('nope'));
+
+      await manager.runShortcutRule('r1');
+
+      expect(mockPlugin.log.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Could not read the focused task'),
+      );
+      expect(mockActionExecutor.executeAll).toHaveBeenCalled();
+    });
+
+    it('should not run a rule whose trigger is not a shortcut', async () => {
+      mockRuleRegistry.getEnabledRules.mockResolvedValue([
+        {
+          id: 'r1',
+          name: 'Other',
+          trigger: { type: 'taskCreated' },
+          conditions: [],
+          actions: [],
+          isEnabled: true,
+        },
+      ]);
+
+      await manager.runShortcutRule('r1');
+
+      expect(mockActionExecutor.executeAll).not.toHaveBeenCalled();
+      expect(mockPlugin.log.warn).toHaveBeenCalledWith(
+        expect.stringContaining('No enabled shortcut rule'),
+      );
+    });
+
+    it('should register the shortcut of a newly saved shortcut rule', async () => {
+      const rule = {
+        id: 'r1',
+        name: 'Tag focused task',
+        trigger: { type: 'shortcut' },
+        conditions: [],
+        actions: [],
+        isEnabled: true,
+      };
+      mockRuleRegistry.getRules.mockResolvedValue([rule]);
+
+      await manager.saveRule(rule);
+
+      expect(mockRuleRegistry.addOrUpdateRule).toHaveBeenCalledWith(rule);
+      expect(mockPlugin.registerShortcut).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'r1', label: 'Tag focused task' }),
+      );
+    });
+
+    it('should release the shortcut of a deleted shortcut rule', async () => {
+      const rule = {
+        id: 'r1',
+        name: 'Tag focused task',
+        trigger: { type: 'shortcut' },
+        conditions: [],
+        actions: [],
+        isEnabled: true,
+      };
+      mockRuleRegistry.getRules.mockResolvedValue([rule]);
+      await manager.saveRule(rule);
+
+      mockRuleRegistry.getRules.mockResolvedValue([]);
+      await manager.deleteRule('r1');
+
+      expect(mockRuleRegistry.deleteRule).toHaveBeenCalledWith('r1');
+      expect(mockPlugin.unregisterShortcut).toHaveBeenCalledWith('r1');
     });
   });
 });

--- a/packages/plugin-dev/automations/src/core/automation-manager.spec.ts
+++ b/packages/plugin-dev/automations/src/core/automation-manager.spec.ts
@@ -389,6 +389,19 @@ describe('AutomationManager', () => {
       );
     });
 
+    // The rate-limit dialog's "Disable Rule" button goes through this wrapper.
+    it('should release the shortcut when a rule is disabled', async () => {
+      const rule = shortcutRule();
+      mockRuleRegistry.getRules.mockResolvedValue([rule]);
+      await manager.saveRule(rule);
+
+      mockRuleRegistry.getRules.mockResolvedValue([{ ...rule, isEnabled: false }]);
+      await manager.toggleRuleStatus('r1', false);
+
+      expect(mockRuleRegistry.toggleRuleStatus).toHaveBeenCalledWith('r1', false);
+      expect(mockPlugin.unregisterShortcut).toHaveBeenCalledWith('r1');
+    });
+
     it('should release the shortcut when a rule mutation removes it from the list', async () => {
       const rule = shortcutRule();
       mockRuleRegistry.getRules.mockResolvedValue([rule]);

--- a/packages/plugin-dev/automations/src/core/automation-manager.ts
+++ b/packages/plugin-dev/automations/src/core/automation-manager.ts
@@ -1,5 +1,5 @@
-import { PluginAPI } from '@super-productivity/plugin-api';
-import { TaskEvent } from '../types';
+import { PluginAPI, Task } from '@super-productivity/plugin-api';
+import { AutomationRule, TaskEvent } from '../types';
 import { RuleRegistry } from './rule-registry';
 import { ConditionEvaluator } from './condition-evaluator';
 import { ActionExecutor } from './action-executor';
@@ -12,6 +12,7 @@ import * as Triggers from './triggers';
 import * as Conditions from './conditions';
 import * as Actions from './actions';
 import { DataCache } from './data-cache';
+import { ShortcutBinder } from './shortcut-binder';
 
 export class AutomationManager {
   private static readonly RATE_LIMIT_MAX = 5;
@@ -24,6 +25,7 @@ export class AutomationManager {
   private actionExecutor: ActionExecutor;
   private rateLimiter: RateLimiter;
   private dataCache: DataCache;
+  private shortcutBinder: ShortcutBinder;
   private pendingDialogs: Set<string> = new Set();
   private lastExecutionTimes: Map<string, number> = new Map();
   private clearTimeCheck?: () => void;
@@ -38,6 +40,10 @@ export class AutomationManager {
       AutomationManager.RATE_LIMIT_MAX,
       AutomationManager.RATE_LIMIT_WINDOW_MS,
     );
+    this.shortcutBinder = new ShortcutBinder(plugin, (ruleId) => {
+      void this.runShortcutRule(ruleId);
+    });
+    void this.syncShortcuts();
     this.initTimeCheck();
   }
 
@@ -49,6 +55,7 @@ export class AutomationManager {
     globalRegistry.registerTrigger(Triggers.TriggerTaskStarted);
     globalRegistry.registerTrigger(Triggers.TriggerTaskStopped);
     globalRegistry.registerTrigger(Triggers.TriggerTimeBased);
+    globalRegistry.registerTrigger(Triggers.TriggerShortcut);
 
     // Conditions
     globalRegistry.registerCondition(Conditions.ConditionTitleContains);
@@ -66,6 +73,34 @@ export class AutomationManager {
     globalRegistry.registerAction(Actions.ActionDisplaySnack);
     globalRegistry.registerAction(Actions.ActionDisplayDialog);
     globalRegistry.registerAction(Actions.ActionWebhook);
+  }
+
+  private async syncShortcuts() {
+    try {
+      this.shortcutBinder.sync(await this.ruleRegistry.getRules());
+    } catch (e) {
+      this.plugin.log.error(`[Automation] Failed to sync shortcuts: ${e}`);
+    }
+  }
+
+  async saveRule(value: unknown) {
+    await this.ruleRegistry.addOrUpdateRule(value);
+    await this.syncShortcuts();
+  }
+
+  async addRules(value: unknown) {
+    await this.ruleRegistry.addRules(value);
+    await this.syncShortcuts();
+  }
+
+  async deleteRule(ruleId: unknown) {
+    await this.ruleRegistry.deleteRule(ruleId);
+    await this.syncShortcuts();
+  }
+
+  async toggleRuleStatus(ruleId: unknown, isEnabled: unknown) {
+    await this.ruleRegistry.toggleRuleStatus(ruleId, isEnabled);
+    await this.syncShortcuts();
   }
 
   private initTimeCheck() {
@@ -167,52 +202,7 @@ export class AutomationManager {
             continue;
           }
 
-          const matches = await this.conditionEvaluator.allConditionsMatch(rule.conditions, event);
-          if (!matches) {
-            continue;
-          }
-
-          // Check rate limit
-          if (!this.rateLimiter.check(rule.id)) {
-            this.plugin.log.warn(`[Automation] Rate limit exceeded for rule: ${rule.name}`);
-
-            if (!this.pendingDialogs.has(rule.id)) {
-              this.pendingDialogs.add(rule.id);
-
-              const dialogCfg: DialogCfg = {
-                htmlContent: `
-              <h3>High Automation Activity Detected</h3>
-              <p>The rule <strong>"${this.escapeHtml(rule.name)}"</strong> is triggering too frequently (infinite loop protection).</p>
-              <p>Do you want to disable this rule or continue execution?</p>
-            `,
-                buttons: [
-                  {
-                    label: 'Disable Rule',
-                    color: 'warn',
-                    onClick: async () => {
-                      await this.ruleRegistry.toggleRuleStatus(rule.id, false);
-                      this.plugin.showSnack({ msg: `Rule "${rule.name}" disabled`, type: 'INFO' });
-                      this.pendingDialogs.delete(rule.id);
-                    },
-                  },
-                  {
-                    label: 'Continue',
-                    color: 'primary',
-                    onClick: () => {
-                      this.rateLimiter.reset(rule.id);
-                      this.pendingDialogs.delete(rule.id);
-                    },
-                  },
-                ],
-              };
-
-              await this.plugin.openDialog(dialogCfg);
-            }
-            continue;
-          }
-
-          this.plugin.log.info(`[Automation] Rule matched: ${rule.name}`);
-          await this.actionExecutor.executeAll(rule.actions, event);
+          await this.runRule(rule, event);
         } catch (e) {
           this.plugin.log.error(`[Automation] Error processing rule ${rule.name}: ${e}`);
         }
@@ -220,6 +210,85 @@ export class AutomationManager {
     } catch (e) {
       this.plugin.log.error(`[Automation] Error in onTaskEvent: ${e}`);
     }
+  }
+
+  /**
+   * Runs the rule bound to the given keyboard shortcut. Actions apply to the
+   * task row the user currently has focused, if any — task-less rules (snack,
+   * webhook, create task) work without one.
+   */
+  async runShortcutRule(ruleId: string) {
+    try {
+      const rules = await this.ruleRegistry.getEnabledRules();
+      const rule = rules.find((r) => r.id === ruleId && r.trigger.type === 'shortcut');
+      if (!rule) {
+        this.plugin.log.warn(`[Automation] No enabled shortcut rule for id: ${ruleId}`);
+        return;
+      }
+
+      this.plugin.log.info(`[Automation] Shortcut rule triggered: ${rule.name}`);
+      await this.runRule(rule, { type: 'shortcut', task: await this.getFocusedTask() });
+    } catch (e) {
+      this.plugin.log.error(`[Automation] Error running shortcut rule ${ruleId}: ${e}`);
+    }
+  }
+
+  private async getFocusedTask(): Promise<Task | undefined> {
+    try {
+      return (await this.plugin.getFocusedTask()) ?? undefined;
+    } catch (e) {
+      this.plugin.log.warn(`[Automation] Could not read the focused task: ${e}`);
+      return undefined;
+    }
+  }
+
+  private async runRule(rule: AutomationRule, event: TaskEvent) {
+    const matches = await this.conditionEvaluator.allConditionsMatch(rule.conditions, event);
+    if (!matches) {
+      return;
+    }
+
+    // Check rate limit
+    if (!this.rateLimiter.check(rule.id)) {
+      this.plugin.log.warn(`[Automation] Rate limit exceeded for rule: ${rule.name}`);
+
+      if (!this.pendingDialogs.has(rule.id)) {
+        this.pendingDialogs.add(rule.id);
+
+        const dialogCfg: DialogCfg = {
+          htmlContent: `
+              <h3>High Automation Activity Detected</h3>
+              <p>The rule <strong>"${this.escapeHtml(rule.name)}"</strong> is triggering too frequently (infinite loop protection).</p>
+              <p>Do you want to disable this rule or continue execution?</p>
+            `,
+          buttons: [
+            {
+              label: 'Disable Rule',
+              color: 'warn',
+              onClick: async () => {
+                await this.toggleRuleStatus(rule.id, false);
+                this.plugin.showSnack({ msg: `Rule "${rule.name}" disabled`, type: 'INFO' });
+                this.pendingDialogs.delete(rule.id);
+              },
+            },
+            {
+              label: 'Continue',
+              color: 'primary',
+              onClick: () => {
+                this.rateLimiter.reset(rule.id);
+                this.pendingDialogs.delete(rule.id);
+              },
+            },
+          ],
+        };
+
+        await this.plugin.openDialog(dialogCfg);
+      }
+      return;
+    }
+
+    this.plugin.log.info(`[Automation] Rule matched: ${rule.name}`);
+    await this.actionExecutor.executeAll(rule.actions, event);
   }
 
   // Minimal HTML escape to prevent rule-provided strings from injecting markup in dialogs.

--- a/packages/plugin-dev/automations/src/core/automation-manager.ts
+++ b/packages/plugin-dev/automations/src/core/automation-manager.ts
@@ -226,8 +226,16 @@ export class AutomationManager {
         return;
       }
 
-      this.plugin.log.info(`[Automation] Shortcut rule triggered: ${rule.name}`);
-      await this.runRule(rule, { type: 'shortcut', task: await this.getFocusedTask() });
+      this.plugin.log.info(`[Automation] Shortcut rule triggered: ${rule.id}`);
+      // Loop protection off: a keypress cannot feed itself, so rapid presses
+      // must not raise the "high activity" dialog.
+      await this.runRule(
+        rule,
+        { type: 'shortcut', task: await this.getFocusedTask() },
+        {
+          applyLoopProtection: false,
+        },
+      );
     } catch (e) {
       this.plugin.log.error(`[Automation] Error running shortcut rule ${ruleId}: ${e}`);
     }
@@ -242,55 +250,69 @@ export class AutomationManager {
     }
   }
 
-  private async runRule(rule: AutomationRule, event: TaskEvent) {
+  private async runRule(
+    rule: AutomationRule,
+    event: TaskEvent,
+    { applyLoopProtection = true }: { applyLoopProtection?: boolean } = {},
+  ) {
     const matches = await this.conditionEvaluator.allConditionsMatch(rule.conditions, event);
     if (!matches) {
       return;
     }
 
-    // Check rate limit. Shortcut rules are exempt: the limiter exists to break
-    // automation loops, but a shortcut run comes from a keypress and cannot feed
-    // itself, so rapid presses must not raise the "high activity" dialog.
-    if (event.type !== 'shortcut' && !this.rateLimiter.check(rule.id)) {
-      this.plugin.log.warn(`[Automation] Rate limit exceeded for rule: ${rule.name}`);
-
-      if (!this.pendingDialogs.has(rule.id)) {
-        this.pendingDialogs.add(rule.id);
-
-        const dialogCfg: DialogCfg = {
-          htmlContent: `
-              <h3>High Automation Activity Detected</h3>
-              <p>The rule <strong>"${this.escapeHtml(rule.name)}"</strong> is triggering too frequently (infinite loop protection).</p>
-              <p>Do you want to disable this rule or continue execution?</p>
-            `,
-          buttons: [
-            {
-              label: 'Disable Rule',
-              color: 'warn',
-              onClick: async () => {
-                await this.toggleRuleStatus(rule.id, false);
-                this.plugin.showSnack({ msg: `Rule "${rule.name}" disabled`, type: 'INFO' });
-                this.pendingDialogs.delete(rule.id);
-              },
-            },
-            {
-              label: 'Continue',
-              color: 'primary',
-              onClick: () => {
-                this.rateLimiter.reset(rule.id);
-                this.pendingDialogs.delete(rule.id);
-              },
-            },
-          ],
-        };
-
-        await this.plugin.openDialog(dialogCfg);
-      }
+    if (applyLoopProtection && (await this.isRateLimited(rule))) {
       return;
     }
 
     this.plugin.log.info(`[Automation] Rule matched: ${rule.name}`);
     await this.actionExecutor.executeAll(rule.actions, event);
+  }
+
+  /**
+   * Breaks automation loops: an action can trigger the very event that runs the
+   * rule again. Returns true when the run must be skipped, offering the user a
+   * one-time dialog to disable the rule.
+   */
+  private async isRateLimited(rule: AutomationRule): Promise<boolean> {
+    if (this.rateLimiter.check(rule.id)) {
+      return false;
+    }
+
+    this.plugin.log.warn(`[Automation] Rate limit exceeded for rule: ${rule.name}`);
+
+    if (!this.pendingDialogs.has(rule.id)) {
+      this.pendingDialogs.add(rule.id);
+
+      const dialogCfg: DialogCfg = {
+        htmlContent: `
+              <h3>High Automation Activity Detected</h3>
+              <p>The rule <strong>"${this.escapeHtml(rule.name)}"</strong> is triggering too frequently (infinite loop protection).</p>
+              <p>Do you want to disable this rule or continue execution?</p>
+            `,
+        buttons: [
+          {
+            label: 'Disable Rule',
+            color: 'warn',
+            onClick: async () => {
+              await this.toggleRuleStatus(rule.id, false);
+              this.plugin.showSnack({ msg: `Rule "${rule.name}" disabled`, type: 'INFO' });
+              this.pendingDialogs.delete(rule.id);
+            },
+          },
+          {
+            label: 'Continue',
+            color: 'primary',
+            onClick: () => {
+              this.rateLimiter.reset(rule.id);
+              this.pendingDialogs.delete(rule.id);
+            },
+          },
+        ],
+      };
+
+      await this.plugin.openDialog(dialogCfg);
+    }
+    return true;
   }
 
   // Minimal HTML escape to prevent rule-provided strings from injecting markup in dialogs.
@@ -303,7 +325,7 @@ export class AutomationManager {
       .replace(/'/g, '&#039;');
   }
 
-  getRegistry(): RuleRegistry {
-    return this.ruleRegistry;
+  getRules(): Promise<AutomationRule[]> {
+    return this.ruleRegistry.getRules();
   }
 }

--- a/packages/plugin-dev/automations/src/core/automation-manager.ts
+++ b/packages/plugin-dev/automations/src/core/automation-manager.ts
@@ -248,8 +248,10 @@ export class AutomationManager {
       return;
     }
 
-    // Check rate limit
-    if (!this.rateLimiter.check(rule.id)) {
+    // Check rate limit. Shortcut rules are exempt: the limiter exists to break
+    // automation loops, but a shortcut run comes from a keypress and cannot feed
+    // itself, so rapid presses must not raise the "high activity" dialog.
+    if (event.type !== 'shortcut' && !this.rateLimiter.check(rule.id)) {
       this.plugin.log.warn(`[Automation] Rate limit exceeded for rule: ${rule.name}`);
 
       if (!this.pendingDialogs.has(rule.id)) {

--- a/packages/plugin-dev/automations/src/core/rule-registry.ts
+++ b/packages/plugin-dev/automations/src/core/rule-registry.ts
@@ -19,6 +19,7 @@ const AUTOMATION_TRIGGER_TYPES = [
   'taskStarted',
   'taskStopped',
   'timeBased',
+  'shortcut',
 ] as const satisfies readonly AutomationTriggerType[];
 const _exhaustiveTriggers: _AssertEq<
   AutomationTriggerType,

--- a/packages/plugin-dev/automations/src/core/shortcut-binder.spec.ts
+++ b/packages/plugin-dev/automations/src/core/shortcut-binder.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PluginAPI } from '@super-productivity/plugin-api';
+import { ShortcutBinder } from './shortcut-binder';
+import { AutomationRule } from '../types';
+
+const rule = (overrides: Partial<AutomationRule> = {}): AutomationRule => ({
+  id: 'r1',
+  name: 'Tag as urgent',
+  trigger: { type: 'shortcut' },
+  conditions: [],
+  actions: [],
+  isEnabled: true,
+  ...overrides,
+});
+
+describe('ShortcutBinder', () => {
+  let mockPlugin: PluginAPI;
+  let onExec: (ruleId: string) => void;
+  let binder: ShortcutBinder;
+
+  beforeEach(() => {
+    mockPlugin = {
+      registerShortcut: vi.fn(),
+      unregisterShortcut: vi.fn(),
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    } as unknown as PluginAPI;
+    onExec = vi.fn();
+    binder = new ShortcutBinder(mockPlugin, onExec);
+  });
+
+  it('registers one shortcut per enabled shortcut rule, keyed by rule id', () => {
+    binder.sync([rule(), rule({ id: 'r2', name: 'Ping webhook' })]);
+
+    expect(mockPlugin.registerShortcut).toHaveBeenCalledTimes(2);
+    expect(mockPlugin.registerShortcut).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'r1', label: 'Tag as urgent' }),
+    );
+    expect(mockPlugin.registerShortcut).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'r2', label: 'Ping webhook' }),
+    );
+  });
+
+  it('ignores rules with other triggers', () => {
+    binder.sync([rule({ trigger: { type: 'taskCreated' } })]);
+
+    expect(mockPlugin.registerShortcut).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a placeholder label for unnamed rules', () => {
+    binder.sync([rule({ name: '  ' })]);
+
+    expect(mockPlugin.registerShortcut).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'Unnamed automation rule' }),
+    );
+  });
+
+  it('runs the rule the pressed shortcut belongs to', () => {
+    binder.sync([rule()]);
+
+    const cfg = (mockPlugin.registerShortcut as any).mock.calls[0][0];
+    cfg.onExec();
+
+    expect(onExec).toHaveBeenCalledWith('r1');
+  });
+
+  it('does not re-register unchanged rules', () => {
+    binder.sync([rule()]);
+    binder.sync([rule()]);
+
+    expect(mockPlugin.registerShortcut).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-registers with the new label when a rule is renamed', () => {
+    binder.sync([rule()]);
+    binder.sync([rule({ name: 'Tag as later' })]);
+
+    expect(mockPlugin.registerShortcut).toHaveBeenCalledTimes(2);
+    expect(mockPlugin.registerShortcut).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 'r1', label: 'Tag as later' }),
+    );
+    expect(mockPlugin.unregisterShortcut).not.toHaveBeenCalled();
+  });
+
+  it('unregisters the shortcut of a deleted rule', () => {
+    binder.sync([rule()]);
+    binder.sync([]);
+
+    expect(mockPlugin.unregisterShortcut).toHaveBeenCalledWith('r1');
+  });
+
+  it('unregisters the shortcut of a disabled rule so it stops swallowing the key', () => {
+    binder.sync([rule()]);
+    binder.sync([rule({ isEnabled: false })]);
+
+    expect(mockPlugin.unregisterShortcut).toHaveBeenCalledWith('r1');
+  });
+
+  it('registers again when a rule is re-enabled', () => {
+    binder.sync([rule()]);
+    binder.sync([rule({ isEnabled: false })]);
+    binder.sync([rule()]);
+
+    expect(mockPlugin.registerShortcut).toHaveBeenCalledTimes(2);
+  });
+
+  it('warns instead of throwing on hosts without unregisterShortcut', () => {
+    (mockPlugin as { unregisterShortcut?: unknown }).unregisterShortcut = undefined;
+
+    binder.sync([rule()]);
+    expect(() => binder.sync([])).not.toThrow();
+    expect(mockPlugin.log.warn).toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-dev/automations/src/core/shortcut-binder.spec.ts
+++ b/packages/plugin-dev/automations/src/core/shortcut-binder.spec.ts
@@ -74,7 +74,6 @@ describe('ShortcutBinder', () => {
     binder.sync([rule()]);
     binder.sync([rule({ name: 'Tag as later' })]);
 
-    expect(mockPlugin.registerShortcut).toHaveBeenCalledTimes(2);
     expect(mockPlugin.registerShortcut).toHaveBeenLastCalledWith(
       expect.objectContaining({ id: 'r1', label: 'Tag as later' }),
     );
@@ -88,26 +87,14 @@ describe('ShortcutBinder', () => {
     expect(mockPlugin.unregisterShortcut).toHaveBeenCalledWith('r1');
   });
 
-  it('unregisters the shortcut of a disabled rule so it stops swallowing the key', () => {
+  it('releases the key of a disabled rule and takes it back when re-enabled', () => {
     binder.sync([rule()]);
     binder.sync([rule({ isEnabled: false })]);
 
     expect(mockPlugin.unregisterShortcut).toHaveBeenCalledWith('r1');
-  });
 
-  it('registers again when a rule is re-enabled', () => {
-    binder.sync([rule()]);
-    binder.sync([rule({ isEnabled: false })]);
     binder.sync([rule()]);
 
     expect(mockPlugin.registerShortcut).toHaveBeenCalledTimes(2);
-  });
-
-  it('warns instead of throwing on hosts without unregisterShortcut', () => {
-    (mockPlugin as { unregisterShortcut?: unknown }).unregisterShortcut = undefined;
-
-    binder.sync([rule()]);
-    expect(() => binder.sync([])).not.toThrow();
-    expect(mockPlugin.log.warn).toHaveBeenCalled();
   });
 });

--- a/packages/plugin-dev/automations/src/core/shortcut-binder.ts
+++ b/packages/plugin-dev/automations/src/core/shortcut-binder.ts
@@ -1,0 +1,63 @@
+import { PluginAPI } from '@super-productivity/plugin-api';
+import { AutomationRule } from '../types';
+
+const FALLBACK_LABEL = 'Unnamed automation rule';
+
+const labelFor = (rule: AutomationRule): string => rule.name.trim() || FALLBACK_LABEL;
+
+/**
+ * Keeps the host's plugin shortcut list in sync with the rules that use the
+ * "shortcut" trigger.
+ *
+ * The host stores the key the user picked under `plugin_<pluginId>:<shortcutId>`,
+ * so the shortcut id has to stay stable for the lifetime of a rule — we use the
+ * rule id, which means renaming a rule keeps its key binding.
+ *
+ * Only enabled rules are registered: a registered shortcut swallows its key
+ * combo in the host, so a disabled rule must not keep the key occupied.
+ */
+export class ShortcutBinder {
+  // ruleId -> last registered label, so we only re-register on actual changes.
+  private registeredLabels = new Map<string, string>();
+
+  constructor(
+    private plugin: PluginAPI,
+    private onExec: (ruleId: string) => void,
+  ) {}
+
+  sync(rules: AutomationRule[]): void {
+    const shortcutRules = rules.filter((r) => r.trigger.type === 'shortcut' && r.isEnabled);
+    const activeIds = new Set(shortcutRules.map((r) => r.id));
+
+    for (const ruleId of [...this.registeredLabels.keys()]) {
+      if (!activeIds.has(ruleId)) {
+        this.unregister(ruleId);
+      }
+    }
+
+    for (const rule of shortcutRules) {
+      const label = labelFor(rule);
+      if (this.registeredLabels.get(rule.id) === label) continue;
+
+      this.plugin.registerShortcut({
+        id: rule.id,
+        label,
+        onExec: () => this.onExec(rule.id),
+      });
+      this.registeredLabels.set(rule.id, label);
+    }
+  }
+
+  private unregister(ruleId: string): void {
+    this.registeredLabels.delete(ruleId);
+    // Older hosts have no way to drop a single shortcut; there the entry just
+    // stays around (inert, since the rule is gone) until the next app start.
+    if (typeof this.plugin.unregisterShortcut !== 'function') {
+      this.plugin.log.warn(
+        '[Automation] Host cannot unregister shortcuts; stale entry remains until restart.',
+      );
+      return;
+    }
+    this.plugin.unregisterShortcut(ruleId);
+  }
+}

--- a/packages/plugin-dev/automations/src/core/shortcut-binder.ts
+++ b/packages/plugin-dev/automations/src/core/shortcut-binder.ts
@@ -1,9 +1,9 @@
 import { PluginAPI } from '@super-productivity/plugin-api';
 import { AutomationRule } from '../types';
 
-const FALLBACK_LABEL = 'Unnamed automation rule';
+const FALLBACK_SHORTCUT_LABEL = 'Unnamed automation rule';
 
-const labelFor = (rule: AutomationRule): string => rule.name.trim() || FALLBACK_LABEL;
+const labelFor = (ruleName: string): string => ruleName.trim() || FALLBACK_SHORTCUT_LABEL;
 
 /**
  * Keeps the host's plugin shortcut list in sync with the rules that use the
@@ -35,29 +35,19 @@ export class ShortcutBinder {
       }
     }
 
-    for (const rule of shortcutRules) {
-      const label = labelFor(rule);
-      if (this.registeredLabels.get(rule.id) === label) continue;
+    for (const { id, name } of shortcutRules) {
+      const label = labelFor(name);
+      if (this.registeredLabels.get(id) === label) continue;
 
-      this.plugin.registerShortcut({
-        id: rule.id,
-        label,
-        onExec: () => this.onExec(rule.id),
-      });
-      this.registeredLabels.set(rule.id, label);
+      // Capture only the id: the host holds onExec for the lifetime of the
+      // registration, so closing over the rule would pin a stale copy of it.
+      this.plugin.registerShortcut({ id, label, onExec: () => this.onExec(id) });
+      this.registeredLabels.set(id, label);
     }
   }
 
   private unregister(ruleId: string): void {
-    // Older hosts have no way to drop a single shortcut; there the entry just
-    // stays around (inert, since the rule is gone) until the next app start.
-    if (typeof this.plugin.unregisterShortcut !== 'function') {
-      this.plugin.log.warn(
-        '[Automation] Host cannot unregister shortcuts; stale entry remains until restart.',
-      );
-    } else {
-      this.plugin.unregisterShortcut(ruleId);
-    }
+    this.plugin.unregisterShortcut(ruleId);
     this.registeredLabels.delete(ruleId);
   }
 }

--- a/packages/plugin-dev/automations/src/core/shortcut-binder.ts
+++ b/packages/plugin-dev/automations/src/core/shortcut-binder.ts
@@ -49,15 +49,15 @@ export class ShortcutBinder {
   }
 
   private unregister(ruleId: string): void {
-    this.registeredLabels.delete(ruleId);
     // Older hosts have no way to drop a single shortcut; there the entry just
     // stays around (inert, since the rule is gone) until the next app start.
     if (typeof this.plugin.unregisterShortcut !== 'function') {
       this.plugin.log.warn(
         '[Automation] Host cannot unregister shortcuts; stale entry remains until restart.',
       );
-      return;
+    } else {
+      this.plugin.unregisterShortcut(ruleId);
     }
-    this.plugin.unregisterShortcut(ruleId);
+    this.registeredLabels.delete(ruleId);
   }
 }

--- a/packages/plugin-dev/automations/src/core/triggers.ts
+++ b/packages/plugin-dev/automations/src/core/triggers.ts
@@ -39,3 +39,11 @@ export const TriggerTimeBased: IAutomationTrigger = {
   name: 'Time Based',
   matches: (event) => event.type === 'timeBased',
 };
+
+export const TriggerShortcut: IAutomationTrigger = {
+  id: 'shortcut',
+  name: 'Keyboard Shortcut',
+  description:
+    'Fires when the keyboard shortcut assigned to this rule is pressed. Assign the key in Settings > Keyboard Shortcuts. Actions apply to the task row currently focused in the app.',
+  matches: (event) => event.type === 'shortcut',
+};

--- a/packages/plugin-dev/automations/src/plugin.ts
+++ b/packages/plugin-dev/automations/src/plugin.ts
@@ -90,18 +90,16 @@ if (plugin.onMessage) {
             .map((a) => ({ id: a.id, name: a.name, description: a.description })),
         };
       case 'saveRule':
-        await automationManager.getRegistry().addOrUpdateRule(message.payload);
+        await automationManager.saveRule(message.payload);
         return { success: true };
       case 'addRules':
-        await automationManager.getRegistry().addRules(message.payload);
+        await automationManager.addRules(message.payload);
         return { success: true };
       case 'deleteRule':
-        await automationManager.getRegistry().deleteRule(message.payload.id);
+        await automationManager.deleteRule(message.payload.id);
         return { success: true };
       case 'toggleRuleStatus':
-        await automationManager
-          .getRegistry()
-          .toggleRuleStatus(message.payload.id, message.payload.isEnabled);
+        await automationManager.toggleRuleStatus(message.payload.id, message.payload.isEnabled);
         return { success: true };
       case 'getProjects':
         return await plugin.getAllProjects();

--- a/packages/plugin-dev/automations/src/plugin.ts
+++ b/packages/plugin-dev/automations/src/plugin.ts
@@ -76,7 +76,7 @@ if (plugin.onMessage) {
   plugin.onMessage(async (message: any) => {
     switch (message?.type) {
       case 'getRules':
-        return await automationManager.getRegistry().getRules();
+        return await automationManager.getRules();
       case 'getDefinitions':
         return {
           triggers: globalRegistry

--- a/packages/plugin-dev/automations/src/types.ts
+++ b/packages/plugin-dev/automations/src/types.ts
@@ -6,7 +6,8 @@ export type AutomationTriggerType =
   | 'taskUpdated'
   | 'taskStarted'
   | 'taskStopped'
-  | 'timeBased';
+  | 'timeBased'
+  | 'shortcut';
 
 export interface AutomationTrigger {
   type: AutomationTriggerType;

--- a/packages/plugin-dev/automations/src/utils/rule-validator.ts
+++ b/packages/plugin-dev/automations/src/utils/rule-validator.ts
@@ -18,6 +18,7 @@ const AUTOMATION_TRIGGER_TYPES = [
   'taskStarted',
   'taskStopped',
   'timeBased',
+  'shortcut',
 ] as const satisfies readonly AutomationTriggerType[];
 const _exhaustiveTriggers: _AssertEq<
   AutomationTriggerType,

--- a/src/app/core-ui/shortcut/shortcut.service.spec.ts
+++ b/src/app/core-ui/shortcut/shortcut.service.spec.ts
@@ -119,7 +119,8 @@ describe('ShortcutService', () => {
       expect(mockRouter.navigate).toHaveBeenCalledWith(['/schedule']);
     });
 
-    it('should execute a plugin shortcut bound to its key combo', async () => {
+    // Ctrl+Shift+U is the combo PLUGIN_SHORTCUT_CFG_KEY is bound to above.
+    const pressPluginCombo = async (repeat = false): Promise<void> => {
       mockPluginBridgeService.shortcuts.set([
         { pluginId: 'automations', id: 'r1', label: 'Tag as urgent', onExec: () => {} },
       ]);
@@ -127,10 +128,15 @@ describe('ShortcutService', () => {
         code: 'KeyU',
         ctrlKey: true,
         shiftKey: true,
+        repeat,
       });
       Object.defineProperty(ev, 'target', { value: document.body });
 
       await service.handleKeyDown(ev);
+    };
+
+    it('should execute a plugin shortcut bound to its key combo', async () => {
+      await pressPluginCombo();
 
       expect(mockPluginBridgeService.executeShortcut).toHaveBeenCalledWith(
         'automations:r1',
@@ -138,18 +144,7 @@ describe('ShortcutService', () => {
     });
 
     it('should NOT execute a plugin shortcut on key auto-repeat', async () => {
-      mockPluginBridgeService.shortcuts.set([
-        { pluginId: 'automations', id: 'r1', label: 'Tag as urgent', onExec: () => {} },
-      ]);
-      const ev = new KeyboardEvent('keydown', {
-        code: 'KeyU',
-        ctrlKey: true,
-        shiftKey: true,
-        repeat: true,
-      });
-      Object.defineProperty(ev, 'target', { value: document.body });
-
-      await service.handleKeyDown(ev);
+      await pressPluginCombo(true);
 
       expect(mockPluginBridgeService.executeShortcut).not.toHaveBeenCalled();
     });

--- a/src/app/core-ui/shortcut/shortcut.service.spec.ts
+++ b/src/app/core-ui/shortcut/shortcut.service.spec.ts
@@ -16,12 +16,15 @@ import { OverlayContainer } from '@angular/cdk/overlay';
 import { signal } from '@angular/core';
 import { of } from 'rxjs';
 
+const PLUGIN_SHORTCUT_CFG_KEY = 'plugin_automations:r1';
+
 describe('ShortcutService', () => {
   let service: ShortcutService;
   let mockTaskShortcutService: any;
   let mockRouter: any;
   let mockConfigService: any;
   let mockMatDialog: any;
+  let mockPluginBridgeService: any;
 
   beforeEach(() => {
     mockMatDialog = {
@@ -40,11 +43,16 @@ describe('ShortcutService', () => {
       navigate: jasmine.createSpy('navigate'),
       url: '/',
     };
+    mockPluginBridgeService = {
+      shortcuts: signal<any[]>([]),
+      executeShortcut: jasmine.createSpy('executeShortcut'),
+    };
     mockConfigService = {
       cfg: signal({
         keyboard: {
           goToScheduledView: 'Shift+S',
           showHelp: '?',
+          [PLUGIN_SHORTCUT_CFG_KEY]: 'Ctrl+Shift+U',
         },
       }),
       appFeatures: signal({
@@ -66,7 +74,7 @@ describe('ShortcutService', () => {
         { provide: UiHelperService, useValue: {} },
         { provide: SyncWrapperService, useValue: {} },
         { provide: Store, useValue: { dispatch: jasmine.createSpy('dispatch') } },
-        { provide: PluginBridgeService, useValue: { shortcuts: signal([]) } },
+        { provide: PluginBridgeService, useValue: mockPluginBridgeService },
         {
           provide: OverlayContainer,
           useValue: {
@@ -109,6 +117,41 @@ describe('ShortcutService', () => {
 
       expect(mockTaskShortcutService.handleTaskShortcuts).toHaveBeenCalledWith(ev);
       expect(mockRouter.navigate).toHaveBeenCalledWith(['/schedule']);
+    });
+
+    it('should execute a plugin shortcut bound to its key combo', async () => {
+      mockPluginBridgeService.shortcuts.set([
+        { pluginId: 'automations', id: 'r1', label: 'Tag as urgent', onExec: () => {} },
+      ]);
+      const ev = new KeyboardEvent('keydown', {
+        code: 'KeyU',
+        ctrlKey: true,
+        shiftKey: true,
+      });
+      Object.defineProperty(ev, 'target', { value: document.body });
+
+      await service.handleKeyDown(ev);
+
+      expect(mockPluginBridgeService.executeShortcut).toHaveBeenCalledWith(
+        'automations:r1',
+      );
+    });
+
+    it('should NOT execute a plugin shortcut on key auto-repeat', async () => {
+      mockPluginBridgeService.shortcuts.set([
+        { pluginId: 'automations', id: 'r1', label: 'Tag as urgent', onExec: () => {} },
+      ]);
+      const ev = new KeyboardEvent('keydown', {
+        code: 'KeyU',
+        ctrlKey: true,
+        shiftKey: true,
+        repeat: true,
+      });
+      Object.defineProperty(ev, 'target', { value: document.body });
+
+      await service.handleKeyDown(ev);
+
+      expect(mockPluginBridgeService.executeShortcut).not.toHaveBeenCalled();
     });
 
     it('should open the shortcut cheat sheet on "?"', async () => {

--- a/src/app/core-ui/shortcut/shortcut.service.ts
+++ b/src/app/core-ui/shortcut/shortcut.service.ts
@@ -260,7 +260,11 @@ export class ShortcutService {
       }
     }
 
-    // Check plugin shortcuts (exec last)
+    // Check plugin shortcuts (exec last). Auto-repeat is dropped: holding the
+    // key would otherwise run the plugin action dozens of times a second.
+    if (ev.repeat) {
+      return;
+    }
     const pluginShortcuts = this._pluginBridgeService.shortcuts();
     for (const shortcut of pluginShortcuts) {
       const shortcutKey = `plugin_${shortcut.pluginId}:${shortcut.id}`;

--- a/src/app/features/tasks/get-dom-focused-task-id.ts
+++ b/src/app/features/tasks/get-dom-focused-task-id.ts
@@ -1,19 +1,15 @@
 /**
- * The id of the <task> the user actually has focused, read from the DOM (#8851).
+ * The id of the task row the user actually has focused, read from the DOM (#8851).
  *
- * `TaskFocusService.focusedTaskId` is tracked via focusin/focusout and can drift
- * from reality in both directions, so the DOM is authoritative for anything that
- * acts on "the focused task":
+ * `TaskFocusService.focusedTaskId` is tracked via focusin/focusout and drifts in
+ * both directions — a `focusout` can clear it without a matching `focusin`, and a
+ * view change can leave it pointing at a row that no longer holds focus — so
+ * anything acting on "the focused task" must not trust it.
  *
- *  1. Focus-tracking recovery: a `focusout` can clear the tracked id without a
- *     following `focusin` rebinding it (e.g. focus staying on the task host
- *     after an inline-edit blur, where `.focus()` is a no-op and no new focusin
- *     fires), which would silently drop the shortcut.
- *  2. Stale-focus guard: navigating to a view with no live <task> (e.g. the
- *     Planner overdue list) leaves the tracked id pointing at a <task> that no
- *     longer holds focus. Acting on it would mutate the wrong task.
+ * @param hostSelector the row host to walk up to. `[data-task-id]` also matches
+ *   `<planner-task>`, which carries a task id without a live `<task>` component.
  */
-export const getDomFocusedTaskId = (): string | null =>
-  (document.activeElement?.closest('task') as HTMLElement | null)?.getAttribute(
+export const getDomFocusedTaskId = (hostSelector = 'task'): string | null =>
+  (document.activeElement?.closest(hostSelector) as HTMLElement | null)?.getAttribute(
     'data-task-id',
   ) ?? null;

--- a/src/app/features/tasks/get-dom-focused-task-id.ts
+++ b/src/app/features/tasks/get-dom-focused-task-id.ts
@@ -1,0 +1,19 @@
+/**
+ * The id of the <task> the user actually has focused, read from the DOM (#8851).
+ *
+ * `TaskFocusService.focusedTaskId` is tracked via focusin/focusout and can drift
+ * from reality in both directions, so the DOM is authoritative for anything that
+ * acts on "the focused task":
+ *
+ *  1. Focus-tracking recovery: a `focusout` can clear the tracked id without a
+ *     following `focusin` rebinding it (e.g. focus staying on the task host
+ *     after an inline-edit blur, where `.focus()` is a no-op and no new focusin
+ *     fires), which would silently drop the shortcut.
+ *  2. Stale-focus guard: navigating to a view with no live <task> (e.g. the
+ *     Planner overdue list) leaves the tracked id pointing at a <task> that no
+ *     longer holds focus. Acting on it would mutate the wrong task.
+ */
+export const getDomFocusedTaskId = (): string | null =>
+  (document.activeElement?.closest('task') as HTMLElement | null)?.getAttribute(
+    'data-task-id',
+  ) ?? null;

--- a/src/app/features/tasks/task-shortcut.service.ts
+++ b/src/app/features/tasks/task-shortcut.service.ts
@@ -8,6 +8,7 @@ import { TaskComponent } from './task/task.component';
 import { TaskContextMenuComponent } from './task-context-menu/task-context-menu.component';
 import { TaskContextMenuInnerComponent } from './task-context-menu/task-context-menu-inner/task-context-menu-inner.component';
 import { isInputElement } from '../../util/dom-element';
+import { getDomFocusedTaskId } from './get-dom-focused-task-id';
 
 type TaskId = string;
 
@@ -61,31 +62,7 @@ export class TaskShortcutService {
     if (!cfg) return false;
 
     const keys = cfg.keyboard;
-    let focusedTaskId: TaskId | null = this._taskFocusService.focusedTaskId();
-
-    // Make the DOM authoritative for task focus (#8851). Two problems this
-    // solves:
-    //  1. Focus-tracking recovery: a `focusout` can clear focusedTaskId without
-    //     a following `focusin` rebinding it (e.g. focus staying on the task
-    //     host after an inline-edit blur, where `.focus()` is a no-op and no new
-    //     focusin fires). If the active element is still inside a <task>, we
-    //     recover the id so shortcuts don't silently drop.
-    //  2. Stale-focus guard: navigating to a view with no live <task> (e.g. the
-    //     Planner overdue list) leaves focusedTaskId pointing at a <task> that
-    //     no longer holds focus. Acting on it would mutate the wrong task. If
-    //     the active element is not inside the <task> matching focusedTaskId,
-    //     drop it.
-    // Only the DOM actively contradicting invalidates focus, so the inline-edit
-    // recovery path above stays intact.
-    const active = document.activeElement as HTMLElement | null;
-    const domFocusedTaskId =
-      (active?.closest('task') as HTMLElement | null)?.getAttribute('data-task-id') ??
-      null;
-    if (domFocusedTaskId) {
-      focusedTaskId = domFocusedTaskId;
-    } else if (focusedTaskId) {
-      focusedTaskId = null;
-    }
+    const focusedTaskId: TaskId | null = getDomFocusedTaskId();
 
     // Schedule for today (Shift+T). This is the one task shortcut wired to work
     // without a live <task> component, so it also fires from views that render

--- a/src/app/features/tasks/task-shortcut.service.ts
+++ b/src/app/features/tasks/task-shortcut.service.ts
@@ -116,7 +116,7 @@ export class TaskShortcutService {
         !hasTextSelected
       ) {
         const taskComponent = this._taskFocusService.lastFocusedTaskComponent();
-        // Recovery path (above) can derive focusedTaskId from the DOM before
+        // getDomFocusedTaskId() can derive focusedTaskId from the DOM before
         // lastFocusedTaskComponent has caught up — fall through to native copy
         // rather than copying a stale title.
         if (taskComponent?.task().id === focusedTaskId) {
@@ -359,15 +359,12 @@ export class TaskShortcutService {
   }
 
   /**
-   * Resolves a task id straight from the focused element by walking up to the
-   * nearest host carrying `data-task-id`. Generic over the host selector (works
-   * for both `<task>` and `<planner-task>`) so the id-based shortcut path can
-   * act on a task without a live `<task>` component. (#8851)
+   * Resolves a task id from the focused element, matching `<planner-task>` as
+   * well as `<task>`, so the id-based shortcut path can act on a task without a
+   * live `<task>` component. (#8851)
    */
   private _resolveTaskIdFromDom(): TaskId | null {
-    const active = document.activeElement as HTMLElement | null;
-    const host = active?.closest('[data-task-id]') as HTMLElement | null;
-    return host?.getAttribute('data-task-id') ?? null;
+    return getDomFocusedTaskId('[data-task-id]');
   }
 
   /**

--- a/src/app/plugins/plugin-api.ts
+++ b/src/app/plugins/plugin-api.ts
@@ -152,6 +152,11 @@ export class PluginAPI implements PluginAPIInterface {
     this.#boundMethods.registerShortcut(shortcut);
   }
 
+  unregisterShortcut(shortcutId: string): void {
+    PluginLog.log(`Plugin ${this.#pluginId} unregistered shortcut`);
+    this.#boundMethods.unregisterShortcut(shortcutId);
+  }
+
   registerSidePanelButton(
     sidePanelBtnCfg: Omit<PluginSidePanelBtnCfg, 'pluginId'>,
   ): void {

--- a/src/app/plugins/plugin-bridge.service.spec.ts
+++ b/src/app/plugins/plugin-bridge.service.spec.ts
@@ -430,6 +430,21 @@ describe('PluginBridgeService - iframe task selection methods', () => {
 
   let service: PluginBridgeService;
   let taskService: jasmine.SpyObj<TaskService>;
+  let taskEl: HTMLElement | null = null;
+
+  // getFocusedTask() reads the DOM, so a focused <task> has to actually exist.
+  const focusTaskEl = (taskId: string): void => {
+    taskEl = document.createElement('task');
+    taskEl.setAttribute('data-task-id', taskId);
+    taskEl.tabIndex = 0;
+    document.body.appendChild(taskEl);
+    taskEl.focus();
+  };
+
+  afterEach(() => {
+    taskEl?.remove();
+    taskEl = null;
+  });
 
   beforeEach(() => {
     taskService = jasmine.createSpyObj<TaskService>('TaskService', ['getByIdOnce$'], {
@@ -474,6 +489,7 @@ describe('PluginBridgeService - iframe task selection methods', () => {
   });
 
   it('exposes selected and focused task readers on iframe bound methods', async () => {
+    focusTaskEl(focusedTask.id);
     const bound = service.createBoundMethods('iframe-plugin');
 
     const selectedResult = await bound.getSelectedTask();
@@ -487,6 +503,7 @@ describe('PluginBridgeService - iframe task selection methods', () => {
   });
 
   it('returns null for stale focused task ids', async () => {
+    focusTaskEl(focusedTask.id);
     taskService.getByIdOnce$.and.returnValue(
       of(undefined as unknown as TaskWithSubTasks),
     );
@@ -494,6 +511,24 @@ describe('PluginBridgeService - iframe task selection methods', () => {
 
     await expectAsync(bound.getFocusedTask()).toBeResolvedTo(null);
     expect(taskService.getByIdOnce$).toHaveBeenCalledOnceWith(focusedTask.id);
+  });
+
+  // A view change can leave the tracked id pointing at a task that no longer
+  // holds focus; acting on it would mutate the wrong task (#8851).
+  it('returns null when no task row is focused, even with a tracked id', async () => {
+    const bound = service.createBoundMethods('iframe-plugin');
+
+    await expectAsync(bound.getFocusedTask()).toBeResolvedTo(null);
+    expect(taskService.getByIdOnce$).not.toHaveBeenCalled();
+  });
+
+  it('prefers the task the DOM says is focused over the tracked id', async () => {
+    focusTaskEl('other-task');
+    const bound = service.createBoundMethods('iframe-plugin');
+
+    await bound.getFocusedTask();
+
+    expect(taskService.getByIdOnce$).toHaveBeenCalledOnceWith('other-task');
   });
 });
 

--- a/src/app/plugins/plugin-bridge.service.spec.ts
+++ b/src/app/plugins/plugin-bridge.service.spec.ts
@@ -278,6 +278,47 @@ describe('PluginBridgeService - Counter Methods', () => {
     });
   });
 
+  describe('shortcuts', () => {
+    const shortcut = (id: string, label: string): any => ({
+      pluginId: 'test-plugin',
+      id,
+      label,
+      onExec: () => {},
+    });
+
+    it('replaces an existing shortcut when the same id is registered again', () => {
+      (service as any)._registerShortcut('test-plugin', shortcut('rule-1', 'Old label'));
+      (service as any)._registerShortcut('test-plugin', shortcut('rule-1', 'New label'));
+
+      expect(service.shortcuts().length).toBe(1);
+      expect(service.shortcuts()[0].label).toBe('New label');
+    });
+
+    it('keeps shortcuts of other plugins with the same id', () => {
+      (service as any)._registerShortcut('test-plugin', shortcut('rule-1', 'Mine'));
+      (service as any)._registerShortcut('other-plugin', shortcut('rule-1', 'Theirs'));
+
+      expect(service.shortcuts().length).toBe(2);
+    });
+
+    it('unregisters a single shortcut of a plugin', () => {
+      (service as any)._registerShortcut('test-plugin', shortcut('rule-1', 'One'));
+      (service as any)._registerShortcut('test-plugin', shortcut('rule-2', 'Two'));
+
+      (service as any)._unregisterShortcut('test-plugin', 'rule-1');
+
+      expect(service.shortcuts().map((s) => s.id)).toEqual(['rule-2']);
+    });
+
+    it('does not unregister the same id of another plugin', () => {
+      (service as any)._registerShortcut('test-plugin', shortcut('rule-1', 'Mine'));
+
+      (service as any)._unregisterShortcut('other-plugin', 'rule-1');
+
+      expect(service.shortcuts().length).toBe(1);
+    });
+  });
+
   describe('reInitData', () => {
     it('should delegate to DataInitService.reInit', async () => {
       await service.reInitData();

--- a/src/app/plugins/plugin-bridge.service.spec.ts
+++ b/src/app/plugins/plugin-bridge.service.spec.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 // Active tests for setCounter fix (issue #5812)
-import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
 import { PluginBridgeService } from './plugin-bridge.service';
+import { PluginShortcutCfg } from '@super-productivity/plugin-api';
 import { selectAllSimpleCounters } from '../features/simple-counter/store/simple-counter.reducer';
 import {
   updateSimpleCounter,
@@ -20,7 +20,6 @@ import { NotifyService } from '../core/notify/notify.service';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { PluginHooksService } from './plugin-hooks';
 import { TaskService } from '../features/tasks/task.service';
-import { TaskFocusService } from '../features/tasks/task-focus.service';
 import { DEFAULT_TASK, TaskWithSubTasks } from '../features/tasks/task.model';
 import { WorkContextService } from '../features/work-context/work-context.service';
 import { ProjectService } from '../features/project/project.service';
@@ -279,41 +278,54 @@ describe('PluginBridgeService - Counter Methods', () => {
   });
 
   describe('shortcuts', () => {
-    const shortcut = (id: string, label: string): any => ({
-      pluginId: 'test-plugin',
+    const shortcut = (
+      pluginId: string,
+      id: string,
+      label: string,
+    ): PluginShortcutCfg => ({
+      pluginId,
       id,
       label,
       onExec: () => {},
     });
 
     it('replaces an existing shortcut when the same id is registered again', () => {
-      (service as any)._registerShortcut('test-plugin', shortcut('rule-1', 'Old label'));
-      (service as any)._registerShortcut('test-plugin', shortcut('rule-1', 'New label'));
+      const bound = service.createBoundMethods('test-plugin');
+
+      bound.registerShortcut(shortcut('test-plugin', 'rule-1', 'Old label'));
+      bound.registerShortcut(shortcut('test-plugin', 'rule-1', 'New label'));
 
       expect(service.shortcuts().length).toBe(1);
       expect(service.shortcuts()[0].label).toBe('New label');
     });
 
     it('keeps shortcuts of other plugins with the same id', () => {
-      (service as any)._registerShortcut('test-plugin', shortcut('rule-1', 'Mine'));
-      (service as any)._registerShortcut('other-plugin', shortcut('rule-1', 'Theirs'));
+      service
+        .createBoundMethods('test-plugin')
+        .registerShortcut(shortcut('test-plugin', 'rule-1', 'Mine'));
+      service
+        .createBoundMethods('other-plugin')
+        .registerShortcut(shortcut('other-plugin', 'rule-1', 'Theirs'));
 
       expect(service.shortcuts().length).toBe(2);
     });
 
     it('unregisters a single shortcut of a plugin', () => {
-      (service as any)._registerShortcut('test-plugin', shortcut('rule-1', 'One'));
-      (service as any)._registerShortcut('test-plugin', shortcut('rule-2', 'Two'));
+      const bound = service.createBoundMethods('test-plugin');
+      bound.registerShortcut(shortcut('test-plugin', 'rule-1', 'One'));
+      bound.registerShortcut(shortcut('test-plugin', 'rule-2', 'Two'));
 
-      (service as any)._unregisterShortcut('test-plugin', 'rule-1');
+      bound.unregisterShortcut('rule-1');
 
       expect(service.shortcuts().map((s) => s.id)).toEqual(['rule-2']);
     });
 
     it('does not unregister the same id of another plugin', () => {
-      (service as any)._registerShortcut('test-plugin', shortcut('rule-1', 'Mine'));
+      service
+        .createBoundMethods('test-plugin')
+        .registerShortcut(shortcut('test-plugin', 'rule-1', 'Mine'));
 
-      (service as any)._unregisterShortcut('other-plugin', 'rule-1');
+      service.createBoundMethods('other-plugin').unregisterShortcut('rule-1');
 
       expect(service.shortcuts().length).toBe(1);
     });
@@ -431,19 +443,30 @@ describe('PluginBridgeService - iframe task selection methods', () => {
   let service: PluginBridgeService;
   let taskService: jasmine.SpyObj<TaskService>;
   let taskEl: HTMLElement | null = null;
+  let activeElementStubbed = false;
 
   // getFocusedTask() reads the DOM, so a focused <task> has to actually exist.
+  // activeElement is stubbed rather than set via el.focus() — headless Chrome
+  // only updates it when the test iframe has window focus, which is not
+  // guaranteed inside a large suite (same pattern as task-shortcut.service.spec).
   const focusTaskEl = (taskId: string): void => {
     taskEl = document.createElement('task');
     taskEl.setAttribute('data-task-id', taskId);
-    taskEl.tabIndex = 0;
     document.body.appendChild(taskEl);
-    taskEl.focus();
+    Object.defineProperty(document, 'activeElement', {
+      configurable: true,
+      get: () => taskEl,
+    });
+    activeElementStubbed = true;
   };
 
   afterEach(() => {
     taskEl?.remove();
     taskEl = null;
+    if (activeElementStubbed) {
+      delete (document as unknown as { activeElement?: unknown }).activeElement;
+      activeElementStubbed = false;
+    }
   });
 
   beforeEach(() => {
@@ -462,12 +485,6 @@ describe('PluginBridgeService - iframe task selection methods', () => {
         { provide: MatDialog, useValue: {} },
         { provide: PluginHooksService, useValue: {} },
         { provide: TaskService, useValue: taskService },
-        {
-          provide: TaskFocusService,
-          useValue: {
-            focusedTaskId: signal<string | null>(focusedTask.id),
-          },
-        },
         { provide: WorkContextService, useValue: { activeWorkContext$: of(null) } },
         { provide: ProjectService, useValue: {} },
         { provide: TagService, useValue: {} },
@@ -513,22 +530,13 @@ describe('PluginBridgeService - iframe task selection methods', () => {
     expect(taskService.getByIdOnce$).toHaveBeenCalledOnceWith(focusedTask.id);
   });
 
-  // A view change can leave the tracked id pointing at a task that no longer
-  // holds focus; acting on it would mutate the wrong task (#8851).
-  it('returns null when no task row is focused, even with a tracked id', async () => {
+  // Focus tracking can keep pointing at a task that no longer holds focus after
+  // a view change; acting on it would mutate the wrong task (#8851).
+  it('returns null when no task row is focused', async () => {
     const bound = service.createBoundMethods('iframe-plugin');
 
     await expectAsync(bound.getFocusedTask()).toBeResolvedTo(null);
     expect(taskService.getByIdOnce$).not.toHaveBeenCalled();
-  });
-
-  it('prefers the task the DOM says is focused over the tracked id', async () => {
-    focusTaskEl('other-task');
-    const bound = service.createBoundMethods('iframe-plugin');
-
-    await bound.getFocusedTask();
-
-    expect(taskService.getByIdOnce$).toHaveBeenCalledOnceWith('other-task');
   });
 });
 

--- a/src/app/plugins/plugin-bridge.service.ts
+++ b/src/app/plugins/plugin-bridge.service.ts
@@ -1659,22 +1659,22 @@ export class PluginBridgeService implements OnDestroy {
     // plugins re-register when a shortcut's label changes, and the keyboard
     // settings form keys its items by `plugin_<pluginId>:<id>`, so duplicates
     // would show up twice there and only the first would ever be executed.
+    const isSameShortcut = (shortcut: PluginShortcutCfg): boolean =>
+      shortcut.pluginId === pluginId && shortcut.id === shortcutWithPluginId.id;
     const currentShortcuts = this.shortcuts();
-    const existingIdx = currentShortcuts.findIndex(
-      (shortcut) =>
-        shortcut.pluginId === pluginId && shortcut.id === shortcutWithPluginId.id,
+    this.shortcuts.set(
+      currentShortcuts.some(isSameShortcut)
+        ? currentShortcuts.map((shortcut) =>
+            isSameShortcut(shortcut) ? shortcutWithPluginId : shortcut,
+          )
+        : [...currentShortcuts, shortcutWithPluginId],
     );
-    if (existingIdx === -1) {
-      this.shortcuts.set([...currentShortcuts, shortcutWithPluginId]);
-    } else {
-      const nextShortcuts = [...currentShortcuts];
-      nextShortcuts[existingIdx] = shortcutWithPluginId;
-      this.shortcuts.set(nextShortcuts);
-    }
 
+    // Labels are user content (a plugin may derive them from task or rule
+    // names) and the log is exportable, so only the ids go in.
     PluginLog.log('PluginBridge: Shortcut registered', {
       pluginId,
-      shortcut: shortcutWithPluginId,
+      shortcutId: shortcutWithPluginId.id,
     });
   }
 
@@ -1703,12 +1703,10 @@ export class PluginBridgeService implements OnDestroy {
     if (shortcut) {
       try {
         await Promise.resolve(shortcut.onExec());
-        PluginLog.log(
-          `Executed shortcut "${shortcut.label}" from plugin ${shortcut.pluginId}`,
-        );
+        PluginLog.log(`Executed shortcut ${shortcutId}`);
         return true;
       } catch (error) {
-        PluginLog.err(`Failed to execute shortcut "${shortcut.label}":`, error);
+        PluginLog.err(`Failed to execute shortcut ${shortcutId}:`, error);
         return false;
       }
     }

--- a/src/app/plugins/plugin-bridge.service.ts
+++ b/src/app/plugins/plugin-bridge.service.ts
@@ -249,6 +249,7 @@ export class PluginBridgeService implements OnDestroy {
       cfg: Omit<PluginWorkContextHeaderBtnCfg, 'pluginId'>,
     ) => void;
     registerShortcut: (cfg: PluginShortcutCfg) => void;
+    unregisterShortcut: (shortcutId: string) => void;
     showIndexHtmlAsView: () => void;
     showInWorkContext: () => void;
     closeWorkContextView: () => void;
@@ -309,6 +310,8 @@ export class PluginBridgeService implements OnDestroy {
         cfg: Omit<PluginWorkContextHeaderBtnCfg, 'pluginId'>,
       ) => this._registerWorkContextHeaderButton(pluginId, cfg),
       registerShortcut: (cfg: PluginShortcutCfg) => this._registerShortcut(pluginId, cfg),
+      unregisterShortcut: (shortcutId: string) =>
+        this._unregisterShortcut(pluginId, shortcutId),
       registerConfigHandler: (handler: () => void) =>
         this._configHandlers.set(pluginId, handler),
 
@@ -1650,13 +1653,42 @@ export class PluginBridgeService implements OnDestroy {
       pluginId,
     };
 
+    // Re-registering an id replaces the previous entry instead of appending:
+    // plugins re-register when a shortcut's label changes, and the keyboard
+    // settings form keys its items by `plugin_<pluginId>:<id>`, so duplicates
+    // would show up twice there and only the first would ever be executed.
     const currentShortcuts = this.shortcuts();
-    this.shortcuts.set([...currentShortcuts, shortcutWithPluginId]);
+    const existingIdx = currentShortcuts.findIndex(
+      (shortcut) =>
+        shortcut.pluginId === pluginId && shortcut.id === shortcutWithPluginId.id,
+    );
+    if (existingIdx === -1) {
+      this.shortcuts.set([...currentShortcuts, shortcutWithPluginId]);
+    } else {
+      const nextShortcuts = [...currentShortcuts];
+      nextShortcuts[existingIdx] = shortcutWithPluginId;
+      this.shortcuts.set(nextShortcuts);
+    }
 
     PluginLog.log('PluginBridge: Shortcut registered', {
       pluginId,
       shortcut: shortcutWithPluginId,
     });
+  }
+
+  /**
+   * Internal method to remove a single shortcut of a plugin
+   */
+  private _unregisterShortcut(pluginId: string, shortcutId: string): void {
+    const currentShortcuts = this.shortcuts();
+    const nextShortcuts = currentShortcuts.filter(
+      (shortcut) => !(shortcut.pluginId === pluginId && shortcut.id === shortcutId),
+    );
+
+    if (nextShortcuts.length !== currentShortcuts.length) {
+      this.shortcuts.set(nextShortcuts);
+      PluginLog.log('PluginBridge: Shortcut unregistered', { pluginId, shortcutId });
+    }
   }
 
   /**

--- a/src/app/plugins/plugin-bridge.service.ts
+++ b/src/app/plugins/plugin-bridge.service.ts
@@ -44,7 +44,7 @@ import {
 import { snackCfgToSnackParams } from './plugin-api-mapper';
 import { PluginHooksService } from './plugin-hooks';
 import { TaskService } from '../features/tasks/task.service';
-import { TaskFocusService } from '../features/tasks/task-focus.service';
+import { getDomFocusedTaskId } from '../features/tasks/get-dom-focused-task-id';
 import { addSubTask } from '../features/tasks/store/task.actions';
 import { selectTaskFeatureState } from '../features/tasks/store/task.selectors';
 import { parseTimeSpentChanges } from '../features/tasks/short-syntax';
@@ -148,7 +148,6 @@ export class PluginBridgeService implements OnDestroy {
   private _store = inject(Store);
   private _pluginHooksService = inject(PluginHooksService);
   private _taskService = inject(TaskService);
-  private _taskFocusService = inject(TaskFocusService);
   private _workContextService = inject(WorkContextService);
   private _projectService = inject(ProjectService);
   private _tagService = inject(TagService);
@@ -1217,7 +1216,10 @@ export class PluginBridgeService implements OnDestroy {
   }
 
   async getFocusedTask(): Promise<TaskCopy | null> {
-    const focusedTaskId = this._taskFocusService.focusedTaskId();
+    // The DOM decides, not the tracked signal: plugins act on this task (a
+    // shortcut-triggered automation rule may delete or re-tag it), so a stale
+    // id left behind by a view change must not resolve to a live task (#8851).
+    const focusedTaskId = getDomFocusedTaskId();
     if (!focusedTaskId) {
       return null;
     }

--- a/src/app/plugins/util/plugin-iframe.util.ts
+++ b/src/app/plugins/util/plugin-iframe.util.ts
@@ -454,6 +454,7 @@ export const createPluginApiScript = (config: PluginIframeConfig): string => {
           registerMenuEntry: unsupportedIframeRegistration('registerMenuEntry'),
           registerConfigHandler: unsupportedIframeRegistration('registerConfigHandler'),
           registerShortcut: unsupportedIframeRegistration('registerShortcut'),
+          unregisterShortcut: unsupportedIframeRegistration('unregisterShortcut'),
           registerSidePanelButton: unsupportedIframeRegistration('registerSidePanelButton'),
           registerWorkContextHeaderButton: (cfg) => {
             // onClick is not structured-cloneable across postMessage; keep it


### PR DESCRIPTION
Adds a **Keyboard Shortcut** trigger to the bundled Automations plugin: a rule can now be run by pressing a key instead of waiting for a task event.

Each enabled rule with the trigger registers a plugin shortcut named after the rule; the user assigns the key under **Settings → Keyboard Shortcuts → Plugin Shortcuts**. Pressing it runs the rule's actions against the currently focused task row — task-independent actions (create task, snack, dialog, webhook) work without one.

The shortcut id is the rule id, so renaming a rule keeps its binding, while disabling or deleting one releases the key again (a registered shortcut swallows its combo, so an inert rule must not hold one).

### Host-side changes

- `registerShortcut()` now replaces an entry with the same `pluginId:id` instead of appending — duplicates showed up twice in the keyboard settings form and only the first ever ran.
- New `unregisterShortcut(shortcutId)` counterpart on `PluginAPI` (not available to iframe plugins, like the other registration methods).
- Plugin shortcuts ignore key auto-repeat: holding the key ran the rule dozens of times a second.
- `getFocusedTask()` resolves focus from the DOM like the built-in task shortcuts already do (#8851). The tracked id survives a view change that removes the task row without a `focusout`, and a shortcut rule acting on it would delete or re-tag a task the user is not looking at. The guard lives in `get-dom-focused-task-id.ts`, shared with `TaskShortcutService`.
- Shortcut rules skip the automation rate limiter — it exists to break automation loops, and a keypress cannot feed itself, so rapid presses must not raise the "high automation activity" dialog.
- Shortcut labels are user content (rule names), so they no longer reach the exportable log — ids only.

### Notes

- No schema or op-log impact: the new trigger type persists as an ordinary rule and older clients preserve unknown entries instead of dropping them.
- No new dependencies.
- Docs updated: `docs/plugin-development.md`, wiki `3.01-API.md`, wiki `3.03-Keyboard-Shortcuts.md`.

### Testing

- Plugin unit tests: 139 passing (new `shortcut-binder.spec.ts`, extended `automation-manager.spec.ts`).
- Host: `plugin-bridge.service.spec.ts`, `shortcut.service.spec.ts`, `task-shortcut.service.spec.ts`, `plugin-api.spec.ts` all green; `tsc --noEmit` clean.
- Not covered by automated tests: the real focus + real keypress seam (there is no plugin E2E suite).

https://claude.ai/code/session_01XBjfUtvdt8Sj6S93LZh9Er