### PR TITLE
fix(schedule): clarify date-only task heading

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3210,7 +3210,7 @@
     "NO_SCHEDULED": "There are currently no scheduled tasks of this type. You can schedule a task by choosing \"Schedule Task\" in the task's context menu. To open it, right-click (long press on mobile) on a task.",
     "NO_SCHEDULED_FOR_DAY": "No tasks planned for specific days yet. Right-click a task and choose \"Schedule\" to plan it for a day.",
     "NO_SCHEDULED_WITH_TIME": "No tasks scheduled with a start time yet. Right-click a task and choose \"Schedule\" to set a specific time.",
-    "NO_SCHEDULED_TITLE": "Scheduled Tasks for Day",
+    "NO_SCHEDULED_TITLE": "Tasks Planned for Specific Days",
     "REPEATED_TASKS": "Recurring Tasks",
     "SCHEDULED_TASKS": "Scheduled Tasks",
     "SCHEDULED_TASKS_WITH_TIME": "Scheduled Tasks with Start Time",


### PR DESCRIPTION
## Summary
- rename the date-only task section from "Scheduled Tasks for Day" to "Tasks Planned for Specific Days"
- match the existing empty-state wording and distinguish the section from tasks with a specific start time
- keep the change in the English source locale so translations continue through the project's normal localization workflow

The section is backed by `selectAllUndoneTasksWithDueDay`, so it can contain any unfinished task planned for a calendar date, including overdue tasks. The new heading describes that behavior without implying a single day or a fixed upcoming window.

## Testing
- parsed `src/assets/i18n/en.json` with `JSON.parse`
- `npm run int:test` (14 tests passed; 0 unexpected placeholders and 0 broken braces)
- `git diff --check`

Closes #9870