### PR TITLE
fix(supersync): stop orphaned healthcheck probes from crash-restarting postgres

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,6 +27,12 @@ services:
       timeout: 5s
       retries: 20
       start_period: 10s
+    # A CMD-SHELL probe that exceeds `timeout` leaves its forked pg_isready
+    # orphaned; with postgres as PID 1 the postmaster reaps it, and an exit
+    # status of 2 is taken for a backend crash that restarts the whole
+    # cluster. docker-init adopts the orphan instead. See #9695 and the
+    # production compose in packages/super-sync-server.
+    init: true
 
   # SuperSync server for E2E testing
   # Start with: docker compose up -d supersync

--- a/packages/super-sync-server/docker-compose.yml
+++ b/packages/super-sync-server/docker-compose.yml
@@ -110,8 +110,8 @@ services:
     # per run — 1058 of them on the hosted server after 3.7 days of uptime,
     # reported by the hoster as PID pressure. docker-init (tini) reaps them and
     # still forwards SIGTERM, so graceful shutdown is unaffected.
-    # (caddy/postgres are exempt: nothing execs a forking command into them,
-    # and the postmaster reaps foreign children anyway.)
+    # (caddy is exempt: nothing execs a forking command into it. postgres is
+    # NOT — see the `init: true` on that service, #9695.)
     init: true
     security_opt:
       - no-new-privileges:true
@@ -197,6 +197,31 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+    # Without an init, `postgres` is PID 1 and adopts every orphan in the
+    # container. The healthcheck above is CMD-SHELL: ash forks `pg_isready` and
+    # exec's `psql` in place, so when a probe exceeds `timeout` and dockerd
+    # SIGKILLs the exec process, a still-running `pg_isready` is orphaned,
+    # reparented to the postmaster, and exits 2 ("no response") once its own
+    # 3s connect timeout expires. The postmaster's CleanupBackend() (same in
+    # PG15-17) treats any reaped status other than 0/1 as a backend crash
+    # BEFORE checking whether the PID is one of its backends: "server process
+    # (PID n) exited with exit code 2 … terminating any other active server
+    # processes", a full in-place crash-restart that drops every client. It
+    # needs a stall that outlives both docker's 5s and the orphan's own 3s
+    # connect window, which is the signature of all 50 crash-restarts on the
+    # hosted server (#9695). docker-init adopts the orphan instead; the
+    # postmaster only ever reaps its own children again. The psql half of the
+    # healthcheck stays: it is what closes the first-run initdb race (see the
+    # root docker-compose).
+    init: true
+    # The image's STOPSIGNAL is SIGINT (fast shutdown): wait for every backend
+    # to exit, then write the shutdown checkpoint. The image itself recommends
+    # a longer stop timeout than docker's default 10s, after which PID 1 is
+    # SIGKILLed and the next start runs crash recovery. Note a recreate stops
+    # the OLD container with the OLD container's timeout, so this value only
+    # protects stops after the first one that applies it; for that first one
+    # run `docker compose stop -t 60 postgres` before `up -d`.
+    stop_grace_period: 60s
     security_opt:
       - no-new-privileges:true
     mem_limit: ${POSTGRES_MEM_LIMIT:-1536m}

--- a/packages/super-sync-server/docs/production-capacity.md
+++ b/packages/super-sync-server/docs/production-capacity.md
@@ -1,6 +1,7 @@
 # Production Capacity and the OpenVZ Constraint
 
-**Status:** current. **Numbers last verified:** 2026-08-28. Every figure below is
+**Status:** current. **Numbers last verified:** 2026-08-28; crash-restart figures
+2026-09-03. Every figure below is
 a point-in-time measurement — re-measure before relying on any of them.
 
 ## Scope
@@ -66,16 +67,17 @@ implemented and then retired as incompatible with the OpenVZ environment. See
 [`../archive/encryption-attempts-openvz-incompatible/`](../archive/encryption-attempts-openvz-incompatible/)
 and [`encryption-at-rest.md`](encryption-at-rest.md).
 
-**2. Undiagnosable database crashes.** A Postgres backend has been exiting with
-code 2 — the `quickdie` / `SIGQUIT` path — roughly every two weeks for months
-(~45 occurrences, #9695). Note this does **not** by itself mean an external
-sender: when any one backend dies unexpectedly, the postmaster itself `SIGQUIT`s
-every sibling connection and re-runs WAL recovery (`scripts/health-alert.sh`),
-so exit code 2 is the ordinary consequence for the siblings. What the platform
-prevents is identifying the sender for the _first_ victim: `auditd` cannot run in
-an OpenVZ guest, and guest processes are ordinary host-visible PIDs. The cause is
-therefore unattributable from inside the container — that is the finding, not
-that any particular party is responsible.
+**2. Database crash-restarts (fixed in #9917, platform-amplified).**
+For months a "server process" exited with code 2 roughly every two weeks, later
+hours apart (50 occurrences, #9695). This was long read as the `quickdie` /
+`SIGQUIT` path and therefore as unattributable from inside an OpenVZ guest. It was
+neither: the dying PID was the compose healthcheck's `pg_isready`, orphaned when
+dockerd killed a timed-out probe shell, adopted by the postmaster running as PID 1,
+and exiting 2 ("no response"). The postmaster treats any reaped status other than
+0/1 as a backend crash. Fixed with `init: true` on the postgres service (see the
+comment in `docker-compose.yml`); closure is tracked on #9695. What the platform
+contributes is the trigger: the 25–52 s I/O stalls that time the probe out come
+from the 150-IOPS budget described here.
 
 **3. A permanent tax on query design.** Every mitigation in the next section
 exists only because random reads cost ~9.5 ms here. That is recurring


### PR DESCRIPTION
## Problem

Fixes #9695. The hosted SuperSync PostgreSQL has crash-restarted 50 times with `server process (PID n) exited with exit code 2` and no other message. Root cause (full analysis on the issue): the postgres service runs the postmaster as PID 1 with a `CMD-SHELL` healthcheck. When an I/O stall pushes a probe past docker's 5 s timeout, dockerd SIGKILLs only the probe's `sh`; the `pg_isready` it forked is orphaned, reparented to the postmaster, and exits 2 (`PQPING_NO_RESPONSE`) after its own 3 s connect timeout. `CleanupBackend()` in `postmaster.c` treats any reaped status other than 0/1 as a backend crash before checking whether the PID is one of its backends, so the whole cluster crash-restarts and drops every client.

Every constraint from the investigation fits: no connection line for the dying PID, exit code exactly 2 with no signal or WARNING, a process seconds old, a healthcheck round missing right before each crash, and no `Failed process was running` DETAIL on any of the 50 lines (a real backend with a pgstat entry would carry one).

## Solution

- `init: true` on the postgres service in the production compose and on the `db` service in the root compose, so orphans are adopted by docker-init and the postmaster only reaps its own children again. The healthcheck is unchanged: the `psql` half is what closes the first-run initdb race, which is why a shell-free `CMD` probe was not an option.
- `stop_grace_period: 60s` on the production postgres service, as the image recommends. Its STOPSIGNAL is SIGINT (fast shutdown); docker's default 10 s SIGKILLs PID 1 into crash recovery. Note this protects every stop *after* the first one that applies it: a recreate stops the old container with the old container's timeout, so the first recreate needs `docker compose stop -t 60 postgres` beforehand (see below).
- Corrected the comment that exempted postgres from `init:` on the grounds that "the postmaster reaps foreign children anyway", and the paragraph in `docs/production-capacity.md` that still described the crashes as an unattributable SIGQUIT.

Two adversarial review passes were run on this change; both confirmed the mechanism against the PostgreSQL 16, moby, and busybox ash sources. Their corrections (recreate semantics of the stop grace, comment overclaims, doc tense) are folded in.

## Before merging

Not reproduced in the authoring environment (no docker daemon). A 10-second check of the mechanism on any machine, with and without `--init`:

```bash
docker run -d --name pgtest -e POSTGRES_PASSWORD=x postgres:16-alpine && sleep 5
docker exec pgtest sh -c '(sleep 1; exit 2) &'
sleep 3; docker logs pgtest 2>&1 | grep -E 'exited with exit code 2|reinitializing'
docker rm -f pgtest
```

The SuperSync E2E job runs on this PR (the root compose is in its path filter) and is the real test of the root-compose `init: true`.

## After merging

Merging changes nothing on the server. At a quiet hour:

```bash
docker compose stop -t 60 postgres   # the old container still has the 10 s default
./scripts/deploy.sh                  # pulls the checkout, `up -d --wait`, recreates postgres
docker inspect supersync-postgres --format '{{.HostConfig.Init}}'   # → true
```

One connection drop and a cold page cache; clients reconnect on their own. The instrumentation from the issue (vacuum-sampling cron, `log_connections`/`log_disconnections`) can then be removed. A tracker for these manual steps follows in a separate PR.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files (none changed; prettier run on the YAML and Markdown)
- [ ] I have added tests for my changes (if applicable) — compose-only change, not unit-testable
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxFKjWbgLiKnkeMfi7f4Zj