### PR TITLE
fix(tasks): emit a real op when starting a done task re-opens it #9904

### DIFF
--- a/docs/sync-and-op-log/contributor-sync-model.md
+++ b/docs/sync-and-op-log/contributor-sync-model.md
@@ -46,6 +46,15 @@ only sees genuine local user intent.
 wrong; the linter rejects `inject(Actions)` / `Actions` imports in
 `*.effects.ts`.
 
+**The reducer-side mirror: a reducer handling a _non-persistent_ action must
+not write synced entity fields.** Capture builds operations from action
+payloads, not from state diffs, so such a write never becomes an op — the local
+device drifts from every other device with no conflict to detect, and
+`getPhantomChangeRisk()` cannot see it either. Not lint-enforced. If a
+UI-pointer action (`setCurrentTask`, `setSelectedTask`, …) needs to change task
+data, dispatch a persistent action from a `LOCAL_ACTIONS` effect instead
+(`TaskInternalEffects.reopenStartedDoneTask$`, #9904).
+
 ## Boundary 2 — The selector boundary
 
 **Selector-driven mutating effects must guard the sync window. Choose whether

--- a/src/app/features/tasks/store/task-internal.effects.spec.ts
+++ b/src/app/features/tasks/store/task-internal.effects.spec.ts
@@ -625,6 +625,29 @@ describe('TaskInternalEffects', () => {
 
       actions$.next(setCurrentTask({ id: 'parent' }));
     });
+
+    it('should re-open the first subtask when a parent with only done subtasks is started', (done) => {
+      const parent = createTask('parent', {
+        subTaskIds: ['sub1', 'sub2'],
+        isDone: false,
+      });
+      const sub1 = createTask('sub1', { parentId: 'parent', isDone: true });
+      const sub2 = createTask('sub2', { parentId: 'parent', isDone: true });
+
+      // The reducer falls back to subTaskIds[0] when every subtask is done.
+      store.overrideSelector(
+        selectTaskFeatureState,
+        createTaskState([parent, sub1, sub2], 'sub1'),
+      );
+      store.refreshState();
+
+      effects.reopenStartedDoneTask$.subscribe((action) => {
+        expect(action.task).toEqual({ id: 'sub1', changes: { isDone: false } });
+        done();
+      });
+
+      actions$.next(setCurrentTask({ id: 'parent' }));
+    });
   });
 
   describe('planStartedTaskForToday$', () => {

--- a/src/app/features/tasks/store/task-internal.effects.spec.ts
+++ b/src/app/features/tasks/store/task-internal.effects.spec.ts
@@ -556,6 +556,77 @@ describe('TaskInternalEffects', () => {
     });
   });
 
+  describe('reopenStartedDoneTask$', () => {
+    it('should emit a persistent updateTask re-opening a started done task', (done) => {
+      const task = createTask('task1', { isDone: true, doneOn: 1234 });
+
+      store.overrideSelector(selectTaskFeatureState, createTaskState([task], 'task1'));
+      store.refreshState();
+
+      effects.reopenStartedDoneTask$.subscribe((action) => {
+        expect(action).toEqual(
+          TaskSharedActions.updateTask({
+            task: { id: 'task1', changes: { isDone: false } },
+          }),
+        );
+        expect(action.meta.isPersistent).toBe(true);
+        done();
+      });
+
+      actions$.next(setCurrentTask({ id: 'task1' }));
+    });
+
+    it('should emit nothing when the started task is not done', () => {
+      const task = createTask('task1', { isDone: false });
+
+      store.overrideSelector(selectTaskFeatureState, createTaskState([task], 'task1'));
+      store.refreshState();
+
+      let emitted = false;
+      effects.reopenStartedDoneTask$.subscribe(() => {
+        emitted = true;
+      });
+
+      actions$.next(setCurrentTask({ id: 'task1' }));
+
+      expect(emitted).toBe(false);
+    });
+
+    it('should emit nothing when no task ends up current', () => {
+      const task = createTask('task1', { isDone: true });
+
+      store.overrideSelector(selectTaskFeatureState, createTaskState([task], null));
+      store.refreshState();
+
+      let emitted = false;
+      effects.reopenStartedDoneTask$.subscribe(() => {
+        emitted = true;
+      });
+
+      actions$.next(setCurrentTask({ id: null }));
+
+      expect(emitted).toBe(false);
+    });
+
+    it('should re-open the subtask that actually got started, not the parent from the action', (done) => {
+      const parent = createTask('parent', { subTaskIds: ['sub1'], isDone: false });
+      const subTask = createTask('sub1', { parentId: 'parent', isDone: true });
+
+      store.overrideSelector(
+        selectTaskFeatureState,
+        createTaskState([parent, subTask], 'sub1'),
+      );
+      store.refreshState();
+
+      effects.reopenStartedDoneTask$.subscribe((action) => {
+        expect(action.task).toEqual({ id: 'sub1', changes: { isDone: false } });
+        done();
+      });
+
+      actions$.next(setCurrentTask({ id: 'parent' }));
+    });
+  });
+
   describe('planStartedTaskForToday$', () => {
     it('should plan the started task for today when it is not in today', (done) => {
       const task = createTask('task1', { isDone: false });

--- a/src/app/features/tasks/store/task-internal.effects.ts
+++ b/src/app/features/tasks/store/task-internal.effects.ts
@@ -161,6 +161,34 @@ export class TaskInternalEffects {
     ),
   );
 
+  /**
+   * Starting a done task re-opens it. The `setCurrentTask` reducer only moves
+   * the unsynced `currentTaskId` pointer (it may resolve a parent to one of its
+   * subtasks), so the completion flip has to be its own persistent op or other
+   * devices never learn about it (#9904). Reads `currentTaskId` after the
+   * reducer ran so the op targets the task that was actually started.
+   */
+  reopenStartedDoneTask$ = createEffect(() =>
+    this._actions$.pipe(
+      ofType(setCurrentTask),
+      withLatestFrom(this._store$.pipe(select(selectTaskFeatureState))),
+      mergeMap(([, state]) => {
+        const currentTaskId = state.currentTaskId;
+        const currentTask = currentTaskId
+          ? (state.entities[currentTaskId] as Task | undefined)
+          : undefined;
+        if (!currentTask || !currentTask.isDone) {
+          return EMPTY;
+        }
+        return of(
+          TaskSharedActions.updateTask({
+            task: { id: currentTask.id, changes: { isDone: false } },
+          }),
+        );
+      }),
+    ),
+  );
+
   planStartedTaskForToday$ = createEffect(() =>
     this._actions$.pipe(
       ofType(setCurrentTask),

--- a/src/app/features/tasks/store/task.reducer.spec.ts
+++ b/src/app/features/tasks/store/task.reducer.spec.ts
@@ -619,6 +619,54 @@ describe('Task Reducer', () => {
       expect(state.lastCurrentTaskId).toBe('task1');
     });
 
+    // setCurrentTask is not a persistent action, so any task-entity write here
+    // would never reach the op log and would silently diverge other devices
+    // (#9904). Re-opening a started done task is emitted as its own updateTask
+    // op by TaskInternalEffects.reopenStartedDoneTask$ instead.
+    it('should not touch isDone/doneOn when starting a done task', () => {
+      const doneTask = createTask('task2', { isDone: true, doneOn: 1234 });
+      const state = taskReducer(
+        { ...stateWithTasks, entities: { ...stateWithTasks.entities, task2: doneTask } },
+        fromActions.setCurrentTask({ id: 'task2' }),
+      );
+
+      expect(state.currentTaskId).toBe('task2');
+      expect(state.entities['task2']).toBe(doneTask);
+    });
+
+    it('should start the first undone subtask when starting a parent', () => {
+      const doneSub = createTask('subTask1', { parentId: 'task1', isDone: true });
+      const state = taskReducer(
+        {
+          ...stateWithTasks,
+          entities: { ...stateWithTasks.entities, subTask1: doneSub },
+        },
+        fromActions.setCurrentTask({ id: 'task1' }),
+      );
+
+      expect(state.currentTaskId).toBe('subTask2');
+    });
+
+    it('should start the first subtask without re-opening it when all subtasks are done', () => {
+      const doneSub1 = createTask('subTask1', { parentId: 'task1', isDone: true });
+      const doneSub2 = createTask('subTask2', { parentId: 'task1', isDone: true });
+      const state = taskReducer(
+        {
+          ...stateWithTasks,
+          entities: {
+            ...stateWithTasks.entities,
+            subTask1: doneSub1,
+            subTask2: doneSub2,
+          },
+        },
+        fromActions.setCurrentTask({ id: 'task1' }),
+      );
+
+      expect(state.currentTaskId).toBe('subTask1');
+      expect(state.entities['subTask1']).toBe(doneSub1);
+      expect(state.entities['subTask2']).toBe(doneSub2);
+    });
+
     it('should preserve lastCurrentTaskId on a no-op unsetCurrentTask', () => {
       const pausedState: TaskState = {
         ...stateWithTasks,

--- a/src/app/features/tasks/store/task.reducer.ts
+++ b/src/app/features/tasks/store/task.reducer.ts
@@ -277,7 +277,12 @@ export const taskReducer = createReducer<TaskState>(
 
   //--------------------------------
 
-  // TODO check if working
+  // Only touches the (unsynced) currentTaskId/selectedTaskId pointers. Starting
+  // a done task re-opens it, but that is a change to synced task data and must
+  // travel as its own op: `TaskInternalEffects.reopenStartedDoneTask$` emits a
+  // persistent `updateTask` for it. Writing `isDone` here on a non-persistent
+  // action was invisible to op-log capture and left other devices showing the
+  // task as done forever (#9904).
   on(setCurrentTask, (state, { id }) => {
     if (id) {
       const task = getTaskById(id, state);
@@ -290,13 +295,7 @@ export const taskReducer = createReducer<TaskState>(
         taskToStartId = undoneTasks.length ? undoneTasks[0].id : subTaskIds[0];
       }
       return {
-        ...taskAdapter.updateOne(
-          {
-            id: taskToStartId,
-            changes: { isDone: false, doneOn: undefined },
-          },
-          state,
-        ),
+        ...state,
         currentTaskId: taskToStartId,
         selectedTaskId: state.selectedTaskId && taskToStartId,
       };


### PR DESCRIPTION
Starting a done task cleared `isDone`/`doneOn` inside the `setCurrentTask`
reducer. That action is not persistent, so op-log capture never saw the
change: the local device showed the task as open while every other device
kept it done, with no conflict to detect.

The reducer now only moves the unsynced `currentTaskId` pointer. A new
action-based effect, `reopenStartedDoneTask$`, reads the task that
actually got started (a parent may resolve to one of its subtasks) and
dispatches a persistent `updateTask({ isDone: false })`, the same op
`TaskService.setUnDone` emits. `doneOn` is cleared in the meta-reducer,
so the clear replays deterministically instead of relying on an
`undefined` payload key.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011Nx6hobYoFUaTLfjZ6dhcS