### PR TITLE
fix(schedule): keep free-flowing tasks off the locale's weekend days

### DIFF
--- a/src/app/features/schedule/map-schedule-data/create-schedule-days.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/create-schedule-days.spec.ts
@@ -702,3 +702,107 @@ describe('createScheduleDays - Task Filtering', () => {
     });
   });
 });
+
+describe('createScheduleDays - Off days (#9418)', () => {
+  const WORK_CFG = { startTime: '09:00', endTime: '17:00' };
+  const H = 60 * 60 * 1000;
+  // Fri Jan 23 2026 … Mon Jan 26 2026 (Saturday/Sunday weekend in the test locale)
+  const fri = new Date(2026, 0, 23, 10, 0, 0);
+  const sat = new Date(2026, 0, 24, 10, 0, 0);
+  const sun = new Date(2026, 0, 25, 10, 0, 0);
+  const mon = new Date(2026, 0, 26, 10, 0, 0);
+  const friStr = getDbDateStr(fri);
+  const satStr = getDbDateStr(sat);
+  const sunStr = getDbDateStr(sun);
+  const monStr = getDbDateStr(mon);
+
+  const dayHasTask = (day: { entries: { id: string }[] }, taskId: string): boolean =>
+    day.entries.some((e) => e.id === taskId || e.id.startsWith(`${taskId}_`));
+
+  it('should hold free-flowing tasks over the weekend until the next work day', () => {
+    const task = createTestTask('flow', 'Flowing Task', { timeEstimate: H });
+    const now = sat.getTime();
+
+    const result = createScheduleDays(
+      [task],
+      [],
+      [satStr, sunStr, monStr],
+      {},
+      {},
+      WORK_CFG,
+      now,
+      now,
+    );
+
+    expect(dayHasTask(result[0], 'flow')).toBe(false);
+    expect(dayHasTask(result[1], 'flow')).toBe(false);
+    expect(dayHasTask(result[2], 'flow')).toBe(true);
+  });
+
+  it('should keep the 7-day flow when no work hours are configured', () => {
+    const task = createTestTask('flow', 'Flowing Task', { timeEstimate: H });
+    const now = sat.getTime();
+
+    const result = createScheduleDays(
+      [task],
+      [],
+      [satStr, sunStr, monStr],
+      {},
+      {},
+      undefined,
+      now,
+      now,
+    );
+
+    expect(dayHasTask(result[0], 'flow')).toBe(true);
+  });
+
+  it('should leave a task explicitly due on a weekend day where the user put it', () => {
+    const task = createTestTask('due-sat', 'Due Saturday', {
+      dueDay: satStr,
+      timeEstimate: H,
+    });
+    const now = fri.getTime();
+
+    const result = createScheduleDays(
+      [task],
+      [],
+      [friStr, satStr, sunStr, monStr],
+      {},
+      {},
+      WORK_CFG,
+      now,
+      now,
+    );
+
+    expect(dayHasTask(result[0], 'due-sat')).toBe(false);
+    expect(dayHasTask(result[1], 'due-sat')).toBe(true);
+    expect(dayHasTask(result[3], 'due-sat')).toBe(false);
+  });
+
+  it('should continue a task split at Friday work end on Monday, not Saturday', () => {
+    const task = createTestTask('long', 'Eight Hour Task', { timeEstimate: 8 * H });
+    const now = fri.getTime();
+    const friWorkEnd = new Date(2026, 0, 23, 17, 0, 0).getTime();
+    const satStart = new Date(2026, 0, 24, 0, 0, 0).getTime();
+    const blockerBlocksDayMap: BlockedBlockByDayMap = {
+      [friStr]: [{ start: friWorkEnd, end: satStart, entries: [] }],
+    };
+
+    const result = createScheduleDays(
+      [task],
+      [],
+      [friStr, satStr, sunStr, monStr],
+      {},
+      blockerBlocksDayMap,
+      WORK_CFG,
+      now,
+      now,
+    );
+
+    expect(dayHasTask(result[0], 'long')).toBe(true);
+    expect(dayHasTask(result[1], 'long')).toBe(false);
+    expect(dayHasTask(result[2], 'long')).toBe(false);
+    expect(dayHasTask(result[3], 'long')).toBe(true);
+  });
+});

--- a/src/app/features/schedule/map-schedule-data/create-schedule-days.ts
+++ b/src/app/features/schedule/map-schedule-data/create-schedule-days.ts
@@ -22,6 +22,7 @@ import { getTasksWithinAndBeyondBudget } from './get-tasks-within-and-beyond-bud
 import { dateStrToUtcDate } from '../../../util/date-str-to-utc-date';
 import { selectTaskRepeatCfgsForExactDay } from '../../task-repeat-cfg/store/task-repeat-cfg.selectors';
 import { Log } from '../../../core/log';
+import { getWeekendDays, isWeekendDay } from '../../../util/get-weekend-days';
 
 type ScheduleFlowTask = TaskWithoutReminder | TaskWithPlannedForDayIndication;
 
@@ -35,7 +36,7 @@ export const createScheduleDays = (
   now: number,
   realNow?: number, // Actual current time for determining "current week"
 ): ScheduleDay[] => {
-  let viewEntriesPushedToNextDay: SVEEntryForNextDay[];
+  let viewEntriesPushedToNextDay: SVEEntryForNextDay[] = [];
   let flowTasksLeftAfterDay: ScheduleFlowTask[] = nonScheduledTasks.map((task) => {
     if (task.timeEstimate === 0 && task.timeSpent === 0) {
       return {
@@ -84,6 +85,11 @@ export const createScheduleDays = (
   const isWorkStartTimeUsable =
     !!workStartEndCfg && isValidSplitTime(workStartEndCfg.startTime);
 
+  // Free-flowing tasks skip the locale's weekend when work hours are configured
+  // (#9418): "non-work days" only exist once a work day exists, so a user
+  // without work hours keeps the 7-day flow. Explicitly dated tasks stay put.
+  const weekendDays = getWeekendDays();
+
   const v: ScheduleDay[] = dayDates.map((dayDate, i) => {
     const nextDayStartDate = dateStrToUtcDate(dayDate);
     nextDayStartDate.setHours(24, 0, 0, 0);
@@ -95,6 +101,7 @@ export const createScheduleDays = (
     // Check if this day is within the current week (today through next 6 days)
     const isInCurrentWeek =
       dayStartTime >= todayStart && dayStartTime < currentWeekEndTime;
+    const isOffDay = !!workStartEndCfg && isWeekendDay(dayStartDate, weekendDays);
 
     let startTime = i == 0 ? now : dayStartTime;
     if (workStartEndCfg && isWorkStartTimeUsable) {
@@ -135,11 +142,21 @@ export const createScheduleDays = (
           return isTaskOnOrAfterDay(task, dayStartTime);
         });
 
+    // On an off day only day-assigned tasks are placed; the rest wait for the
+    // next work day, as do split continuations pushed in from the day before.
+    const flowTasksHeldForNextWorkDay = isOffDay
+      ? filteredFlowTasks.filter((task) => !isDayAssignedTask(task))
+      : [];
+    const flowTasksEligibleForDay = isOffDay
+      ? filteredFlowTasks.filter(isDayAssignedTask)
+      : filteredFlowTasks;
+    const pushedEntriesHeldForNextWorkDay = isOffDay ? viewEntriesPushedToNextDay : [];
+
     const plannedForDayTasks = (plannerDayMap[dayDate] || []).map((t) =>
       asPlannedForDayTask(t, dayDate),
     );
     const flowTasksForDay = uniqueTasksById([
-      ...filteredFlowTasks.flatMap((task): ScheduleFlowTask[] => {
+      ...flowTasksEligibleForDay.flatMap((task): ScheduleFlowTask[] => {
         if (isPlannedForDayTask(task)) {
           return task.plannedForDay === dayDate ? [task] : [];
         }
@@ -189,7 +206,7 @@ export const createScheduleDays = (
       repeatCfgsToProjectForDay,
       within,
       blockerBlocksForDay,
-      viewEntriesPushedToNextDay,
+      isOffDay ? [] : viewEntriesPushedToNextDay,
     );
     beyondBudgetTasks = dayAssignedBeyondBudgetTasks;
     // For the current week (days within 7 days from today), include all tasks including unscheduled ones
@@ -198,6 +215,7 @@ export const createScheduleDays = (
       (task) => isDayAssignedTask(task) && isTaskOnOrAfterDay(task, nextDayStart),
     );
     flowTasksLeftAfterDay = uniqueTasksById([
+      ...flowTasksHeldForNextWorkDay,
       ...(isInCurrentWeek
         ? [...nonSplitBeyondTasks]
         : nonSplitBeyondTasks.filter((task) => {
@@ -207,7 +225,7 @@ export const createScheduleDays = (
     ]);
 
     const viewEntriesToRenderForDay: SVE[] = [];
-    viewEntriesPushedToNextDay = [];
+    viewEntriesPushedToNextDay = pushedEntriesHeldForNextWorkDay;
     viewEntries.forEach((entry) => {
       const taskId = getEntryTaskId(entry);
       if (taskId && overBudgetTaskIds.has(taskId)) {

--- a/src/app/features/schedule/map-schedule-data/map-to-schedule-days.spec.ts
+++ b/src/app/features/schedule/map-schedule-data/map-to-schedule-days.spec.ts
@@ -599,13 +599,8 @@ describe('mapToScheduleDays()', () => {
           plannedForDay: '1970-01-03',
           sourceOccurrenceDate: '1970-01-03',
         },
-        {
-          data: jasmine.any(Object),
-          duration: h(2),
-          id: 'N1_1970-01-02_1',
-          start: dhTz(2, 11),
-          type: 'SplitTaskContinuedLast',
-        },
+        // 1970-01-03 is a Saturday: with work hours configured the last 2h of
+        // N1 are held for the next work day instead of flowing in here (#9418).
       ],
       isToday: false,
     } as any);

--- a/src/app/util/get-weekend-days.spec.ts
+++ b/src/app/util/get-weekend-days.spec.ts
@@ -1,0 +1,41 @@
+import { getWeekendDays, isWeekendDay } from './get-weekend-days';
+
+describe('getWeekendDays', () => {
+  it('should return Saturday/Sunday for en-US', () => {
+    expect(getWeekendDays('en-US')).toEqual([6, 7]);
+  });
+
+  it('should return Friday/Saturday for ar-EG when the platform exposes week info', () => {
+    const l = new Intl.Locale('ar-EG') as unknown as {
+      getWeekInfo?: () => unknown;
+      weekInfo?: unknown;
+    };
+    if (!l.getWeekInfo && !l.weekInfo) {
+      pending('Intl.Locale week info not supported in this browser');
+      return;
+    }
+    expect(getWeekendDays('ar-EG')).toEqual([5, 6]);
+  });
+
+  it('should fall back to Saturday/Sunday for an invalid locale tag', () => {
+    expect(getWeekendDays('not a locale')).toEqual([6, 7]);
+  });
+});
+
+describe('isWeekendDay', () => {
+  it('should map JS Sunday (0) to ISO 7', () => {
+    const sunday = new Date(2026, 0, 25);
+    const monday = new Date(2026, 0, 26);
+    const saturday = new Date(2026, 0, 24);
+    expect(isWeekendDay(sunday, [6, 7])).toBe(true);
+    expect(isWeekendDay(saturday, [6, 7])).toBe(true);
+    expect(isWeekendDay(monday, [6, 7])).toBe(false);
+  });
+
+  it('should respect a Friday/Saturday weekend', () => {
+    const friday = new Date(2026, 0, 23);
+    const sunday = new Date(2026, 0, 25);
+    expect(isWeekendDay(friday, [5, 6])).toBe(true);
+    expect(isWeekendDay(sunday, [5, 6])).toBe(false);
+  });
+});

--- a/src/app/util/get-weekend-days.ts
+++ b/src/app/util/get-weekend-days.ts
@@ -1,0 +1,43 @@
+// ISO weekday numbers, 1 = Monday … 7 = Sunday, as used by Intl week info.
+export type IsoWeekday = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+const DEFAULT_WEEKEND: IsoWeekday[] = [6, 7];
+// Date#getDay() is 0 = Sunday … 6 = Saturday.
+const JS_DAY_TO_ISO: readonly IsoWeekday[] = [7, 1, 2, 3, 4, 5, 6];
+
+interface WeekInfo {
+  weekend?: IsoWeekday[];
+}
+
+// Not in TS 5.9's lib yet: the method landed in Chrome 130 / Safari 17, older
+// Chromium exposed the same data as a `weekInfo` accessor, Firefox has neither.
+interface LocaleWithWeekInfo {
+  getWeekInfo?: () => WeekInfo;
+  weekInfo?: WeekInfo;
+}
+
+/**
+ * Weekend days for a locale, derived from the platform's week info so locales
+ * whose weekend is not Saturday/Sunday (e.g. ar-EG: Fri/Sat) are respected.
+ * Falls back to Saturday/Sunday where the API is unavailable or the locale is
+ * invalid.
+ */
+export const getWeekendDays = (locale: string = navigator.language): IsoWeekday[] => {
+  try {
+    const l = new Intl.Locale(locale) as unknown as LocaleWithWeekInfo;
+    const weekend = (l.getWeekInfo?.() ?? l.weekInfo)?.weekend;
+    if (weekend?.length) {
+      return weekend;
+    }
+  } catch {
+    // invalid locale tag: fall through to the default
+  }
+  return DEFAULT_WEEKEND;
+};
+
+export const isWeekendDay = (
+  date: Date,
+  weekendDays: IsoWeekday[] = getWeekendDays(),
+): boolean => {
+  return weekendDays.includes(JS_DAY_TO_ISO[date.getDay()]);
+};


### PR DESCRIPTION
## Problem

Unscheduled tasks flow into every calendar day. With work start/end set for a Mon–Fri week, whatever does not fit on Friday lands on Saturday and Sunday, and a task split at Friday's work end resumes at 00:00 on Saturday. #9418

## Solution

Per the scope you set on the issue: no new setting, no new UI. `createScheduleDays` now skips the locale's weekend days for the auto-flowed pool.

- Weekend days come from `Intl.Locale` week info (`getWeekInfo()`, or the older `weekInfo` accessor), falling back to Saturday/Sunday where the API is missing (Firefox) or the tag is invalid. New util `getWeekendDays` / `isWeekendDay` in `src/app/util/get-weekend-days.ts`.
- On a weekend day only day-assigned tasks (due day or planned day) are placed; the rest are held and prepended to the next day's pool. A split continuation pushed out of the previous day is held the same way and resumes on the next work day.
- Tasks the user explicitly put on a weekend day stay exactly where they are.

One judgement call to flag: the skip only applies when work start/end is configured. Without a work day there is no non-work day, so a user with no work hours keeps the 7-day flow they have today. Happy to drop that gate if you would rather skip weekends unconditionally.

The `mapToScheduleDays` "spanning multiple days" spec ended on 1970-01-03, which is a Saturday, with work hours set; its last 2h continuation is now held, and the expectation says so.

Tests: 4 new specs in `create-schedule-days.spec.ts` (held over the weekend, 7-day flow kept without work hours, explicit Saturday due day stays, Friday split resumes Monday) and 5 for the util. Full schedule and planner suites pass.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
