### PR TITLE
fix(ui): clip route wrapper overflow to stop enter-animation scroll nudge

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -883,7 +883,10 @@ async function testAPI() {
 If you create a useful plugin, consider:
 
 1. Posting on reddit or GitHub discussions about it
-2. Submitting a PR to add it to the community plugins list (coming soon)
+2. Submitting a PR adding it to [community-plugins.json](../src/assets/community-plugins.json)
+
+   Document installation as: download the release ZIP, then Settings → Plugins → Choose Plugin File.
+   Uploading a ZIP is the only install path — there is no "load from folder" option.
 
 Happy plugin development! 🚀
 

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -122,7 +122,10 @@
 .route-wrapper {
   flex-grow: 1;
   position: relative;
-  overflow: hidden;
+  // `clip` rather than `hidden`: `hidden` makes this a scroll container, so a route's
+  // scaled enter animation paints outside the box and the browser corrects by scrolling
+  // the wrapper — a transient nudge on route enter. See #9873, #9837.
+  overflow: clip;
   -webkit-app-region: no-drag !important;
   height: 100%;
   container-type: inline-size;


### PR DESCRIPTION
Two independent fixes from the 2026-09-04 PR review pass.

**`src/app/app.component.scss`** — `.route-wrapper` used `overflow: hidden`, which makes it a
scroll container. A route's scaled enter animation painted outside the box and the browser
corrected by scrolling the wrapper, producing a transient nudge on route enter. `clip` bounds
the paint without creating the scroll container, matching existing use in right-panel and
nav-list-tree.

Closes #9873. Supersedes the timing-based approach in #9837 (now closed), which deferred the
schedule's initial scroll past the 225ms enter animation and turned a never-painted correction
into a visible jump.

**`docs/plugin-development.md`** — the community-plugin submission steps described a
"load from folder" install path that does not exist; uploading a release ZIP via
Settings → Plugins → Choose Plugin File is the only one.

E2E: 118 passed, 1 flaky (`context-switching.spec.ts`, passes 5/5 in isolation; not A/B'd
against the parent commit).

https://claude.ai/code/session_01SSNFuW2G9kKxJvp4sVQjq8