### PR TITLE
fix(e2e): pin test timezone away from midnight

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -37,6 +37,13 @@ const globalSetup = async (config: FullConfig): Promise<void> => {
   // TZ is picked so the run stays far from midnight — a day rollover mid-suite
   // breaks date-sensitive specs (see ./utils/test-timezone.ts). Workers are
   // forked after this, so they and the browsers they launch inherit the zone.
+  //
+  // This must stay an env var rather than Playwright's `use.timezoneId`, which
+  // would move only the browser: many specs compute a date in Node and assert it
+  // against the browser's local day (see utils/time-input-helper.ts and the note
+  // in tests/sync/supersync-round-time-conflict.spec.ts), so both sides have to
+  // move together. Specs that pin their own `timezoneId` opt out of this.
+  //
   // Set E2E_TZ to pin a specific zone when reproducing a timezone-dependent bug.
   process.env.TZ = process.env.E2E_TZ || pickTestTimezone();
   process.env.NODE_ENV = 'test';

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -3,6 +3,7 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { isServerHealthy } from './utils/supersync-helpers';
+import { pickTestTimezone } from './utils/test-timezone';
 
 /**
  * Warm up the dev server by fetching the app once before any tests start.
@@ -32,10 +33,14 @@ const warmUpDevServer = async (baseURL: string): Promise<void> => {
 };
 
 const globalSetup = async (config: FullConfig): Promise<void> => {
-  // Set test environment variables
-  process.env.TZ = 'Europe/Berlin';
+  // Set test environment variables.
+  // TZ is picked so the run stays far from midnight — a day rollover mid-suite
+  // breaks date-sensitive specs (see ./utils/test-timezone.ts). Workers are
+  // forked after this, so they and the browsers they launch inherit the zone.
+  // Set E2E_TZ to pin a specific zone when reproducing a timezone-dependent bug.
+  process.env.TZ = process.env.E2E_TZ || pickTestTimezone();
   process.env.NODE_ENV = 'test';
-  console.log(`Running tests with ${config.workers} workers`);
+  console.log(`Running tests with ${config.workers} workers in TZ=${process.env.TZ}`);
 
   // Build plugins before starting tests (skip if already built)
   // Check both the dev path (src/assets/) and the CI pre-built path (.tmp/angular-dist/)

--- a/e2e/utils/test-timezone.ts
+++ b/e2e/utils/test-timezone.ts
@@ -14,12 +14,18 @@
 /**
  * Candidates are DST-free, so the offset cannot shift while tests run, and are
  * spaced at most 4h apart, so the picked zone always lands within 2h of midday.
+ *
+ * None of them is UTC itself, deliberately: at UTC+0 every local-vs-UTC
+ * divergence collapses, so an off-by-one-day regression in `toISOString()` or
+ * `dateStrToUtcDate` would pass silently (see
+ * tests/recurring/skip-overdue-reaps-timed-instance.spec.ts, which exists
+ * because the unit suites cannot catch that drift).
  */
 const CANDIDATE_TIMEZONES = [
   'Pacific/Honolulu', // UTC-10
   'America/Regina', // UTC-6
   'America/Sao_Paulo', // UTC-3
-  'UTC', // UTC+0
+  'Africa/Lagos', // UTC+1
   'Africa/Nairobi', // UTC+3
   'Asia/Dhaka', // UTC+6
   'Asia/Shanghai', // UTC+8

--- a/e2e/utils/test-timezone.ts
+++ b/e2e/utils/test-timezone.ts
@@ -1,0 +1,60 @@
+/**
+ * Keeps the E2E suite's wall clock far away from midnight.
+ *
+ * A day rollover mid-run silently breaks any date-sensitive spec: the TODAY_TAG
+ * repair selector clears `taskIds` once `todayStr` moves on, tasks drop into the
+ * "From previous days" panel, and ordering assertions fail for reasons that have
+ * nothing to do with the change under test. Run 33808991574 hit exactly this —
+ * a 21:38 UTC push ran the WebDAV suite straight through 00:00 Europe/Berlin.
+ *
+ * Day rollover itself is still worth testing, but from a dedicated spec that
+ * seeds `dueDay` or moves `startOfNextDayDiff` — not by accident at 00:00 in CI.
+ */
+
+/**
+ * Candidates are DST-free, so the offset cannot shift while tests run, and are
+ * spaced at most 4h apart, so the picked zone always lands within 2h of midday.
+ */
+const CANDIDATE_TIMEZONES = [
+  'Pacific/Honolulu', // UTC-10
+  'America/Regina', // UTC-6
+  'America/Sao_Paulo', // UTC-3
+  'UTC', // UTC+0
+  'Africa/Nairobi', // UTC+3
+  'Asia/Dhaka', // UTC+6
+  'Asia/Shanghai', // UTC+8
+  'Pacific/Guadalcanal', // UTC+11
+] as const;
+
+const MIDDAY_HOUR = 12;
+
+/** Local time in the given zone, as fractional hours since midnight. */
+const localHourIn = (timeZone: string, now: Date): number => {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hour: 'numeric',
+    minute: 'numeric',
+    hour12: false,
+  }).formatToParts(now);
+  const partValue = (type: string): number =>
+    Number(parts.find((p) => p.type === type)?.value ?? '0');
+  // Some ICU versions report midnight as hour 24 under hour12: false
+  const hour = partValue('hour') % 24;
+  const minuteFraction = partValue('minute') / 60;
+  return hour + minuteFraction;
+};
+
+/**
+ * Picks the candidate zone whose local time is closest to midday, leaving ~10h
+ * of margin to the next day boundary regardless of when CI is triggered.
+ *
+ * Independent of `process.env.TZ` — every zone is resolved explicitly — so it is
+ * safe to call before the suite's timezone has been set.
+ */
+export const pickTestTimezone = (now: Date = new Date()): string =>
+  CANDIDATE_TIMEZONES.reduce((best, zone) =>
+    Math.abs(localHourIn(zone, now) - MIDDAY_HOUR) <
+    Math.abs(localHourIn(best, now) - MIDDAY_HOUR)
+      ? zone
+      : best,
+  );


### PR DESCRIPTION
## Problem

[Run 33808991574](https://github.com/super-productivity/super-productivity/actions/runs/33808991574) failed `e2e/tests/sync/webdav-sync-today-tag.spec.ts:115`:

```
Expected: ["Task3-Reorder", "Task2-Reorder", "Task1-Reorder"]
Received: ["Task1-Reorder", "Task2-Reorder", "Task3-Reorder"]
```

The identical SHA (`df16412c8b`) passed on [run 33829283411](https://github.com/super-productivity/super-productivity/actions/runs/33829283411) four hours later, so it was never a code regression.

## Root cause

`e2e/global-setup.ts` hardcoded `TZ=Europe/Berlin`. A push at 21:38 UTC ran the WebDAV suite through 22:00 UTC — which is 00:00 in Berlin. From the Client A trace, six seconds after the sync completed:

```
611.4  SyncWrapperService: Sync complete, status=IN_SYNC     ← 21:59:58Z
613.2  DAY_CHANGE 2026-09-04                                  ← 22:00:00Z
613.2  Repairing TODAY_TAG consistency {repairedTaskIds: Array(0)}
```

`todayStr` moved on while the three tasks still carried `dueDay: 2026-09-03`, so `selectTodayTagRepair` cleared `TODAY_TAG.taskIds`. With no stored order left, `computeOrderedTaskIdsForToday` fell through to its `unorderedTasks` branch, which iterates `Object.keys(taskEntities)` — entity insertion order, the exact reverse of the expected add-order. The failure screenshot confirms it: the TODAY view shows *"No tasks planned"* with a **"From previous days (3)"** panel holding all three tasks, stamped `3/9`.

The nightly cron (`0 2 * * *` = 04:00 Berlin) never hits this. The `push:` trigger does, and `retries: 0` means one hit fails the job.

## Fix

Pick `TZ` at setup time from DST-free zones spanning UTC-10..UTC+11, choosing whichever puts local time nearest midday. Whatever hour CI is triggered, the suite runs at 10:00-14:00 local with ~10h of margin to the next day boundary.

This stays an env var rather than Playwright's `use.timezoneId`, which would move only the browser: many specs compute a date in Node and assert it against the browser's local day (`utils/time-input-helper.ts`, and the note in `tests/sync/supersync-round-time-conflict.spec.ts:35`), so both sides have to move together. That also means the 33 `browser.newContext()` call sites need no changes — none passes `timezoneId`.

`E2E_TZ` overrides for reproducing timezone-dependent bugs, and the resolved zone is logged at startup.

No UTC+0 zone is a candidate, deliberately: at UTC+0 every local-vs-UTC divergence collapses, so an off-by-one-day regression in `toISOString()` or `dateStrToUtcDate` would pass silently — `tests/recurring/skip-overdue-reaps-timed-instance.spec.ts` exists precisely because the unit suites cannot catch that drift.

## Verification

Selector logic swept at 5-minute granularity across a full day:

```
2026-09-03T21:38:00Z  ->  Pacific/Honolulu     local 11:38   ← the push that broke the run
2026-09-04T02:22:00Z  ->  Pacific/Guadalcanal  local 13:22   ← nightly cron slot

worst-case margin to next midnight: 10.08h
minutes selecting a UTC+0 zone:     0/1440
```

All 8 candidates confirmed DST-free by scanning every day of 2026-2027. Browser inheritance confirmed against real Chromium with a bare `newContext()` (no `timezoneId`): Node `TZ=Asia/Dhaka` -> browser zone `Asia/Dhaka`.

## Not verified

The suite has never run in a negative-offset zone, and three of eight candidates are (~42% of trigger times). Under Berlin the local date was always >= the UTC date; it can now be behind.

The case worth checking first is `tests/calendar/deleted-calendar-task-no-reimport.spec.ts:41-43`, which builds `DTSTART:${localDay}T120000Z` — a local day glued to a UTC clock time. It stays on the intended local day for all 8 candidates, but the event moves from 02:00 local (Honolulu) to 23:00 local (Guadalcanal); whether the Schedule view still renders it is unconfirmed.

Checking that means running with `E2E_TZ=Pacific/Honolulu` and `E2E_TZ=Pacific/Guadalcanal`, but `e2e-scheduled.yml` accepts no TZ input, so it is not dispatchable as-is. Adding an optional `tz` input would make it a one-line dispatch — deliberately left out of this PR.

## Scope

Test infrastructure only. No `src/` changes, so no sync-correctness or schema-version implications. Day rollover itself is still worth testing, but from a dedicated spec that seeds `dueDay` or moves `startOfNextDayDiff` — not by accident at 00:00 in CI.

https://claude.ai/code/session_01FzYZqg7oQ7eyUmhAa7Z8Sd