### PR TITLE
fix(electron): bump electron to 43.5.0 to restore the Linux tray icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "cross-env": "^10.1.0",
         "detect-it": "^4.0.1",
         "dotenv": "^17.4.2",
-        "electron": "43.4.0",
+        "electron": "43.5.0",
         "electron-builder": "^26.8.1",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
@@ -14102,9 +14102,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "43.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-43.4.0.tgz",
-      "integrity": "sha512-3qxGF0CeQbiox5oWV1JlbWGQ1VerbmDhTFqW4sJ8h7uqTHniFYPObXJcDna0DMh32et0fFyKzz0YY8lJv3t5jg==",
+      "version": "43.5.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.5.0.tgz",
+      "integrity": "sha512-nV2aWuKatmUrxrAWP2pNIynNX7dy83TCAz+6KnsbK7hDVLE+6fa2iouOtir41AboZTa+J5w2UgicWHAqUaaUJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
     "cross-env": "^10.1.0",
     "detect-it": "^4.0.1",
     "dotenv": "^17.4.2",
-    "electron": "43.4.0",
+    "electron": "43.5.0",
     "electron-builder": "^26.8.1",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
Fixes the dead placeholder tray icon reported on Linux Mint / Cinnamon.

## Root cause

Electron 43.3.0 replaced the per-icon `StatusNotifierItem` objects with a multiplexer that only answered on the item's well-known bus name via the `org.kde` interface. Hosts that resolve that name to the unique D-Bus connection and then call `org.freedesktop.StatusNotifierItem` there — **Cinnamon (xapp-sn-watcher), GNOME with the AppIndicator extension, XFCE** — get a GDBus property-read error, so the panel draws a dead placeholder glyph whose menu never opens.

We shipped straight into that window: #9571 (v18.20.0) bumped Electron 41.4.0 → 43.4.0.

| Release | Electron | Tray |
| --- | --- | --- |
| v18.19.0 | 41.4.0 | works |
| v18.20.0 – v18.21.2, master | 43.4.0 | broken |

That matches the reporter's bisect in #9812 (v18.19.0L fine, v18.21.1L broken), and the same regression window was reported for Signal Desktop (signalapp/Signal-Desktop#7992, #7995) and Obsidian. Nothing in `electron/indicator.ts` is involved and there is no app-side workaround. The scope is wider than the issue title: every Linux user on Cinnamon, XFCE, or GNOME+AppIndicator has had a dead tray icon since v18.20.0.

## Fix

Upstream removed the multiplexer and restored per-icon object paths in **43.4.1** (electron/electron#52952, cherry-picking `crrev.com/c/8189930` and `crrev.com/c/8250459`; see electron/electron#52674). 43.4.1 in turn broke the icon on GNOME and made it vanish on Wayland, fixed in **43.5.0** — so 43.5.0 is the first release that is correct on every affected desktop.

Not 43.5.1/43.6.0: `.npmrc` pins `min-release-age=3` and both are newer than that cutoff. Neither carries a further tray fix.

## Verification

- `npm run test:electron` — 287/287 pass
- `node --test tools/verify-linux-wm-class.test.js` — 5/5 pass
- Prettier clean

Not verified locally: the packaged runtime. The new binary could not be installed in my environment, and this machine is KDE/X11, which the regression never affected — the fix needs a CI build checked on a Cinnamon or GNOME+AppIndicator session.

Closes #9812

https://claude.ai/code/session_01XsKoJgJjuxikWNSQ4NH8xu