### PR TITLE
fix(notes): remove close button from mobile notes panel

### DIFF
--- a/src/app/features/bottom-panel/bottom-panel-container.component.html
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.html
@@ -1,21 +1,9 @@
 <div class="bottom-panel-container">
   <div
     class="bottom-panel-header"
-    [class.has-close-btn]="isShowCloseButton()"
     #panelHeader
   >
     <div class="drag-handle"></div>
-    @if (isShowCloseButton()) {
-      <button
-        mat-icon-button
-        class="close-btn"
-        [attr.aria-label]="T.G.CLOSE | translate"
-        (pointerdown)="stopHeaderEventPropagation($event)"
-        (click)="close(); stopHeaderEventPropagation($event)"
-      >
-        <mat-icon>close</mat-icon>
-      </button>
-    }
   </div>
 
   <div class="bottom-panel-content">

--- a/src/app/features/bottom-panel/bottom-panel-container.component.scss
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.scss
@@ -36,23 +36,6 @@
       background-color: var(--bottom-panel-handle-active);
     }
   }
-
-  .close-btn {
-    display: none; // Hidden by default to keep task panel autofocus behavior unchanged.
-  }
-
-  &.has-close-btn {
-    justify-content: center;
-
-    .close-btn {
-      display: inline-flex;
-      position: absolute;
-      right: 4px;
-      top: 50%;
-      transform: translateY(-50%);
-      pointer-events: auto;
-    }
-  }
 }
 
 .bottom-panel-content {

--- a/src/app/features/bottom-panel/bottom-panel-container.component.spec.ts
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.spec.ts
@@ -1,8 +1,4 @@
-import {
-  getInitialBottomPanelHeightRatio,
-  isBottomPanelCloseButtonVisible,
-  stopBottomPanelHeaderEventPropagation,
-} from './bottom-panel-container.component';
+import { getInitialBottomPanelHeightRatio } from './bottom-panel-container.component';
 
 describe('getInitialBottomPanelHeightRatio', () => {
   it('uses the compact height for task panels', () => {
@@ -16,24 +12,5 @@ describe('getInitialBottomPanelHeightRatio', () => {
   it('uses the expanded height for other panels', () => {
     expect(getInitialBottomPanelHeightRatio('ISSUE_PANEL')).toBe(0.9);
     expect(getInitialBottomPanelHeightRatio(null)).toBe(0.9);
-  });
-});
-
-describe('isBottomPanelCloseButtonVisible', () => {
-  it('only shows the close button for notes panels', () => {
-    expect(isBottomPanelCloseButtonVisible('NOTES')).toBeTrue();
-    expect(isBottomPanelCloseButtonVisible('TASK')).toBeFalse();
-    expect(isBottomPanelCloseButtonVisible('ISSUE_PANEL')).toBeFalse();
-    expect(isBottomPanelCloseButtonVisible(null)).toBeFalse();
-  });
-});
-
-describe('stopBottomPanelHeaderEventPropagation', () => {
-  it('stops close-button pointer and click events from starting a header drag', () => {
-    const event = jasmine.createSpyObj<Event>('event', ['stopPropagation']);
-
-    stopBottomPanelHeaderEventPropagation(event);
-
-    expect(event.stopPropagation).toHaveBeenCalledOnceWith();
   });
 });

--- a/src/app/features/bottom-panel/bottom-panel-container.component.ts
+++ b/src/app/features/bottom-panel/bottom-panel-container.component.ts
@@ -19,16 +19,12 @@ import { TaskViewCustomizerPanelComponent } from '../task-view-customizer/task-v
 import { PluginPanelContainerComponent } from '../../plugins/ui/plugin-panel-container/plugin-panel-container.component';
 import { fadeAnimation } from '../../ui/animations/fade.ani';
 import { taskDetailPanelTaskChangeAnimation } from '../tasks/task-detail-panel/task-detail-panel.ani';
-import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
 import { TaskService } from '../tasks/task.service';
 import { Log } from '../../core/log';
 import { PanelContentService, PanelContentType } from '../panels/panel-content.service';
 import { BottomPanelStateService } from '../../core-ui/bottom-panel-state.service';
 import { IS_TOUCH_ONLY } from '../../util/is-touch-only';
 import { BodyClass } from '../../app.constants';
-import { T } from '../../t.const';
-import { TranslatePipe } from '@ngx-translate/core';
 
 export interface BottomPanelData {
   panelContent: PanelContentType;
@@ -79,14 +75,6 @@ export const getInitialBottomPanelHeightRatio = (
   }
 };
 
-export const isBottomPanelCloseButtonVisible = (
-  panelContent: PanelContentType | null,
-): boolean => panelContent === 'NOTES';
-
-export const stopBottomPanelHeaderEventPropagation = (event: Event): void => {
-  event.stopPropagation();
-};
-
 const KEYBOARD_DETECT_THRESHOLD = 100;
 const KEYBOARD_SAFE_HEIGHT_MIN = 200;
 const KEYBOARD_SAFE_HEIGHT_RATIO = 0.85;
@@ -102,19 +90,15 @@ const CSS_VAR_VISUAL_VIEWPORT_HEIGHT = '--visual-viewport-height';
   changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [fadeAnimation, taskDetailPanelTaskChangeAnimation],
   imports: [
-    MatIconModule,
-    MatButtonModule,
     TaskDetailPanelComponent,
     NotesComponent,
     IssuePanelComponent,
     TaskViewCustomizerPanelComponent,
     PluginPanelContainerComponent,
-    TranslatePipe,
   ],
   standalone: true,
 })
 export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
-  readonly T = T;
   private _bottomSheetRef = inject(MatBottomSheetRef<BottomPanelContainerComponent>);
   private _elementRef = inject(ElementRef);
   private _taskService = inject(TaskService);
@@ -131,9 +115,6 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
     const dataContent = this.data?.panelContent ?? null;
     return dataContent ?? this._panelContentService.getCurrentPanelType();
   });
-  readonly isShowCloseButton = computed<boolean>(() =>
-    isBottomPanelCloseButtonVisible(this.panelContent()),
-  );
   readonly selectedTask = toSignal(this._taskService.selectedTask$, {
     initialValue: null,
   });
@@ -194,10 +175,6 @@ export class BottomPanelContainerComponent implements AfterViewInit, OnDestroy {
 
   close(): void {
     this._bottomSheetRef.dismiss();
-  }
-
-  stopHeaderEventPropagation(event: Event): void {
-    stopBottomPanelHeaderEventPropagation(event);
   }
 
   private _setupDragListeners(): void {

--- a/src/app/features/right-panel/right-panel.component.ts
+++ b/src/app/features/right-panel/right-panel.component.ts
@@ -259,8 +259,7 @@ export class RightPanelComponent implements AfterViewInit, OnDestroy {
                 closeOnNavigation: false,
                 panelClass: 'bottom-panel-sheet',
                 // Default 'first-tabbable' otherwise focuses the tag-edit
-                // input (the bottom-panel close-btn is display:none and gets
-                // skipped), which on touch makes mat-autocomplete pop open
+                // input, which on touch makes mat-autocomplete pop open
                 // immediately on every task open in portrait.
                 autoFocus: false,
               },


### PR DESCRIPTION
The X only ever appeared for the notes bottom sheet; dismissal is now swipe-down or backdrop-tap, consistent with every other panel content.

Claude-Session: https://claude.ai/code/session_01SMKsMhXHAKuYvFkFm2s2Gk

## Problem

<!-- Describe the problem that these changes solve (links to issues are welcome). -->

## Solution

<!-- Describe your changes in detail. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [ ] My commit messages follow the Angular format (`type(scope): description`)
