### PR TITLE
fix(task-view-customizer): order date-only scheduled tasks after timed tasks

### DIFF
--- a/src/app/features/task-view-customizer/task-view-customizer.service.spec.ts
+++ b/src/app/features/task-view-customizer/task-view-customizer.service.spec.ts
@@ -35,6 +35,8 @@ import { LS } from '../../core/persistence/storage-keys.const';
 import { LanguageService } from 'src/app/core/language/language.service';
 import { TranslateService } from '@ngx-translate/core';
 import { T } from '../../t.const';
+import { getDateTimeFromClockString } from '../../util/get-date-time-from-clock-string';
+import { parseDbDateStr } from '../../util/parse-db-date-str';
 
 describe('TaskViewCustomizerService', () => {
   let service: TaskViewCustomizerService;
@@ -271,6 +273,77 @@ describe('TaskViewCustomizerService', () => {
     expect(sorted.asc[1].title).toBe('Beta');
     expect(sorted.desc[0].title).toBe('Zebra');
     expect(sorted.desc[1].title).toBe('Third Task');
+  });
+
+  it('should place date-only tasks after timed tasks on the same scheduled day', () => {
+    const scheduledAt = (day: string, time: string): number =>
+      getDateTimeFromClockString(time, parseDbDateStr(day));
+    const tasks: TaskWithSubTasks[] = [
+      { ...mockTasks[1], id: 'today-date-only', dueDay: todayStr },
+      {
+        ...mockTasks[0],
+        id: 'tomorrow-timed',
+        dueDay: undefined,
+        dueWithTime: scheduledAt(tomorrowStr, '08:00'),
+      },
+      {
+        ...mockTasks[2],
+        id: 'today-late',
+        dueDay: undefined,
+        dueWithTime: scheduledAt(todayStr, '23:00'),
+      },
+      {
+        ...mockTasks[3],
+        id: 'today-early',
+        dueDay: undefined,
+        dueWithTime: scheduledAt(todayStr, '09:00'),
+      },
+    ];
+
+    const asc = service['applySort'](
+      tasks,
+      SORT_OPTION_TYPE.scheduledDate,
+      SORT_ORDER.ASC,
+    );
+    const desc = service['applySort'](
+      tasks,
+      SORT_OPTION_TYPE.scheduledDate,
+      SORT_ORDER.DESC,
+    );
+
+    expect(asc.map((task) => task.id)).toEqual([
+      'today-early',
+      'today-late',
+      'today-date-only',
+      'tomorrow-timed',
+    ]);
+    expect(desc.map((task) => task.id)).toEqual([
+      'tomorrow-timed',
+      'today-date-only',
+      'today-late',
+      'today-early',
+    ]);
+  });
+
+  it('should keep date-only deadlines before timed deadlines on the same day', () => {
+    const tasks: TaskWithSubTasks[] = [
+      {
+        ...mockTasks[0],
+        id: 'timed-deadline',
+        deadlineWithTime: getDateTimeFromClockString('09:00', parseDbDateStr(todayStr)),
+      },
+      {
+        ...mockTasks[1],
+        id: 'date-only-deadline',
+        deadlineDay: todayStr,
+      },
+    ];
+
+    const asc = service['applySort'](tasks, SORT_OPTION_TYPE.deadline, SORT_ORDER.ASC);
+    const desc = service['applySort'](tasks, SORT_OPTION_TYPE.deadline, SORT_ORDER.DESC);
+
+    expect(asc.map((task) => task.id)).toEqual(['date-only-deadline', 'timed-deadline']);
+    expect(desc.map((task) => task.id)).toEqual(['timed-deadline', 'date-only-deadline']);
   });
 
   it('should sort numeric prefixes in title correctly', () => {

--- a/src/app/features/task-view-customizer/task-view-customizer.service.spec.ts
+++ b/src/app/features/task-view-customizer/task-view-customizer.service.spec.ts
@@ -325,7 +325,7 @@ describe('TaskViewCustomizerService', () => {
     ]);
   });
 
-  it('should keep date-only deadlines before timed deadlines on the same day', () => {
+  it('should place date-only deadlines after timed deadlines on the same day', () => {
     const tasks: TaskWithSubTasks[] = [
       {
         ...mockTasks[0],
@@ -342,8 +342,8 @@ describe('TaskViewCustomizerService', () => {
     const asc = service['applySort'](tasks, SORT_OPTION_TYPE.deadline, SORT_ORDER.ASC);
     const desc = service['applySort'](tasks, SORT_OPTION_TYPE.deadline, SORT_ORDER.DESC);
 
-    expect(asc.map((task) => task.id)).toEqual(['date-only-deadline', 'timed-deadline']);
-    expect(desc.map((task) => task.id)).toEqual(['timed-deadline', 'date-only-deadline']);
+    expect(asc.map((task) => task.id)).toEqual(['timed-deadline', 'date-only-deadline']);
+    expect(desc.map((task) => task.id)).toEqual(['date-only-deadline', 'timed-deadline']);
   });
 
   it('should sort numeric prefixes in title correctly', () => {

--- a/src/app/features/task-view-customizer/task-view-customizer.service.ts
+++ b/src/app/features/task-view-customizer/task-view-customizer.service.ts
@@ -36,6 +36,7 @@ import { LS } from '../../core/persistence/storage-keys.const';
 import { LanguageService } from 'src/app/core/language/language.service';
 import { TranslateService } from '@ngx-translate/core';
 import { T } from '../../t.const';
+import { parseDbDateStr } from '../../util/parse-db-date-str';
 
 const GROUP_OPTIONS_NO_PROJECT = OPTIONS.group.list.filter(
   (opt) => opt.type !== GROUP_OPTION_TYPE.project,
@@ -367,10 +368,12 @@ export class TaskViewCustomizerService {
         return tasksCopy.sort((a, b) => (a.created - b.created) * factor);
 
       case SORT_OPTION_TYPE.scheduledDate:
-        return this._sortByDateFields(tasksCopy, factor, (t) => [
-          t.dueDay,
-          t.dueWithTime,
-        ]);
+        return this._sortByDateFields(
+          tasksCopy,
+          factor,
+          (t) => [t.dueDay, t.dueWithTime],
+          true,
+        );
 
       case SORT_OPTION_TYPE.deadline:
         return this._sortByDateFields(tasksCopy, factor, (t) => [
@@ -641,12 +644,25 @@ export class TaskViewCustomizerService {
     getFields: (
       t: TaskWithSubTasks,
     ) => [string | undefined | null, number | undefined | null],
+    dateOnlyAtEndOfDay = false,
   ): TaskWithSubTasks[] {
+    const toDate = (
+      day: string | undefined | null,
+      withTime: number | undefined | null,
+    ): Date | null => {
+      if (day) {
+        const date = dateOnlyAtEndOfDay ? parseDbDateStr(day) : new Date(day);
+        if (dateOnlyAtEndOfDay) date.setHours(23, 59, 59, 999);
+        return date;
+      }
+      return withTime ? new Date(withTime) : null;
+    };
+
     return tasks.sort((a, b) => {
       const [dayA, withTimeA] = getFields(a);
       const [dayB, withTimeB] = getFields(b);
-      const dateA = dayA ? new Date(dayA) : withTimeA ? new Date(withTimeA) : null;
-      const dateB = dayB ? new Date(dayB) : withTimeB ? new Date(withTimeB) : null;
+      const dateA = toDate(dayA, withTimeA);
+      const dateB = toDate(dayB, withTimeB);
 
       if (dateA === null && dateB === null) return 0;
       if (dateA === null) return 1 * factor;

--- a/src/app/features/task-view-customizer/task-view-customizer.service.ts
+++ b/src/app/features/task-view-customizer/task-view-customizer.service.ts
@@ -368,12 +368,10 @@ export class TaskViewCustomizerService {
         return tasksCopy.sort((a, b) => (a.created - b.created) * factor);
 
       case SORT_OPTION_TYPE.scheduledDate:
-        return this._sortByDateFields(
-          tasksCopy,
-          factor,
-          (t) => [t.dueDay, t.dueWithTime],
-          true,
-        );
+        return this._sortByDateFields(tasksCopy, factor, (t) => [
+          t.dueDay,
+          t.dueWithTime,
+        ]);
 
       case SORT_OPTION_TYPE.deadline:
         return this._sortByDateFields(tasksCopy, factor, (t) => [
@@ -644,15 +642,15 @@ export class TaskViewCustomizerService {
     getFields: (
       t: TaskWithSubTasks,
     ) => [string | undefined | null, number | undefined | null],
-    dateOnlyAtEndOfDay = false,
   ): TaskWithSubTasks[] {
     const toDate = (
       day: string | undefined | null,
       withTime: number | undefined | null,
     ): Date | null => {
       if (day) {
-        const date = dateOnlyAtEndOfDay ? parseDbDateStr(day) : new Date(day);
-        if (dateOnlyAtEndOfDay) date.setHours(23, 59, 59, 999);
+        // A date-only value means "by the end of that day" for sorting (#9828).
+        const date = parseDbDateStr(day);
+        date.setHours(23, 59, 59, 999);
         return date;
       }
       return withTime ? new Date(withTime) : null;


### PR DESCRIPTION
## Problem

When tasks are sorted by scheduled date or deadline, a date-only value should represent the end of its local calendar day. Scheduled values were treated as midnight, while deadline days were parsed as UTC and could shift to the previous local day.

Fixes #9828 #10005.

## Solution

- Parse date-only scheduled and deadline values with `parseDbDateStr`.
- Sort them at the end of the local day, after timed values on the same day.
- Document the rule beside the conversion.
- Add timezone-independent coverage for both sort directions.

No wiki update is needed because the existing scheduling documentation does not specify custom sort ordering.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Verification

- Focused 54-test spec passed under Europe/Berlin, Asia/Tokyo, and Australia/Sydney.
- Full pre-push suite passed under Europe/Berlin and America/Los_Angeles.
- `npm run checkFile` passed for both changed files.

## Checklist

- [x] I have included relevant changes to the documentation/wiki.
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## AI Assistance

OpenAI Codex assisted with implementation and verification.