### PR TITLE
fix(android): keep add-task bar above keyboard on old WebViews, validated on an API 34 emulator

### DIFF
--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -18,7 +18,7 @@ jobs:
   android-native-tests:
     name: Android Native Tests (JVM + Emulator)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Check out Git repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -142,6 +142,23 @@ jobs:
           # input one line per `sh -c`, so variables, `set -u` and multi-line
           # `if` do not survive between lines.
           script: ./run-android-checks.sh
+
+      # Second emulator, one API level below where SystemBars takes over: the
+      # API 34 google_apis image ships a bundled WebView below 140 that never
+      # auto-updates, which is the only way CI reaches the API 30-34 /
+      # WebView < 140 band of #9316 — the band the native IME shim exists for
+      # and that the API 35 run above cannot exercise (the shim is a no-op
+      # there by construction). Only the IME shim test runs here.
+      - name: Run IME inset shim check on API 34 (old bundled WebView)
+        if: steps.changes.outputs.android == 'true'
+        uses: ReactiveCircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          avd-name: test-api34
+          working-directory: ./android
+          script: ./run-android-ime-check.sh
 
       # cancelled(), not just failure(): a job that exceeds timeout-minutes
       # concludes as cancelled, which is exactly the run whose artifacts we

--- a/android/app/src/androidTest/java/com/superproductivity/superproductivity/ImeInsetShimInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/superproductivity/superproductivity/ImeInsetShimInstrumentedTest.kt
@@ -20,6 +20,7 @@ import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.math.abs
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
@@ -64,7 +65,7 @@ class ImeInsetShimInstrumentedTest {
         val webViewBottom: Int,
         /** `webView.layoutParams.height`: MATCH_PARENT at rest, explicit px under the shim. */
         val paramsHeight: Int,
-        /** Root window insets' IME visibility — informational on API < 30. */
+        /** Root window insets' IME visibility — diagnostic only, not asserted. */
         val imeVisible: Boolean,
     ) {
         /** Same criterion as `CapacitorMainActivity`'s `OnGlobalLayoutListener`. */
@@ -112,6 +113,21 @@ class ImeInsetShimInstrumentedTest {
                     "currentWebViewPackage=${current?.packageName}/${current?.versionName} " +
                     "expectShim=$expectShim"
             )
+            // CI pins which owner an emulator image is meant to exercise. If the
+            // image is refreshed with a WebView across the 140 boundary the gate
+            // flips branch and every assertion below would still pass — silently
+            // dropping coverage of the #9316 band. Fail loudly instead.
+            InstrumentationRegistry.getArguments().getString(EXPECT_SHIM_ARG)?.let { pinned ->
+                assertEquals(
+                    "$EXPECT_SHIM_ARG=$pinned was pinned for this emulator image but the gate " +
+                        "decided otherwise (sdk=${Build.VERSION.SDK_INT} activeMajor=$activeMajor " +
+                        "current=${current?.versionName}): the image's WebView crossed the 140 " +
+                        "boundary or the version source broke, so this run no longer covers " +
+                        "the band it was added for",
+                    pinned.toBoolean(),
+                    expectShim,
+                )
+            }
 
             val resting = awaitGeometry(activity, webView, "the keyboard to be closed before the test starts") {
                 !it.keyboardOpenPerListener
@@ -146,14 +162,15 @@ class ImeInsetShimInstrumentedTest {
                 )
             }
 
-            // Symptom, independent of owner: the WebView ends at (or above) the
-            // keyboard top, and the web layout viewport shrank with it.
+            // Symptom, independent of owner: the WebView ends AT the keyboard top —
+            // two-sided, because a WebView ending well above it is the #8508
+            // double-inset squash — and the web layout viewport shrank with it.
             val above = awaitGeometry(
                 activity,
                 webView,
-                "the WebView bottom to sit at or above the keyboard top",
+                "the WebView bottom to sit at the keyboard top (within ${TOLERANCE_PX}px)",
             ) {
-                it.keyboardOpenPerListener && it.webViewBottom <= it.rectBottom + TOLERANCE_PX
+                it.keyboardOpenPerListener && abs(it.webViewBottom - it.rectBottom) <= TOLERANCE_PX
             }
             awaitJavaScript(webView, "window.innerHeight < $innerHeightBefore")
             Log.i(TAG, "settled: $above innerHeight=${readInnerHeight(webView)}")
@@ -171,6 +188,13 @@ class ImeInsetShimInstrumentedTest {
                 above.webViewBottom,
                 later.webViewBottom,
             )
+            if (!expectShim) {
+                assertEquals(
+                    "the shim must stay off across layout passes where SystemBars owns the inset: $later",
+                    resting.paramsHeight,
+                    later.paramsHeight,
+                )
+            }
 
             hideIme(activity, webView)
             awaitGeometry(activity, webView, "the keyboard to close") { !it.keyboardOpenPerListener }
@@ -321,6 +345,8 @@ class ImeInsetShimInstrumentedTest {
 
     private companion object {
         const val TAG = "SUPKeyboardTest"
+        /** Instrumentation argument set by android/run-android-ime-check.sh. */
+        const val EXPECT_SHIM_ARG = "expectShim"
         const val DEFAULT_TIMEOUT_SECONDS = 10L
         const val SHOW_IME_FIRST_TRY_SECONDS = 5L
         const val POLL_MS = 50L
@@ -330,9 +356,10 @@ class ImeInsetShimInstrumentedTest {
 
         // The viewport meta mirrors src/index.html: SystemBars reads
         // viewport-fit=cover back from this tag at onDOMReady and only takes its
-        // WebView >= 140 passthrough branch when it is present, so the page has to
-        // carry it for the API >= 35 / WebView >= 140 run to exercise production
-        // ownership.
+        // WebView >= 140 passthrough branch when it is present. On API >= 35 it
+        // pads in both branches, so today this only matters if an image in the
+        // API < 35 / WebView >= 140 band is ever added — keep the page matching
+        // production regardless.
         val TEST_PAGE = """
             <!doctype html>
             <html>

--- a/android/app/src/androidTest/java/com/superproductivity/superproductivity/ImeInsetShimInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/superproductivity/superproductivity/ImeInsetShimInstrumentedTest.kt
@@ -13,7 +13,6 @@ import androidx.core.view.WindowInsetsControllerCompat
 import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.runner.AndroidJUnit4
-import androidx.webkit.WebViewCompat
 import com.superproductivity.superproductivity.webview.ImeWebViewHeight
 import com.superproductivity.superproductivity.webview.NativeInsetShimGate
 import com.superproductivity.superproductivity.webview.WebViewCompatibilityChecker
@@ -101,7 +100,10 @@ class ImeInsetShimInstrumentedTest {
             val compat = onMainSync { WebViewCompatibilityChecker.evaluate(activity) }
             val activeMajor = NativeInsetShimGate.activeProviderMajor(compat)
             val expectShim = NativeInsetShimGate.shouldRunShim(Build.VERSION.SDK_INT, activeMajor)
-            val current = WebViewCompat.getCurrentWebViewPackage(activity)
+            // Framework API (26+), same source SystemBars reads; androidx.webkit is
+            // not on the app's compile classpath.
+            val current =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) WebView.getCurrentWebViewPackage() else null
             Log.i(
                 TAG,
                 "sdk=${Build.VERSION.SDK_INT} activeMajor=$activeMajor " +

--- a/android/app/src/androidTest/java/com/superproductivity/superproductivity/ImeInsetShimInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/superproductivity/superproductivity/ImeInsetShimInstrumentedTest.kt
@@ -1,0 +1,354 @@
+package com.superproductivity.superproductivity
+
+import android.graphics.Rect
+import android.os.Build
+import android.os.SystemClock
+import android.util.Log
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+import android.webkit.WebView
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnit4
+import androidx.webkit.WebViewCompat
+import com.superproductivity.superproductivity.webview.ImeWebViewHeight
+import com.superproductivity.superproductivity.webview.NativeInsetShimGate
+import com.superproductivity.superproductivity.webview.WebViewCompatibilityChecker
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Opens the soft keyboard over the real Capacitor shell and checks who moved the
+ * WebView out from under it — the answer #9316 could not get from a reporter.
+ *
+ * Two inset owners exist (docs/android-edge-to-edge-keyboard.md): Capacitor's
+ * `SystemBars` on WebView >= 140 or API >= 35, and our native shim
+ * (`CapacitorMainActivity.adjustWebViewHeightForKeyboard`, gated by
+ * [NativeInsetShimGate]) on the remaining API < 35 / WebView < 140 band. The
+ * shim is a strict no-op wherever SystemBars acts, so "the bar looks fixed" on a
+ * device cannot tell a working shim from one that never ran. This test can: it
+ * computes the gate's inputs the way the activity does, then asserts the
+ * **mechanism** the gate selects (an explicit WebView height pinned to the
+ * keyboard top, or untouched layout params) and, on every API level, the
+ * **symptom** (the WebView ends at the keyboard top and the web layout viewport
+ * shrank — which is what lifts the `position: fixed` add-task bar).
+ *
+ * CI runs it twice (android/run-android-checks.sh on API 35, where SystemBars
+ * owns the inset, and android/run-android-ime-check.sh on an API 34 image whose
+ * bundled WebView is below 140, where the shim must). Emulators report a
+ * hardware keyboard, so both scripts set `show_ime_with_hard_keyboard` first —
+ * without it the IME never opens and the test fails on the first wait.
+ *
+ * Geometry and versions only are logged, never user content.
+ */
+@RunWith(AndroidJUnit4::class)
+class ImeInsetShimInstrumentedTest {
+
+    /** One reading of everything the activity's keyboard listener decides from. */
+    private data class Geometry(
+        /** `rootView.rootView.height` — the listener's `screenHeight`. */
+        val rootHeight: Int,
+        /** `getWindowVisibleDisplayFrame().bottom` — the keyboard top while it is up. */
+        val rectBottom: Int,
+        val webViewTop: Int,
+        val webViewBottom: Int,
+        /** `webView.layoutParams.height`: MATCH_PARENT at rest, explicit px under the shim. */
+        val paramsHeight: Int,
+        /** Root window insets' IME visibility — informational on API < 30. */
+        val imeVisible: Boolean,
+    ) {
+        /** Same criterion as `CapacitorMainActivity`'s `OnGlobalLayoutListener`. */
+        val keyboardOpenPerListener: Boolean
+            get() = rootHeight - rectBottom > rootHeight * 0.15
+    }
+
+    @Test
+    fun webContentEndsAboveTheKeyboardWhicheverOwnerInsetsIt() {
+        val scenario = ActivityScenario.launch(CapacitorMainActivity::class.java)
+        lateinit var activity: CapacitorMainActivity
+        lateinit var webView: WebView
+        var webRoot: File? = null
+
+        try {
+            scenario.onActivity { a ->
+                activity = a
+                webView = a.bridge.webView
+                val root = File(a.cacheDir, "ime-inset-shim-test")
+                check(root.mkdirs() || root.isDirectory)
+                File(root, "index.html").writeText(TEST_PAGE)
+                webRoot = root
+                a.bridge.setServerBasePath(root.absolutePath)
+            }
+            awaitJavaScript(
+                webView,
+                "document.readyState === 'complete' && !!document.getElementById('field')",
+            )
+
+            // Gate inputs, derived exactly as the activity derives them, so the
+            // expectation below is the gate's own decision rather than a guess
+            // about the emulator image.
+            val compat = onMainSync { WebViewCompatibilityChecker.evaluate(activity) }
+            val activeMajor = NativeInsetShimGate.activeProviderMajor(compat)
+            val expectShim = NativeInsetShimGate.shouldRunShim(Build.VERSION.SDK_INT, activeMajor)
+            val current = WebViewCompat.getCurrentWebViewPackage(activity)
+            Log.i(
+                TAG,
+                "sdk=${Build.VERSION.SDK_INT} activeMajor=$activeMajor " +
+                    "(raw=${compat.majorVersion} src=${compat.source} " +
+                    "current=${compat.providerPackageIsCurrent}) " +
+                    "currentWebViewPackage=${current?.packageName}/${current?.versionName} " +
+                    "expectShim=$expectShim"
+            )
+
+            val resting = awaitGeometry(activity, webView, "the keyboard to be closed before the test starts") {
+                !it.keyboardOpenPerListener
+            }
+            val innerHeightBefore = readInnerHeight(webView)
+            Log.i(TAG, "resting: $resting innerHeight=$innerHeightBefore")
+
+            showIme(activity, webView)
+            val open = awaitImeOpen(activity, webView)
+            Log.i(TAG, "open: $open")
+
+            // Mechanism: the owner the gate selected must be the one that acted.
+            if (expectShim) {
+                val pinned = awaitGeometry(
+                    activity,
+                    webView,
+                    "the native shim to pin the WebView height to the keyboard top",
+                ) {
+                    it.keyboardOpenPerListener &&
+                        it.paramsHeight == ImeWebViewHeight.targetHeight(it.rectBottom, it.webViewTop)
+                }
+                assertNotEquals(
+                    "the shim must write an explicit height, not leave the resting value: $pinned",
+                    resting.paramsHeight,
+                    pinned.paramsHeight,
+                )
+            } else {
+                assertEquals(
+                    "the shim must not touch the layout params where SystemBars owns the IME inset: $open",
+                    resting.paramsHeight,
+                    open.paramsHeight,
+                )
+            }
+
+            // Symptom, independent of owner: the WebView ends at (or above) the
+            // keyboard top, and the web layout viewport shrank with it.
+            val above = awaitGeometry(
+                activity,
+                webView,
+                "the WebView bottom to sit at or above the keyboard top",
+            ) {
+                it.keyboardOpenPerListener && it.webViewBottom <= it.rectBottom + TOLERANCE_PX
+            }
+            awaitJavaScript(webView, "window.innerHeight < $innerHeightBefore")
+            Log.i(TAG, "settled: $above innerHeight=${readInnerHeight(webView)}")
+
+            // No feedback loop: a later pass must read the same height.
+            SystemClock.sleep(SETTLE_MS)
+            val later = measure(activity, webView)
+            assertEquals(
+                "WebView height must be stable across layout passes: $above vs $later",
+                above.paramsHeight,
+                later.paramsHeight,
+            )
+            assertEquals(
+                "WebView bottom must be stable across layout passes: $above vs $later",
+                above.webViewBottom,
+                later.webViewBottom,
+            )
+
+            hideIme(activity, webView)
+            awaitGeometry(activity, webView, "the keyboard to close") { !it.keyboardOpenPerListener }
+            awaitGeometry(activity, webView, "the resting WebView height to be restored") {
+                it.paramsHeight == resting.paramsHeight
+            }
+            awaitJavaScript(webView, "Math.abs(window.innerHeight - $innerHeightBefore) <= 1")
+        } finally {
+            scenario.close()
+            webRoot?.deleteRecursively()
+        }
+    }
+
+    private fun showIme(activity: CapacitorMainActivity, webView: WebView) {
+        // View focus first, then the editable inside it, then the request: a
+        // programmatic focus() without a user gesture does not raise the IME by
+        // itself, and show(ime()) needs an editor attached to the focused view.
+        onMainSync { webView.requestFocus() }
+        evaluateJavaScript(webView, "document.getElementById('field').focus(); 'focused'")
+        onMainSync {
+            WindowInsetsControllerCompat(activity.window, webView)
+                .show(WindowInsetsCompat.Type.ime())
+        }
+    }
+
+    private fun hideIme(activity: CapacitorMainActivity, webView: WebView) {
+        evaluateJavaScript(webView, "document.getElementById('field').blur(); 'blurred'")
+        onMainSync {
+            WindowInsetsControllerCompat(activity.window, webView)
+                .hide(WindowInsetsCompat.Type.ime())
+        }
+    }
+
+    /**
+     * Waits for the keyboard as the activity's listener sees it. One fallback via
+     * InputMethodManager if the insets-controller request did nothing, then a hard
+     * failure carrying the last geometry — never a silent pass.
+     */
+    private fun awaitImeOpen(activity: CapacitorMainActivity, webView: WebView): Geometry {
+        val first = pollGeometry(activity, webView, SHOW_IME_FIRST_TRY_SECONDS) {
+            it.keyboardOpenPerListener
+        }
+        if (first != null) return first
+        Log.i(TAG, "IME not open after show(ime()); retrying via InputMethodManager")
+        onMainSync {
+            activity.getSystemService(InputMethodManager::class.java)
+                .showSoftInput(webView, InputMethodManager.SHOW_IMPLICIT)
+        }
+        return awaitGeometry(
+            activity,
+            webView,
+            "the IME to open (visible frame must drop by more than 15% of the root height; " +
+                "on an emulator make sure `settings put secure show_ime_with_hard_keyboard 1` ran)",
+        ) { it.keyboardOpenPerListener }
+    }
+
+    private fun measure(activity: CapacitorMainActivity, webView: WebView): Geometry =
+        onMainSync {
+            val content = activity.findViewById<View>(android.R.id.content)
+            val rect = Rect()
+            content.getWindowVisibleDisplayFrame(rect)
+            val location = IntArray(2)
+            webView.getLocationOnScreen(location)
+            Geometry(
+                rootHeight = content.rootView.height,
+                rectBottom = rect.bottom,
+                webViewTop = location[1],
+                webViewBottom = location[1] + webView.height,
+                paramsHeight = webView.layoutParams.height,
+                imeVisible = ViewCompat.getRootWindowInsets(content)
+                    ?.isVisible(WindowInsetsCompat.Type.ime()) == true,
+            )
+        }
+
+    private fun pollGeometry(
+        activity: CapacitorMainActivity,
+        webView: WebView,
+        timeoutSeconds: Long,
+        predicate: (Geometry) -> Boolean,
+    ): Geometry? {
+        val deadline = SystemClock.elapsedRealtime() + TimeUnit.SECONDS.toMillis(timeoutSeconds)
+        var last: Geometry
+        do {
+            last = measure(activity, webView)
+            if (predicate(last)) return last
+            SystemClock.sleep(POLL_MS)
+        } while (SystemClock.elapsedRealtime() < deadline)
+        lastGeometry = last
+        return null
+    }
+
+    private fun awaitGeometry(
+        activity: CapacitorMainActivity,
+        webView: WebView,
+        waitingFor: String,
+        timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS,
+        predicate: (Geometry) -> Boolean,
+    ): Geometry =
+        pollGeometry(activity, webView, timeoutSeconds, predicate)
+            ?: run {
+                fail("Timed out waiting for $waitingFor; last geometry: $lastGeometry")
+                error("unreachable")
+            }
+
+    private var lastGeometry: Geometry? = null
+
+    private fun readInnerHeight(webView: WebView): Int =
+        evaluateJavaScript(webView, "window.innerHeight").toDouble().toInt()
+
+    private fun <T> onMainSync(block: () -> T): T {
+        val result = AtomicReference<T>()
+        InstrumentationRegistry.getInstrumentation().runOnMainSync { result.set(block()) }
+        return result.get()
+    }
+
+    private fun awaitJavaScript(
+        webView: WebView,
+        predicate: String,
+        timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS,
+    ) {
+        val deadline = SystemClock.elapsedRealtime() + TimeUnit.SECONDS.toMillis(timeoutSeconds)
+        var lastResult = "not evaluated"
+        while (SystemClock.elapsedRealtime() < deadline) {
+            lastResult = evaluateJavaScript(webView, "Boolean($predicate)")
+            if (lastResult == "true") {
+                return
+            }
+            SystemClock.sleep(POLL_MS)
+        }
+        fail("Timed out waiting for JavaScript predicate `$predicate`; last result: $lastResult")
+    }
+
+    private fun evaluateJavaScript(webView: WebView, script: String): String {
+        val completed = CountDownLatch(1)
+        val result = AtomicReference<String>()
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            webView.evaluateJavascript(script) {
+                result.set(it)
+                completed.countDown()
+            }
+        }
+        assertTrue(
+            "JavaScript evaluation should complete",
+            completed.await(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+        )
+        return requireNotNull(result.get())
+    }
+
+    private companion object {
+        const val TAG = "SUPKeyboardTest"
+        const val DEFAULT_TIMEOUT_SECONDS = 10L
+        const val SHOW_IME_FIRST_TRY_SECONDS = 5L
+        const val POLL_MS = 50L
+        const val SETTLE_MS = 300L
+        // Sub-pixel rounding between the visible frame and the view bottom.
+        const val TOLERANCE_PX = 2
+
+        // The viewport meta mirrors src/index.html: SystemBars reads
+        // viewport-fit=cover back from this tag at onDOMReady and only takes its
+        // WebView >= 140 passthrough branch when it is present, so the page has to
+        // carry it for the API >= 35 / WebView >= 140 run to exercise production
+        // ownership.
+        val TEST_PAGE = """
+            <!doctype html>
+            <html>
+              <head>
+                <meta charset="utf-8" />
+                <meta
+                  name="viewport"
+                  content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content"
+                />
+              </head>
+              <body style="margin: 0">
+                <input
+                  id="field"
+                  type="text"
+                  style="position: fixed; bottom: 8px; left: 8px; right: 8px"
+                />
+              </body>
+            </html>
+        """.trimIndent()
+    }
+}

--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -593,9 +593,10 @@ class CapacitorMainActivity : BridgeActivity() {
      * That absolute target is also what makes this **resize-detecting**, the
      * hard requirement #8508 left behind: on a device where the window already
      * shrank for the IME, the WebView bottom is already at `rect.bottom`, so the
-     * computed height equals the current one and nothing moves. It cannot
-     * re-create the squashed-WebView regression the way the reverted delta-based
-     * inset did. See docs/android-edge-to-edge-keyboard.md.
+     * computed height equals the one in effect. The write still happens once
+     * (MATCH_PARENT never equals a px target) but changes nothing visible, so it
+     * cannot re-create the squashed-WebView regression the way the reverted
+     * delta-based inset did. See docs/android-edge-to-edge-keyboard.md.
      */
     private fun adjustWebViewHeightForKeyboard(rect: Rect, isKeyboardOpen: Boolean) {
         if (!shouldRunNativeInsetShim()) return
@@ -622,12 +623,6 @@ class CapacitorMainActivity : BridgeActivity() {
         if (params.height == targetHeight) return
         params.height = targetHeight
         webView.layoutParams = params
-        if (BuildConfig.DEBUG) {
-            Log.d(
-                "SUPKeyboard",
-                "webView height -> $targetHeight (kbOpen=$isKeyboardOpen rectB=${rect.bottom})"
-            )
-        }
     }
 
     /**
@@ -658,6 +653,13 @@ class CapacitorMainActivity : BridgeActivity() {
      * Shares [NativeInsetShimGate] with the keyboard shim so it never fights
      * SystemBars; on API >= 35 the injected --safe-area-inset-top wins via var()
      * precedence and the published var is ignored regardless.
+     *
+     * Known gap, pre-existing (follow-up, not #9316): SystemBars 8.4 also injects
+     * `--safe-area-inset-top: 0px` inline on its non-passthrough path at every API
+     * level, so the SCSS `var(--safe-area-inset-top, max(env(), var(--android-
+     * status-bar-overlap)))` fallback resolves to 0px and the var published here
+     * is shadowed on exactly the band this runs on. See the note under "header
+     * draws BEHIND the status bar" in docs/android-edge-to-edge-keyboard.md.
      */
     private fun pushStatusBarOverlap(rect: Rect) {
         if (!shouldRunNativeInsetShim()) return

--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -27,6 +27,7 @@ import com.superproductivity.superproductivity.service.SyncReminderScheduler
 import com.superproductivity.superproductivity.service.TrackingForegroundService
 import com.superproductivity.superproductivity.util.printWebViewVersion
 import com.superproductivity.superproductivity.webview.JavaScriptInterface
+import com.superproductivity.superproductivity.webview.NativeInsetShimGate
 import com.superproductivity.superproductivity.webview.WebHelper
 import com.superproductivity.superproductivity.webview.WebViewBlockActivity
 import com.superproductivity.superproductivity.webview.WebViewCompatibilityChecker
@@ -49,18 +50,18 @@ class CapacitorMainActivity : BridgeActivity() {
     private var isFrontendReady = false
     private var startupOverlayManager: StartupOverlayManager? = null
 
-    // SDK < 30 soft-keyboard workaround: the WebView's resting layout height
+    // Soft-keyboard workaround: the WebView's resting layout height
     // (e.g. MATCH_PARENT), captured so it can be restored when the keyboard hides.
-    // See adjustWebViewHeightForKeyboardBelowApi30.
+    // See adjustWebViewHeightForKeyboard.
     private var webViewLayoutHeightDefault: Int? = null
 
     // Reused scratch for getLocationOnScreen in the keyboard layout listener (hot
     // path) to avoid allocating an IntArray on every pass while the IME is up.
     private val webViewLocationOnScreen = IntArray(2)
 
-    // SDK < 30 status-bar overlap workaround: last value pushed to JS, to dedupe
-    // the per-layout-pass listener. -1 = nothing pushed yet.
-    // See pushStatusBarOverlapBelowApi30.
+    // Status-bar overlap workaround: last value pushed to JS, to dedupe the
+    // per-layout-pass listener. -1 = nothing pushed yet.
+    // See pushStatusBarOverlap.
     private var lastStatusBarOverlapCssPx: Int = -1
 
     private var isTimerCompleteReceiverRegistered = false
@@ -214,8 +215,8 @@ class CapacitorMainActivity : BridgeActivity() {
 
 
         // Remember the WebView's resting layout height (e.g. MATCH_PARENT) so the
-        // SDK < 30 keyboard workaround can restore it on hide. See
-        // adjustWebViewHeightForKeyboardBelowApi30.
+        // keyboard workaround can restore it on hide. See
+        // adjustWebViewHeightForKeyboard.
         webViewLayoutHeightDefault = bridge?.webView?.layoutParams?.height
 
         // Handle keyboard visibility changes
@@ -232,8 +233,8 @@ class CapacitorMainActivity : BridgeActivity() {
                 "isKeyboardShown$",
                 if (isKeyboardOpen) "true" else "false"
             )
-            adjustWebViewHeightForKeyboardBelowApi30(rect, isKeyboardOpen)
-            pushStatusBarOverlapBelowApi30(rect)
+            adjustWebViewHeightForKeyboard(rect, isKeyboardOpen)
+            pushStatusBarOverlap(rect)
         }
 
         // Register broadcast receiver for focus mode timer completion
@@ -360,8 +361,8 @@ class CapacitorMainActivity : BridgeActivity() {
         // re-enters here, but it also wipes the inline --android-status-bar-overlap
         // off the fresh document. Re-arm the dedupe so the next layout pass
         // re-publishes it; otherwise the unchanged value is skipped and the
-        // header overlaps the status bar again on the WebView < 140 / API < 30
-        // tail. See pushStatusBarOverlapBelowApi30.
+        // header overlaps the status bar again on the WebView < 140 / API < 35
+        // tail. See pushStatusBarOverlap.
         lastStatusBarOverlapCssPx = -1
         pendingShareIntent?.let {
             Log.d("SP_SHARE", "Flushing pending share intent")
@@ -506,17 +507,27 @@ class CapacitorMainActivity : BridgeActivity() {
     }
 
     /**
-     * SDK < 30 soft-keyboard fallback for the add-task bar sitting behind the
-     * keyboard (#8508 follow-up, Android 9 / API 28).
+     * Whether Capacitor's SystemBars leaves the insets unowned on this device, so
+     * our native shims below have to step in. See [NativeInsetShimGate].
+     */
+    private fun shouldRunNativeInsetShim(): Boolean =
+        NativeInsetShimGate.shouldRunShim(
+            sdkInt = android.os.Build.VERSION.SDK_INT,
+            webViewMajor = webViewCompatibility?.majorVersion,
+        )
+
+    /**
+     * Soft-keyboard fallback for the add-task bar sitting behind the keyboard
+     * (#8508 follow-up on Android 9 / API 28; #9316 on API 34 + WebView 124/126).
      *
      * Context: Android edge-to-edge inset handling is owned by Capacitor's
      * built-in SystemBars now (the `@capawesome` edge-to-edge plugin was removed).
      * SystemBars only pads the WebView for the IME on **WebView >= 140**
-     * (passthrough) or **API >= 35**; below that band it is a no-op, and under
-     * enforced edge-to-edge the window does NOT resize for the IME on API < 30,
-     * so the `position: fixed` add-task bar sits behind the keyboard. This shim
-     * covers exactly that WebView < 140 / API < 30 tail and is **gated to
-     * WebView < 140** so it never double-counts against SystemBars' own padding.
+     * (passthrough) or **API >= 35**; outside that it applies nothing, the window
+     * does NOT resize for the IME, and the `position: fixed` add-task bar sits
+     * behind the keyboard. This shim covers exactly that gap — see
+     * [NativeInsetShimGate] for why the gate is the complement of SystemBars'
+     * two ownership branches, so the two never double-count.
      *
      * We must NOT correct this via `bottomMargin` or `padding` (a margin writer
      * fights whatever owns the insets, and WebView padding does not move the web
@@ -526,19 +537,19 @@ class CapacitorMainActivity : BridgeActivity() {
      * the view shrinks the web layout viewport, so the existing CSS resolves the
      * bar above the keyboard with no web-side keyboard-height math (avoiding the
      * reverted #8295 fallback). The target (`rect.bottom − webViewTop`) is read
-     * from `getWindowVisibleDisplayFrame` (reliable on API 28) and does not
-     * depend on the WebView's own height, so it is stable across passes — no
-     * feedback loop. See docs/android-edge-to-edge-keyboard.md.
+     * from `getWindowVisibleDisplayFrame` and does not depend on the WebView's
+     * own height, so it is stable across passes — no feedback loop.
      *
-     * API >= 30 and WebView >= 140 are strict no-ops.
+     * That absolute target is also what makes this **resize-detecting**, the
+     * hard requirement #8508 left behind: on a device where the window already
+     * shrank for the IME, the WebView bottom is already at `rect.bottom`, so the
+     * computed height equals the current one and nothing moves. It cannot
+     * re-create the squashed-WebView regression the way the reverted delta-based
+     * inset did. See docs/android-edge-to-edge-keyboard.md and
+     * docs/plans/2026-06-22-android-systembars-migration-corrected.md.
      */
-    private fun adjustWebViewHeightForKeyboardBelowApi30(rect: Rect, isKeyboardOpen: Boolean) {
-        if (android.os.Build.VERSION.SDK_INT >= 30) return
-        // Skip when SystemBars already handles the IME inset (WebView >= 140
-        // passthrough pads the WebView parent itself). Unknown version (null) ->
-        // run the shim, the safe default on API < 30.
-        val wvMajor = webViewCompatibility?.majorVersion
-        if (wvMajor != null && wvMajor >= 140) return
+    private fun adjustWebViewHeightForKeyboard(rect: Rect, isKeyboardOpen: Boolean) {
+        if (!shouldRunNativeInsetShim()) return
         val webView = bridge?.webView ?: return
         val params = webView.layoutParams ?: return
         // Ignore stale/pre-layout geometry so the height is not set from a bad frame.
@@ -570,7 +581,8 @@ class CapacitorMainActivity : BridgeActivity() {
 
     /**
      * Status-bar overlap workaround for the web header drawing BEHIND the status
-     * bar on the WebView < 140 tail (#8508 / #8283 follow-up, Android 9 / API 28).
+     * bar on the WebView < 140 tail (#8508 / #8283 follow-up, Android 9 / API 28;
+     * reads 0 and self-disables where the WebView is already inset).
      *
      * Edge-to-edge insets are owned by Capacitor's built-in SystemBars now. On
      * **API >= 35** it injects the real `--safe-area-inset-*` px, and on
@@ -592,19 +604,12 @@ class CapacitorMainActivity : BridgeActivity() {
      * once it is — `max()` never double-counts. Physical px → CSS px via display
      * density; deduped so the per-layout listener does not spam evaluateJavascript.
      *
-     * Gated to **SDK < 30 AND WebView < 140** (mirrors
-     * adjustWebViewHeightForKeyboardBelowApi30) so it never fights SystemBars; on
-     * API >= 35 the injected --safe-area-inset-top wins via var() precedence and
-     * the published var is ignored regardless. (Known small gap: an API 30–34
-     * device on an old WebView < 140 also has env()==0; rare, since WebView
-     * auto-updates above API 30 — broaden the gate if it ever surfaces.)
+     * Shares [NativeInsetShimGate] with the keyboard shim so it never fights
+     * SystemBars; on API >= 35 the injected --safe-area-inset-top wins via var()
+     * precedence and the published var is ignored regardless.
      */
-    private fun pushStatusBarOverlapBelowApi30(rect: Rect) {
-        if (android.os.Build.VERSION.SDK_INT >= 30) return
-        // Skip when SystemBars/env() already give the correct top inset (WebView
-        // >= 140 passthrough). Unknown version (null) -> run it, the safe default.
-        val wvMajor = webViewCompatibility?.majorVersion
-        if (wvMajor != null && wvMajor >= 140) return
+    private fun pushStatusBarOverlap(rect: Rect) {
+        if (!shouldRunNativeInsetShim()) return
         if (!::javaScriptInterface.isInitialized) return
         val webView = bridge?.webView ?: return
         webView.getLocationOnScreen(webViewLocationOnScreen)

--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -595,8 +595,7 @@ class CapacitorMainActivity : BridgeActivity() {
      * shrank for the IME, the WebView bottom is already at `rect.bottom`, so the
      * computed height equals the current one and nothing moves. It cannot
      * re-create the squashed-WebView regression the way the reverted delta-based
-     * inset did. See docs/android-edge-to-edge-keyboard.md and
-     * docs/plans/2026-06-22-android-systembars-migration-corrected.md.
+     * inset did. See docs/android-edge-to-edge-keyboard.md.
      */
     private fun adjustWebViewHeightForKeyboard(rect: Rect, isKeyboardOpen: Boolean) {
         if (!shouldRunNativeInsetShim()) return

--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -26,6 +26,7 @@ import com.superproductivity.superproductivity.service.RemoteTrackingNotificatio
 import com.superproductivity.superproductivity.service.SyncReminderScheduler
 import com.superproductivity.superproductivity.service.TrackingForegroundService
 import com.superproductivity.superproductivity.util.printWebViewVersion
+import com.superproductivity.superproductivity.webview.ImeWebViewHeight
 import com.superproductivity.superproductivity.webview.JavaScriptInterface
 import com.superproductivity.superproductivity.webview.NativeInsetShimGate
 import com.superproductivity.superproductivity.webview.WebHelper
@@ -238,9 +239,11 @@ class CapacitorMainActivity : BridgeActivity() {
                 "isKeyboardShown$",
                 if (isKeyboardOpen) "true" else "false"
             )
-            logImeGeometryOnTransition(rect, isKeyboardOpen)
             adjustWebViewHeightForKeyboard(rect, isKeyboardOpen)
             pushStatusBarOverlap(rect)
+            // After the shim, so the log shows the height it applied. See
+            // logImeGeometryOnTransition.
+            logImeGeometryOnTransition(rect, isKeyboardOpen)
         }
 
         // Register broadcast receiver for focus mode timer completion
@@ -531,6 +534,13 @@ class CapacitorMainActivity : BridgeActivity() {
      * prints the gate's inputs next to the geometry it decides from, so a test
      * build gives an unambiguous answer.
      *
+     * Must be called **after** the shim has had its pass, so `paramsHeight` is
+     * what the shim just applied rather than the value it replaced. `target` is
+     * recomputed here from the same input, so a pass where the shim bailed on a
+     * degenerate frame still reads unambiguously (`target` set, `paramsHeight`
+     * unchanged) instead of looking like the gate was off. `webViewHeight` is
+     * still the pre-layout measurement — it catches up on the next pass.
+     *
      * Silent unless explicitly enabled (`adb shell setprop log.tag.SUPKeyboard
      * DEBUG`), so release builds stay quiet; the transition check comes first to
      * keep the per-layout-pass listener cheap. Geometry and versions only — never
@@ -549,6 +559,9 @@ class CapacitorMainActivity : BridgeActivity() {
                 "wvMajor=${NativeInsetShimGate.activeProviderMajor(webViewCompatibility)} " +
                 "(raw=${webViewCompatibility?.majorVersion} src=${webViewCompatibility?.source}) " +
                 "rectBottom=${rect.bottom} webViewTop=${webViewLocationOnScreen[1]} " +
+                "target=${
+                    ImeWebViewHeight.targetHeight(rect.bottom, webViewLocationOnScreen[1])
+                } " +
                 "webViewHeight=${webView.height} paramsHeight=${webView.layoutParams?.height}"
         )
     }
@@ -595,12 +608,14 @@ class CapacitorMainActivity : BridgeActivity() {
         val targetHeight: Int
         if (isKeyboardOpen) {
             webView.getLocationOnScreen(webViewLocationOnScreen)
-            val heightToKeyboardTop = rect.bottom - webViewLocationOnScreen[1]
-            // Guard against a degenerate/transient measurement collapsing the
-            // WebView to 0 — the height==0 check above would then latch and stop
-            // recomputing. Keep the current height until a sane value appears.
-            if (heightToKeyboardTop <= 0) return
-            targetHeight = heightToKeyboardTop
+            // Absolute target, never a delta — see ImeWebViewHeight for why that is
+            // what keeps this from re-creating #8508. null = degenerate/transient
+            // frame; keep the current height until a sane value appears, or the
+            // height==0 check above would latch and stop recomputing.
+            targetHeight = ImeWebViewHeight.targetHeight(
+                rectBottom = rect.bottom,
+                webViewTop = webViewLocationOnScreen[1],
+            ) ?: return
         } else {
             targetHeight = webViewLayoutHeightDefault ?: ViewGroup.LayoutParams.MATCH_PARENT
         }

--- a/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/CapacitorMainActivity.kt
@@ -64,6 +64,11 @@ class CapacitorMainActivity : BridgeActivity() {
     // See pushStatusBarOverlap.
     private var lastStatusBarOverlapCssPx: Int = -1
 
+    // Last IME state the geometry diagnostic logged, so the per-layout-pass
+    // listener logs once per transition instead of every pass. null = nothing yet.
+    // See logImeGeometryOnTransition.
+    private var lastLoggedKeyboardOpen: Boolean? = null
+
     private var isTimerCompleteReceiverRegistered = false
     private var isForegroundServiceFailureReceiverRegistered = false
     private var isWidgetDoneDrainReceiverRegistered = false
@@ -233,6 +238,7 @@ class CapacitorMainActivity : BridgeActivity() {
                 "isKeyboardShown$",
                 if (isKeyboardOpen) "true" else "false"
             )
+            logImeGeometryOnTransition(rect, isKeyboardOpen)
             adjustWebViewHeightForKeyboard(rect, isKeyboardOpen)
             pushStatusBarOverlap(rect)
         }
@@ -513,8 +519,39 @@ class CapacitorMainActivity : BridgeActivity() {
     private fun shouldRunNativeInsetShim(): Boolean =
         NativeInsetShimGate.shouldRunShim(
             sdkInt = android.os.Build.VERSION.SDK_INT,
-            webViewMajor = webViewCompatibility?.majorVersion,
+            webViewMajor = NativeInsetShimGate.activeProviderMajor(webViewCompatibility),
         )
+
+    /**
+     * One-line IME geometry diagnostic, logged once per keyboard transition.
+     *
+     * #9316 can only be settled on a reporter's device, and the shim is a strict
+     * no-op wherever the window already resizes for the IME — so "the bar looks
+     * fixed" cannot by itself tell a working shim from one that never ran. This
+     * prints the gate's inputs next to the geometry it decides from, so a test
+     * build gives an unambiguous answer.
+     *
+     * Silent unless explicitly enabled (`adb shell setprop log.tag.SUPKeyboard
+     * DEBUG`), so release builds stay quiet; the transition check comes first to
+     * keep the per-layout-pass listener cheap. Geometry and versions only — never
+     * user content.
+     */
+    private fun logImeGeometryOnTransition(rect: Rect, isKeyboardOpen: Boolean) {
+        if (lastLoggedKeyboardOpen == isKeyboardOpen) return
+        lastLoggedKeyboardOpen = isKeyboardOpen
+        if (!Log.isLoggable("SUPKeyboard", Log.DEBUG)) return
+        val webView = bridge?.webView ?: return
+        webView.getLocationOnScreen(webViewLocationOnScreen)
+        Log.d(
+            "SUPKeyboard",
+            "ime=$isKeyboardOpen shim=${shouldRunNativeInsetShim()} " +
+                "sdk=${android.os.Build.VERSION.SDK_INT} " +
+                "wvMajor=${NativeInsetShimGate.activeProviderMajor(webViewCompatibility)} " +
+                "(raw=${webViewCompatibility?.majorVersion} src=${webViewCompatibility?.source}) " +
+                "rectBottom=${rect.bottom} webViewTop=${webViewLocationOnScreen[1]} " +
+                "webViewHeight=${webView.height} paramsHeight=${webView.layoutParams?.height}"
+        )
+    }
 
     /**
      * Soft-keyboard fallback for the add-task bar sitting behind the keyboard

--- a/android/app/src/main/java/com/superproductivity/superproductivity/webview/ImeWebViewHeight.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/webview/ImeWebViewHeight.kt
@@ -1,0 +1,28 @@
+package com.superproductivity.superproductivity.webview
+
+/**
+ * The WebView layout height that keeps the web content above the soft keyboard,
+ * for `CapacitorMainActivity.adjustWebViewHeightForKeyboard`.
+ *
+ * Split out from the activity for one reason: this arithmetic *is* the argument
+ * that widening [NativeInsetShimGate] cannot re-create #8508, and that argument
+ * deserves a test rather than a comment. The target is **absolute** — the visible
+ * frame's bottom minus where the WebView starts — never a delta applied to the
+ * current height. So on a device whose window already shrank for the IME, the
+ * WebView bottom is already at `rectBottom` and this returns the height already
+ * in effect: the caller compares, sees no change, and writes nothing. A
+ * delta-based inset is what squashed the WebView in #8508; do not reintroduce
+ * one here.
+ */
+object ImeWebViewHeight {
+    /**
+     * @param rectBottom bottom of `getWindowVisibleDisplayFrame` — the keyboard's
+     *   top edge while the IME is up, in physical px.
+     * @param webViewTop the WebView's top on screen (`getLocationOnScreen`).
+     * @return the height to apply, or `null` for a degenerate/transient frame
+     *   that would collapse the WebView — the caller must then leave the current
+     *   height alone rather than latch a bad value.
+     */
+    fun targetHeight(rectBottom: Int, webViewTop: Int): Int? =
+        (rectBottom - webViewTop).takeIf { it > 0 }
+}

--- a/android/app/src/main/java/com/superproductivity/superproductivity/webview/ImeWebViewHeight.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/webview/ImeWebViewHeight.kt
@@ -4,15 +4,18 @@ package com.superproductivity.superproductivity.webview
  * The WebView layout height that keeps the web content above the soft keyboard,
  * for `CapacitorMainActivity.adjustWebViewHeightForKeyboard`.
  *
- * Split out from the activity for one reason: this arithmetic *is* the argument
- * that widening [NativeInsetShimGate] cannot re-create #8508, and that argument
- * deserves a test rather than a comment. The target is **absolute** — the visible
- * frame's bottom minus where the WebView starts — never a delta applied to the
- * current height. So on a device whose window already shrank for the IME, the
- * WebView bottom is already at `rectBottom` and this returns the height already
- * in effect: the caller compares, sees no change, and writes nothing. A
- * delta-based inset is what squashed the WebView in #8508; do not reintroduce
- * one here.
+ * Split out from the activity for one reason: this arithmetic is what makes a
+ * gate mistake harmless in the resize direction, i.e. why widening
+ * [NativeInsetShimGate] cannot re-create #8508, and that argument deserves a test
+ * rather than a comment. The target is **absolute** — the visible frame's bottom
+ * minus where the WebView starts — never a delta applied to the current height.
+ * So on a device whose window already shrank for the IME, the WebView bottom is
+ * already at `rectBottom` and this returns the height already in effect. The
+ * caller still writes it once (the resting value is MATCH_PARENT, which never
+ * equals a px target), but the write is a no-op in effect: same height, nothing
+ * moves, no second inset stacked on the system's own. A delta-based inset is what
+ * squashed the WebView in #8508; do not reintroduce one here. (What keeps the two
+ * owners from both acting is the gate, not this arithmetic.)
  */
 object ImeWebViewHeight {
     /**

--- a/android/app/src/main/java/com/superproductivity/superproductivity/webview/NativeInsetShimGate.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/webview/NativeInsetShimGate.kt
@@ -16,6 +16,14 @@ package com.superproductivity.superproductivity.webview
  * are nobody's job. That intersection is what this gate names, so the shims run
  * exactly where `SystemBars` is absent and are a strict no-op everywhere it acts.
  *
+ * Why nothing else catches it: the app runs the WebView under
+ * `SYSTEM_UI_FLAG_LAYOUT_STABLE or SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN` (Capacitor's
+ * StatusBar plugin, `overlaysWebView: true` in `capacitor.config.ts`), and under
+ * layout-fullscreen the manifest's `adjustResize` does **not** shrink the window
+ * for the IME. So on API < 35 the framework never resizes anything either — which
+ * is why this is a WebView-version problem, not the SDK-version problem the
+ * original gate assumed.
+ *
  * Widened from the original `SDK_INT < 30` gate for #9316: two users on **API 34
  * with WebView 124 / 126** had the add-task bar sit behind the keyboard, and one
  * of them confirmed the fix by side-loading WebView 151 with no app change. The
@@ -23,9 +31,11 @@ package com.superproductivity.superproductivity.webview
  * false on a custom ROM that ships its own `com.android.webview` and disables the
  * Play-updated Google package.
  *
- * @param webViewMajor the **active** provider's major version
- *   (`WebView.getCurrentWebViewPackage()`, the same source `SystemBars` reads), or
- *   `null` when it could not be read.
+ * **Not quite the exact complement:** branch 1 also requires `viewport-fit=cover`,
+ * which `SystemBars` only learns at `onDOMReady`. `src/index.html` sets it (keep it
+ * there — dropping it strands WebView >= 140 / API < 35 devices with no inset
+ * owner), so the only residual gap is the window before the first DOM ready, where
+ * the IME cannot be up yet.
  */
 object NativeInsetShimGate {
     /** `SystemBars` passthrough threshold — `WEBVIEW_VERSION_WITH_SAFE_AREA_FIX`. */
@@ -33,6 +43,33 @@ object NativeInsetShimGate {
 
     /** `SystemBars` pads the WebView for the IME unconditionally from Android 15. */
     const val SDK_WITH_SYSTEM_BARS_IME_PADDING = 35
+
+    /**
+     * The version to gate on: the **active** provider's major version, or `null`
+     * when we do not know what is actually rendering.
+     *
+     * `SystemBars` reads only `WebView.getCurrentWebViewPackage()` and treats a
+     * failed read as `0`, so the gate must agree with *that* or the two can
+     * disagree about who owns the insets. [WebViewCompatibilityChecker] answers a
+     * different question (may we block the app?) and therefore falls back to
+     * scanning installed packages — which on a custom ROM can report an
+     * installed-but-**disabled** provider. That is exactly the #9316 layout, where
+     * the scan finds `com.google.android.webview` 150 while the active provider is
+     * `com.android.webview` 124: feeding the gate 150 would switch the shim off on
+     * the one device it exists for, with `SystemBars` (seeing 0) off as well.
+     *
+     * So only an authoritative reading counts — `getCurrentWebViewPackage()`
+     * ([WebViewCompatibilityChecker.Result.providerPackageIsCurrent]) or the
+     * user-agent string, both of which describe the provider actually in use.
+     * Anything else degrades to `null`, which runs the shim.
+     */
+    fun activeProviderMajor(result: WebViewCompatibilityChecker.Result?): Int? =
+        result
+            ?.takeIf {
+                it.providerPackageIsCurrent ||
+                    it.source == WebViewCompatibilityChecker.VersionSource.USER_AGENT
+            }
+            ?.majorVersion
 
     fun shouldRunShim(sdkInt: Int, webViewMajor: Int?): Boolean {
         if (sdkInt >= SDK_WITH_SYSTEM_BARS_IME_PADDING) return false

--- a/android/app/src/main/java/com/superproductivity/superproductivity/webview/NativeInsetShimGate.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/webview/NativeInsetShimGate.kt
@@ -58,18 +58,17 @@ object NativeInsetShimGate {
      * `com.android.webview` 124: feeding the gate 150 would switch the shim off on
      * the one device it exists for, with `SystemBars` (seeing 0) off as well.
      *
-     * So only an authoritative reading counts — `getCurrentWebViewPackage()`
-     * ([WebViewCompatibilityChecker.Result.providerPackageIsCurrent]) or the
-     * user-agent string, both of which describe the provider actually in use.
-     * Anything else degrades to `null`, which runs the shim.
+     * So only a `getCurrentWebViewPackage()` reading counts
+     * ([WebViewCompatibilityChecker.Result.providerPackageIsCurrent]). The
+     * user-agent string also describes the active provider, but the checker only
+     * falls back to it when `getCurrentWebViewPackage()` failed — precisely the
+     * case where `SystemBars` reads 0 and is off — so trusting a UA major >= 140
+     * there would switch the shim off as well and leave the device with no inset
+     * owner: the #9316 symptom on a perfectly current WebView. Anything but the
+     * current-package reading degrades to `null`, which runs the shim.
      */
     fun activeProviderMajor(result: WebViewCompatibilityChecker.Result?): Int? =
-        result
-            ?.takeIf {
-                it.providerPackageIsCurrent ||
-                    it.source == WebViewCompatibilityChecker.VersionSource.USER_AGENT
-            }
-            ?.majorVersion
+        result?.takeIf { it.providerPackageIsCurrent }?.majorVersion
 
     fun shouldRunShim(sdkInt: Int, webViewMajor: Int?): Boolean {
         if (sdkInt >= SDK_WITH_SYSTEM_BARS_IME_PADDING) return false

--- a/android/app/src/main/java/com/superproductivity/superproductivity/webview/NativeInsetShimGate.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/webview/NativeInsetShimGate.kt
@@ -1,0 +1,45 @@
+package com.superproductivity.superproductivity.webview
+
+/**
+ * Decides whether our native inset shims in `CapacitorMainActivity` must run, or
+ * whether Capacitor's built-in `SystemBars` already owns the insets.
+ *
+ * `SystemBars` installs an `OnApplyWindowInsetsListener` on the WebView's parent
+ * (the activity content root) on **every** API level, so it — not the framework —
+ * is the inset owner. But it only ever applies IME padding / real safe-area px on
+ * two paths (`SystemBars.initWindowInsetsListener`):
+ *
+ * 1. the passthrough branch, gated `webViewMajor >= 140 && viewport-fit=cover`
+ * 2. an `SDK_INT >= 35` branch
+ *
+ * Outside those two, it applies nothing at all — the keyboard and the status bar
+ * are nobody's job. That intersection is what this gate names, so the shims run
+ * exactly where `SystemBars` is absent and are a strict no-op everywhere it acts.
+ *
+ * Widened from the original `SDK_INT < 30` gate for #9316: two users on **API 34
+ * with WebView 124 / 126** had the add-task bar sit behind the keyboard, and one
+ * of them confirmed the fix by side-loading WebView 151 with no app change. The
+ * old gate assumed API >= 30 implies a current WebView because it auto-updates —
+ * false on a custom ROM that ships its own `com.android.webview` and disables the
+ * Play-updated Google package.
+ *
+ * @param webViewMajor the **active** provider's major version
+ *   (`WebView.getCurrentWebViewPackage()`, the same source `SystemBars` reads), or
+ *   `null` when it could not be read.
+ */
+object NativeInsetShimGate {
+    /** `SystemBars` passthrough threshold — `WEBVIEW_VERSION_WITH_SAFE_AREA_FIX`. */
+    const val WEBVIEW_VERSION_WITH_INSET_SUPPORT = 140
+
+    /** `SystemBars` pads the WebView for the IME unconditionally from Android 15. */
+    const val SDK_WITH_SYSTEM_BARS_IME_PADDING = 35
+
+    fun shouldRunShim(sdkInt: Int, webViewMajor: Int?): Boolean {
+        if (sdkInt >= SDK_WITH_SYSTEM_BARS_IME_PADDING) return false
+        // Unknown version -> run the shim. SystemBars reads the same provider and
+        // treats an unreadable version as 0, so it skips its passthrough branch
+        // too; leaving both off would strand the device with no inset owner.
+        if (webViewMajor == null) return true
+        return webViewMajor < WEBVIEW_VERSION_WITH_INSET_SUPPORT
+    }
+}

--- a/android/app/src/test/java/com/superproductivity/superproductivity/webview/ImeWebViewHeightTest.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/webview/ImeWebViewHeightTest.kt
@@ -1,0 +1,53 @@
+package com.superproductivity.superproductivity.webview
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ImeWebViewHeightTest {
+
+    @Test
+    fun `computes the height already in effect where the window resized itself`() {
+        // The #8508 invariant, and the reason widening the gate is safe: on a
+        // device that already shrank for the IME the WebView bottom is at
+        // rectBottom, so the target equals the current height. The caller's
+        // `params.height == targetHeight` check then writes nothing — no second
+        // inset stacked on the system's own, which is what squashed the WebView
+        // in #8508. A delta-based target would fail this test.
+        val webViewTop = 100
+        val rectBottom = 1800
+        val currentHeight = rectBottom - webViewTop
+
+        assertEquals(
+            currentHeight,
+            ImeWebViewHeight.targetHeight(rectBottom = rectBottom, webViewTop = webViewTop)
+        )
+    }
+
+    @Test
+    fun `shrinks to the keyboard top where the window did not resize`() {
+        // #9316: window stays full height (layout-fullscreen suppresses
+        // adjustResize), the visible frame stops at the keyboard, so the WebView
+        // must be pinned to that.
+        assertEquals(1100, ImeWebViewHeight.targetHeight(rectBottom = 1200, webViewTop = 100))
+    }
+
+    @Test
+    fun `stays idempotent when applied repeatedly`() {
+        // The listener fires on every layout pass; feeding the result back must
+        // not drift, or the shim would walk the WebView shut over a few passes.
+        val first = ImeWebViewHeight.targetHeight(rectBottom = 1200, webViewTop = 100)
+        val second = ImeWebViewHeight.targetHeight(rectBottom = 1200, webViewTop = 100)
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun `refuses a degenerate frame instead of collapsing the WebView`() {
+        // Transient/pre-layout geometry. Returning 0 or a negative height would
+        // latch (the caller stops recomputing once the WebView measures 0), so
+        // the current height must be kept instead.
+        assertNull(ImeWebViewHeight.targetHeight(rectBottom = 100, webViewTop = 100))
+        assertNull(ImeWebViewHeight.targetHeight(rectBottom = 50, webViewTop = 100))
+        assertNull(ImeWebViewHeight.targetHeight(rectBottom = 0, webViewTop = 0))
+    }
+}

--- a/android/app/src/test/java/com/superproductivity/superproductivity/webview/ImeWebViewHeightTest.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/webview/ImeWebViewHeightTest.kt
@@ -10,10 +10,11 @@ class ImeWebViewHeightTest {
     fun `computes the height already in effect where the window resized itself`() {
         // The #8508 invariant, and the reason widening the gate is safe: on a
         // device that already shrank for the IME the WebView bottom is at
-        // rectBottom, so the target equals the current height. The caller's
-        // `params.height == targetHeight` check then writes nothing — no second
-        // inset stacked on the system's own, which is what squashed the WebView
-        // in #8508. A delta-based target would fail this test.
+        // rectBottom, so the target equals the current height. The caller
+        // writes that as an explicit px (replacing MATCH_PARENT), which changes
+        // nothing visible — no second inset stacked on the system's own, which
+        // is what squashed the WebView in #8508. A delta-based target would fail
+        // this test.
         val webViewTop = 100
         val rectBottom = 1800
         val currentHeight = rectBottom - webViewTop

--- a/android/app/src/test/java/com/superproductivity/superproductivity/webview/NativeInsetShimGateTest.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/webview/NativeInsetShimGateTest.kt
@@ -71,26 +71,38 @@ class NativeInsetShimGateTest {
 
     @Test
     fun `trusts versions that describe the provider actually in use`() {
-        // getCurrentWebViewPackage() and the user-agent string both describe the
-        // active provider, which is what SystemBars branches on.
-        assertEquals(
-            124,
-            NativeInsetShimGate.activeProviderMajor(
-                result(
-                    majorVersion = 124,
-                    source = WebViewCompatibilityChecker.VersionSource.PACKAGE,
-                    providerPackageIsCurrent = true,
+        // getCurrentWebViewPackage() is what SystemBars branches on, whichever
+        // source the checker ended up reporting the number from.
+        for (source in WebViewCompatibilityChecker.VersionSource.values()) {
+            assertEquals(
+                124,
+                NativeInsetShimGate.activeProviderMajor(
+                    result(
+                        majorVersion = 124,
+                        source = source,
+                        providerPackageIsCurrent = true,
+                    )
                 )
             )
+        }
+    }
+
+    @Test
+    fun `runs on a user-agent reading because it only exists when SystemBars reads 0`() {
+        // The checker falls back to the user-agent string only when
+        // getCurrentWebViewPackage() failed — which is exactly when SystemBars
+        // treats the version as 0 and applies nothing. Trusting a UA major >= 140
+        // there would switch the shim off too and leave no inset owner at all.
+        val fromUserAgent = result(
+            majorVersion = 152,
+            source = WebViewCompatibilityChecker.VersionSource.USER_AGENT,
+            providerPackageIsCurrent = false,
         )
-        assertEquals(
-            126,
-            NativeInsetShimGate.activeProviderMajor(
-                result(
-                    majorVersion = 126,
-                    source = WebViewCompatibilityChecker.VersionSource.USER_AGENT,
-                    providerPackageIsCurrent = false,
-                )
+        assertNull(NativeInsetShimGate.activeProviderMajor(fromUserAgent))
+        assertTrue(
+            NativeInsetShimGate.shouldRunShim(
+                sdkInt = 34,
+                webViewMajor = NativeInsetShimGate.activeProviderMajor(fromUserAgent),
             )
         )
     }

--- a/android/app/src/test/java/com/superproductivity/superproductivity/webview/NativeInsetShimGateTest.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/webview/NativeInsetShimGateTest.kt
@@ -1,6 +1,8 @@
 package com.superproductivity.superproductivity.webview
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -45,4 +47,75 @@ class NativeInsetShimGateTest {
         assertTrue(NativeInsetShimGate.shouldRunShim(sdkInt = 34, webViewMajor = null))
         assertTrue(NativeInsetShimGate.shouldRunShim(sdkInt = 28, webViewMajor = null))
     }
+
+    @Test
+    fun `ignores a version scanned from an installed-but-disabled provider`() {
+        // The crDroid layout in #9316: getCurrentWebViewPackage() failed, so the
+        // checker's PackageManager scan reported the *disabled* Google package
+        // (150) while the active provider is com.android.webview 124. SystemBars
+        // reads 0 there and does nothing, so trusting 150 would leave the device
+        // with no inset owner — the exact bug. Degrade to null and run the shim.
+        val scanned = result(
+            majorVersion = 150,
+            source = WebViewCompatibilityChecker.VersionSource.PACKAGE,
+            providerPackageIsCurrent = false,
+        )
+        assertNull(NativeInsetShimGate.activeProviderMajor(scanned))
+        assertTrue(
+            NativeInsetShimGate.shouldRunShim(
+                sdkInt = 34,
+                webViewMajor = NativeInsetShimGate.activeProviderMajor(scanned),
+            )
+        )
+    }
+
+    @Test
+    fun `trusts versions that describe the provider actually in use`() {
+        // getCurrentWebViewPackage() and the user-agent string both describe the
+        // active provider, which is what SystemBars branches on.
+        assertEquals(
+            124,
+            NativeInsetShimGate.activeProviderMajor(
+                result(
+                    majorVersion = 124,
+                    source = WebViewCompatibilityChecker.VersionSource.PACKAGE,
+                    providerPackageIsCurrent = true,
+                )
+            )
+        )
+        assertEquals(
+            126,
+            NativeInsetShimGate.activeProviderMajor(
+                result(
+                    majorVersion = 126,
+                    source = WebViewCompatibilityChecker.VersionSource.USER_AGENT,
+                    providerPackageIsCurrent = false,
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `runs when the compatibility check produced no result at all`() {
+        assertNull(NativeInsetShimGate.activeProviderMajor(null))
+        assertTrue(
+            NativeInsetShimGate.shouldRunShim(
+                sdkInt = 34,
+                webViewMajor = NativeInsetShimGate.activeProviderMajor(null),
+            )
+        )
+    }
+
+    private fun result(
+        majorVersion: Int?,
+        source: WebViewCompatibilityChecker.VersionSource,
+        providerPackageIsCurrent: Boolean,
+    ) = WebViewCompatibilityChecker.Result(
+        status = WebViewCompatibilityChecker.Status.OK,
+        majorVersion = majorVersion,
+        providerPackage = null,
+        providerVersionName = null,
+        source = source,
+        providerPackageIsCurrent = providerPackageIsCurrent,
+    )
 }

--- a/android/app/src/test/java/com/superproductivity/superproductivity/webview/NativeInsetShimGateTest.kt
+++ b/android/app/src/test/java/com/superproductivity/superproductivity/webview/NativeInsetShimGateTest.kt
@@ -1,0 +1,48 @@
+package com.superproductivity.superproductivity.webview
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeInsetShimGateTest {
+
+    @Test
+    fun `runs on the API 34 old-WebView gap reported in 9316`() {
+        // OnePlus 7T Pro / crDroid (Android 14) with the ROM's own
+        // com.android.webview 124, and a bigme HiBreak Pro on WebView 126.
+        // SystemBars pads for neither (< 140 and < API 35), so the add-task bar
+        // sat behind the keyboard. This is the regression this gate fixes.
+        assertTrue(NativeInsetShimGate.shouldRunShim(sdkInt = 34, webViewMajor = 124))
+        assertTrue(NativeInsetShimGate.shouldRunShim(sdkInt = 34, webViewMajor = 126))
+    }
+
+    @Test
+    fun `still runs on the API 28 case it was originally written for`() {
+        assertTrue(NativeInsetShimGate.shouldRunShim(sdkInt = 28, webViewMajor = 100))
+    }
+
+    @Test
+    fun `off once SystemBars passthrough owns the insets`() {
+        // WebView >= 140 pads the WebView parent itself; running as well would
+        // double-count and re-create the squashed WebView of #8508.
+        assertFalse(NativeInsetShimGate.shouldRunShim(sdkInt = 34, webViewMajor = 140))
+        assertFalse(NativeInsetShimGate.shouldRunShim(sdkInt = 28, webViewMajor = 151))
+    }
+
+    @Test
+    fun `off from API 35 regardless of WebView version`() {
+        // SystemBars' unconditional SDK >= 35 branch owns the IME padding there,
+        // so the shim must stay a strict no-op even on an ancient WebView.
+        assertFalse(NativeInsetShimGate.shouldRunShim(sdkInt = 35, webViewMajor = 124))
+        assertFalse(NativeInsetShimGate.shouldRunShim(sdkInt = 36, webViewMajor = null))
+    }
+
+    @Test
+    fun `runs when the WebView version cannot be read below API 35`() {
+        // SystemBars reads the same provider and treats an unreadable version as
+        // 0, so it skips its passthrough branch too. Both off would strand the
+        // device with no inset owner at all.
+        assertTrue(NativeInsetShimGate.shouldRunShim(sdkInt = 34, webViewMajor = null))
+        assertTrue(NativeInsetShimGate.shouldRunShim(sdkInt = 28, webViewMajor = null))
+    }
+}

--- a/android/run-android-checks.sh
+++ b/android/run-android-checks.sh
@@ -32,6 +32,9 @@ capture_diagnostics() {
   adb pull /data/anr "$DIAG/anr" > /dev/null 2>&1 || true
 }
 
+# The emulator reports a hardware keyboard, which keeps the soft keyboard
+# hidden; ImeInsetShimInstrumentedTest needs it to open. See that test.
+adb shell settings put secure show_ime_with_hard_keyboard 1 || true
 adb logcat -c || true
 
 # Bounded so a hung instrumentation fails with a report instead of consuming the
@@ -114,6 +117,10 @@ case "$smoke_status" in
     # state and the bridge version the minified build returned.
     echo "Minified launch smoke passed."
     adb logcat -d | grep -F 'SP_SMOKE OK' | tail -1
+    # Nothing else runs on this emulator, and the action only kills it in a post
+    # step: free the CPU for the API 34 session that run-android-ime-check.sh
+    # boots next, and leave that script's newest-serial pick unambiguous.
+    adb emu kill > /dev/null 2>&1 || true
     ;;
   fail)
     echo "::error::minified build reached the bridge but the smoke page reported a failure"

--- a/android/run-android-checks.sh
+++ b/android/run-android-checks.sh
@@ -117,10 +117,6 @@ case "$smoke_status" in
     # state and the bridge version the minified build returned.
     echo "Minified launch smoke passed."
     adb logcat -d | grep -F 'SP_SMOKE OK' | tail -1
-    # Nothing else runs on this emulator, and the action only kills it in a post
-    # step: free the CPU for the API 34 session that run-android-ime-check.sh
-    # boots next, and leave that script's newest-serial pick unambiguous.
-    adb emu kill > /dev/null 2>&1 || true
     ;;
   fail)
     echo "::error::minified build reached the bridge but the smoke page reported a failure"

--- a/android/run-android-ime-check.sh
+++ b/android/run-android-ime-check.sh
@@ -17,16 +17,18 @@ set -uo pipefail
 DIAG=build/instrumentation-diagnostics/api34-ime
 mkdir -p "$DIAG"
 
-# android-emulator-runner only kills its emulator in a post step, so if the
-# API 35 session above is still alive there are two devices attached and bare
-# adb (and Gradle's connected task) would refuse or fan out. Pin to the newest
-# emulator: ports are handed out ascending, so the highest serial is this one.
-ANDROID_SERIAL="$(adb devices | awk '/^emulator-/ { print $1 }' | sort | tail -n 1)"
-if [ -z "$ANDROID_SERIAL" ]; then
-  echo "::error::no emulator attached"
-  exit 1
+# android-emulator-runner exports ANDROID_SERIAL for the emulator it booted and
+# kills that emulator when its script ends, so the API 35 session is gone by the
+# time this runs and exactly one device is attached. Honour the export; only if
+# it is missing (running this by hand) fall back to the single attached device.
+if [ -z "${ANDROID_SERIAL:-}" ]; then
+  ANDROID_SERIAL="$(adb devices | awk '/^emulator-.*[[:space:]]device$/ { print $1 }')"
+  if [ "$(printf '%s\n' "$ANDROID_SERIAL" | grep -c .)" -ne 1 ]; then
+    echo "::error::expected exactly one emulator attached, got: ${ANDROID_SERIAL:-none}"
+    exit 1
+  fi
+  export ANDROID_SERIAL
 fi
-export ANDROID_SERIAL
 echo "Using $ANDROID_SERIAL"
 
 # The emulator reports a hardware keyboard; without this the system keeps the
@@ -38,8 +40,12 @@ adb shell settings put secure show_ime_with_hard_keyboard 1
 adb shell dumpsys webviewupdate | grep -i 'Current WebView package' || true
 adb logcat -c || true
 
+# expectShim=true pins the band: if this image is ever refreshed with a WebView
+# >= 140 the gate flips to the SystemBars branch and the test would stay green
+# while the #9316 band silently lost its only coverage. With the pin it fails.
 timeout 480 ./gradlew :app:connectedPlayDebugAndroidTest \
-  -Pandroid.testInstrumentationRunnerArguments.class=com.superproductivity.superproductivity.ImeInsetShimInstrumentedTest
+  -Pandroid.testInstrumentationRunnerArguments.class=com.superproductivity.superproductivity.ImeInsetShimInstrumentedTest \
+  -Pandroid.testInstrumentationRunnerArguments.expectShim=true
 status=$?
 if [ "$status" -eq 124 ]; then
   echo "::error::ImeInsetShimInstrumentedTest exceeded 8 minutes on API 34 — see the android-instrumentation-diagnostics artifact"

--- a/android/run-android-ime-check.sh
+++ b/android/run-android-ime-check.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# The IME inset shim check on a second emulator, one API level below where
+# Capacitor's SystemBars takes over. run-android-checks.sh boots API 35, where
+# NativeInsetShimGate is a strict no-op by construction, so that run can only
+# prove the shim stayed out of SystemBars' way. This one boots an API 34
+# google_apis image, whose bundled WebView never auto-updates and sits below 140:
+# the API 30-34 / WebView < 140 band #9316 was reported in, which no device on
+# hand covers. ImeInsetShimInstrumentedTest asserts the mechanism there (explicit
+# WebView height == keyboard top) as well as the symptom (web content ends above
+# the keyboard). Only that test runs here; the full suite already ran on API 35.
+# See docs/android-edge-to-edge-keyboard.md.
+#
+# A file, not an inline `script:` block — see run-android-checks.sh for why.
+set -uo pipefail
+
+DIAG=build/instrumentation-diagnostics/api34-ime
+mkdir -p "$DIAG"
+
+# android-emulator-runner only kills its emulator in a post step, so if the
+# API 35 session above is still alive there are two devices attached and bare
+# adb (and Gradle's connected task) would refuse or fan out. Pin to the newest
+# emulator: ports are handed out ascending, so the highest serial is this one.
+ANDROID_SERIAL="$(adb devices | awk '/^emulator-/ { print $1 }' | sort | tail -n 1)"
+if [ -z "$ANDROID_SERIAL" ]; then
+  echo "::error::no emulator attached"
+  exit 1
+fi
+export ANDROID_SERIAL
+echo "Using $ANDROID_SERIAL"
+
+# The emulator reports a hardware keyboard; without this the system keeps the
+# soft keyboard hidden, the IME never opens and the test cannot tell a working
+# shim from one that never ran.
+adb shell settings put secure show_ime_with_hard_keyboard 1
+# Which band this image is actually in — the test branches on it and logs the
+# same, but the dumpsys line is the reading to compare a reporter's device to.
+adb shell dumpsys webviewupdate | grep -i 'Current WebView package' || true
+adb logcat -c || true
+
+timeout 480 ./gradlew :app:connectedPlayDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=com.superproductivity.superproductivity.ImeInsetShimInstrumentedTest
+status=$?
+if [ "$status" -eq 124 ]; then
+  echo "::error::ImeInsetShimInstrumentedTest exceeded 8 minutes on API 34 — see the android-instrumentation-diagnostics artifact"
+fi
+if [ "$status" -ne 0 ]; then
+  adb logcat -d > "$DIAG/logcat.txt" 2>&1 || true
+  adb shell dumpsys webviewupdate > "$DIAG/webviewupdate.txt" 2>&1 || true
+  exit $status
+fi
+
+# On green, echo what the test measured so the job log documents which owner
+# insetted the WebView and by how much — geometry and versions only.
+echo "IME inset shim check passed on API 34:"
+adb logcat -d -s SUPKeyboardTest | tail -n 8 || true

--- a/docs/android-edge-to-edge-keyboard.md
+++ b/docs/android-edge-to-edge-keyboard.md
@@ -159,8 +159,9 @@ reverted #8295 formula in "What NOT to do" below**. On a device that _does_
 resize, that double-counts and floats the bar mid-screen. The web layer lacks
 the signal to disambiguate; native has it unambiguously.
 
-**Implemented fix (native, explicit WebView height while the IME is up, scoped to
-API < 30) — `CapacitorMainActivity.adjustWebViewHeightForKeyboard`.**
+**Implemented fix (native, explicit WebView height while the IME is up; originally
+scoped to API < 30, now gated by `NativeInsetShimGate` — see #9316 below) —
+`CapacitorMainActivity.adjustWebViewHeightForKeyboard`.**
 Driven from the existing keyboard `OnGlobalLayoutListener`:
 
 - while the keyboard is up: set an explicit WebView **layout height** to the
@@ -171,8 +172,10 @@ Driven from the existing keyboard `OnGlobalLayoutListener`:
 - while the keyboard is down: restore the resting height
   (`webViewLayoutHeightDefault`, captured at startup, e.g. `MATCH_PARENT`), so the
   plugin's normal margin-based layout applies unchanged.
-- gated `Build.VERSION.SDK_INT < 30`, so on API >= 30 it is a strict no-op and the
-  behavior verified in 18.12.0 is **untouched**.
+- ~~gated `Build.VERSION.SDK_INT < 30`, so on API >= 30 it is a strict no-op and
+  the behavior verified in 18.12.0 is **untouched**.~~ Gate since broadened to
+  `SDK < 35 && WebView < 140` (`NativeInsetShimGate`, #9316 below); outside that
+  band it still returns before writing anything.
 
 > **Why height, not `bottomMargin` and not the plugin's listener.** The plugin owns
 > `webView.bottomMargin` and rewrites it to 0 on every inset dispatch while the IME
@@ -248,7 +251,8 @@ This is **not** the reverted-#8295 trap above: it reads the pure VisualViewport
 `--keyboard-height`, never augments it with native data. Coverage across the
 device classes this doc tracks:
 
-- **API < 30** — the SDK 28 native fix shrinks the WebView layout height, so
+- **API < 35 + WebView < 140** (originally API < 30 for the SDK 28 report;
+  broadened for #9316) — the native shim shrinks the WebView layout height, so
   `100%` is already above the keyboard and `--keyboard-height == 0`; the rule is
   `100% - 0`. Works.
 - **API >= 30, window resizes** (verified 18.12.0) — `--keyboard-height == 0`,
@@ -296,8 +300,9 @@ the existing keyboard `OnGlobalLayoutListener`, measure the overlap
 (= status-bar height, reliable on API 28; the same frame the keyboard path reads)
 and `getLocationOnScreen` is the WebView's top (0 edge-to-edge, == status-bar
 height once inset). Publish it (physical px → CSS px, deduped) as the
-`--android-status-bar-overlap` CSS var, gated **SDK < 30 AND WebView < 140**
-(mirrors the keyboard shim, never fights SystemBars). The var is folded into the
+`--android-status-bar-overlap` CSS var, gated by `NativeInsetShimGate`
+(**SDK < 35 AND WebView < 140** since #9316; originally SDK < 30 — mirrors the
+keyboard shim, never fights SystemBars). The var is folded into the
 SCSS fallback (`_css-variables.scss`) — NOT written from JS, so it never races
 SystemBars on `--safe-area-inset-*`:
 
@@ -320,6 +325,19 @@ SystemBars on `--safe-area-inset-*`:
   env()==0 but is excluded by the SDK < 30 gate; rare (WebView auto-updates above
   API 30) — broaden the gate to WebView-only if it ever surfaces.~~ **It surfaced
   (#9316); the gate was broadened — see the section below.**
+- **Known gap, pre-existing — follow-up, not part of #9316:** SystemBars 8.4 also
+  injects `--safe-area-inset-top: 0px` _inline_ on its non-passthrough path at
+  **every** API level (`SystemBars.initWindowInsetsListener`: zeroed `newInsets` →
+  `injectSafeAreaCSS`, re-fired on `onPageCommitVisible`, `onDOMReady` and each
+  IME toggle). `var(--safe-area-inset-top, …)` therefore resolves to `0px` and the
+  `max(env(), var(--android-status-bar-overlap))` fallback is never consulted — the
+  overlap var published by `pushStatusBarOverlap` is shadowed on exactly the band
+  the shim runs on, so the header fix above is most likely inert there. Not yet
+  device-verified. To settle it: log
+  `getComputedStyle(document.documentElement).getPropertyValue('--safe-area-top')`
+  on the API 34 emulator; if `0px`, move the overlap out of the fallback, e.g.
+  `max(var(--safe-area-inset-top, env(safe-area-inset-top, 0px)), var(--android-status-bar-overlap, 0px))`
+  (safe: the var is only ever written where the gate is on).
 - The var lives only as an inline style on the document, so a web-side reload
   (`window.location.reload()` — language change, PWA update, sync-conflict
   recovery) wipes it. The native dedupe (`lastStatusBarOverlapCssPx`) is reset in
@@ -348,20 +366,21 @@ the `position: fixed` bar stays at the bottom of a viewport that extends behind
 the IME. The reporters' before/after screenshots are pixel-identical, which is
 exactly this signature.
 
-**Why `adjustResize` does not save us — INFERRED, not yet observed.** This is
-read off the sources below, not measured on a device in the affected band; treat
-it as the working explanation and confirm it before building on it (an API 30–34
-emulator settles it — the window configuration does not depend on the WebView
-version, so any device in the band answers the question). The manifest declares
+**Why `adjustResize` does not save us — read off the sources, then confirmed on
+the API 34 emulator (measured 2026-09; see Validation below: the root stayed 640 px
+while the visible frame dropped to 405).** The manifest declares
 `windowSoftInputMode="adjustResize"`, so the obvious question is why the window
 does not simply shrink. Because Capacitor's StatusBar plugin runs with
 `overlaysWebView: true` (`capacitor.config.ts`), which applies
 `SYSTEM_UI_FLAG_LAYOUT_STABLE or SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN` to the decor
-view (`StatusBar.setOverlaysWebView`) — and under layout-fullscreen `adjustResize`
-stops resizing for the IME. That is the long-standing Android behaviour the
-`getWindowVisibleDisplayFrame` + explicit-height workaround exists for, and it is
-SDK-independent below 35, which is why the symptom never depended on the API
-level the original gate keyed off.
+view (`StatusBar.setOverlaysWebView`). The operative flag is `LAYOUT_STABLE`: with
+it set the decor view skips the fits-system-windows padding that `adjustResize`
+relies on, so the window keeps its full height while the IME is up. That is the
+long-standing Android behaviour the `getWindowVisibleDisplayFrame` +
+explicit-height workaround exists for, and it is SDK-independent below 35, which
+is why the symptom never depended on the API level the original gate keyed off.
+Real-device confirmation in the band is still outstanding (the window configuration
+does not depend on the WebView version, so any device in the band answers it).
 
 **Why the old gate's assumption failed.** `SDK_INT < 30` encoded "API >= 30
 implies a current WebView, because it auto-updates." Not on a custom ROM:
@@ -402,8 +421,12 @@ be _resize-detecting_. This shim already is, structurally: it sets the WebView's
 layout height to an **absolute** target read from the visible frame
 (`rect.bottom − webViewTop`), not a delta. On a device where the window already
 shrank for the IME, the WebView bottom is already at `rect.bottom`, so the
-computed height equals the current one and nothing moves. That property is what
-makes broadening the gate safe; do not replace it with a delta-based inset.
+computed height equals the one in effect. The shim still writes it once — the
+resting value is `MATCH_PARENT`, which never equals a px target — but the write is
+a no-op in effect: same height, nothing moves, no second inset stacks on the
+system's own. That property is what makes a gate mistake harmless in the resize
+direction; what keeps the two owners from both acting is the gate itself. Do not
+replace the absolute target with a delta-based inset.
 
 **Validation — `ImeInsetShimInstrumentedTest` (CI, both inset owners).** No
 device on hand sits in the widened band, and the reporter who offered to test had
@@ -424,28 +447,33 @@ The test derives the gate's inputs the way the activity does
 and asserts the **mechanism** the gate selects — an explicit WebView height equal
 to `ImeWebViewHeight.targetHeight(rect.bottom, webViewTop)` under the shim,
 untouched layout params where SystemBars owns the inset — plus, on every API
-level, the **symptom**: WebView bottom at or above the keyboard top,
-`window.innerHeight` shrank (what lifts the `position: fixed` bar), the height
-stable across a later layout pass (no feedback loop), and the resting height
-restored on hide. Emulators report a hardware keyboard, so both scripts run
+level, the **symptom**: WebView bottom _at_ the keyboard top (within 2 px, both
+directions — a WebView ending well above it is the #8508 double-inset squash and
+fails too), `window.innerHeight` shrank (what lifts the `position: fixed` bar),
+the height stable across a later layout pass (no feedback loop, and the shim still
+off where SystemBars owns the inset), and the resting height restored on hide. The
+API 34 step also passes `expectShim=true` as an instrumentation argument, so the
+test fails rather than silently switching branch if that image is ever refreshed
+with a WebView ≥ 140. Emulators report a hardware keyboard, so both scripts run
 `settings put secure show_ime_with_hard_keyboard 1` first; without it the IME
 never opens and the test fails on its first wait rather than passing vacuously.
 
-Still open: the API 34 row also settles the "adjustResize does not resize" inference
-above — the window kept its full 640 px until the shim pinned it (had the framework
-resized, `paramsHeight` would have been a no-op write of the height already in
-effect). Not yet observed on a real device in the band; the reporters' A/B with
-WebView 151/153 remains the field evidence.
+The API 34 row is also what settled the "`adjustResize` does not resize" question
+above: the window kept its full 640 px until the shim pinned it (had the framework
+resized, `paramsHeight` would still read `target`, but `webViewHeight` would
+already have equalled it before the shim's pass). Real-device confirmation in the
+band is still outstanding; the reporters' A/B with WebView 151/153 remains the
+field evidence.
 
 **On a reporter's device, validate the mechanism, not just the symptom.** The
-shim is a strict no-op wherever the window already resizes, so "the bar looks
-fixed" cannot distinguish a working shim from one that never ran — and a
+shim's write changes nothing visible wherever the window already resizes, so "the
+bar looks fixed" cannot distinguish a working shim from one that never ran — and a
 coincidental fix would send the next regression hunt down the wrong path.
 `logImeGeometryOnTransition` prints the gate inputs and geometry once per keyboard
 transition; it is off unless enabled, so ask the reporter for:
 
 ```
-adb shell setprop log.tag.SUPKeyboard DEBUG   # then restart the app
+adb shell setprop log.tag.SUPKeyboard DEBUG   # no restart needed: read live
 adb logcat -s SUPKeyboard
 adb shell dumpsys webviewupdate | grep -i 'Current WebView package'
 ```
@@ -456,11 +484,14 @@ The line is printed **after** the shim's pass, so on a fixed device the
 
 - `shim=false` → the gate is off: compare `wvMajor=` against the `dumpsys`
   provider. The version source is wrong, not the theory.
-- `target` set but `paramsHeight` unchanged → the shim ran and bailed on a
-  degenerate frame, or the height was already correct (the device resized itself,
-  in which case the shim is a legitimate no-op — see `ImeWebViewHeight`).
+- `target` set but `paramsHeight` unchanged (still `-1`) → the shim bailed on a
+  degenerate frame on that pass. Note a device that resized itself does **not**
+  look like this: the shim still writes `paramsHeight == target` there; what tells
+  it apart is `webViewHeight` already equalling `target` _before_ the shim's pass
+  (see `ImeWebViewHeight`).
 - no line at all → the listener never saw a transition; check the tag is enabled
-  and the app was restarted after `setprop`.
+  (`Log.isLoggable` reads the property live, no restart needed) and that the
+  keyboard actually crossed the 15% threshold.
 
 `webViewHeight` lags by one layout pass — that is expected, not a failure.
 
@@ -493,12 +524,15 @@ items to **check**, not to blind-fix — a blind fix risks re-creating #8508.
    insets while injecting real px into the vars, so the two families disagree.
    Confirm bottom-nav / add-task-bar spacing on API 35/36; reconcile to one source
    per band if it is wrong.
-3. **API 30-34 + WebView < 140 IME owner.** The native shim is gated `SDK_INT < 30`
-   deliberately (newer APIs were observed to resize the window for the IME, and
-   insetting on top of that re-creates the #8508 squash). Under SystemBars,
-   WebView < 140 gets no IME padding below API 35. Verify whether the window still
-   resizes on API 30-34: if it does, there is no gap; if it does not, extend the
-   shim to `< 35 && WebView < 140` — but only after confirming on a device.
+3. ~~**API 30-34 + WebView < 140 IME owner.** The native shim is gated
+   `SDK_INT < 30` deliberately (newer APIs were observed to resize the window for
+   the IME, and insetting on top of that re-creates the #8508 squash). Under
+   SystemBars, WebView < 140 gets no IME padding below API 35. Verify whether the
+   window still resizes on API 30-34: if it does, there is no gap; if it does not,
+   extend the shim to `< 35 && WebView < 140` — but only after confirming on a
+   device.~~ **Done (#9316):** the window does not resize there; the shim is gated
+   `< 35 && WebView < 140` (`NativeInsetShimGate`) and validated on the API 34
+   emulator — see the #9316 section.
 4. **CDK overlay / context-menu top position shifts on API >= 35.**
    `--safe-area-inset-top` resolves to real px there (it was 0 on Android before),
    so connected overlays clamp below the status bar. Likely more correct; re-test

--- a/docs/android-edge-to-edge-keyboard.md
+++ b/docs/android-edge-to-edge-keyboard.md
@@ -347,10 +347,21 @@ the `position: fixed` bar stays at the bottom of a viewport that extends behind
 the IME. The reporters' before/after screenshots are pixel-identical, which is
 exactly this signature.
 
+**Why `adjustResize` does not save us.** The manifest declares
+`windowSoftInputMode="adjustResize"`, so the obvious question is why the window
+does not simply shrink. Because Capacitor's StatusBar plugin runs with
+`overlaysWebView: true` (`capacitor.config.ts`), which applies
+`SYSTEM_UI_FLAG_LAYOUT_STABLE or SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN` to the decor
+view (`StatusBar.setOverlaysWebView`) — and under layout-fullscreen `adjustResize`
+stops resizing for the IME. That is the long-standing Android behaviour the
+`getWindowVisibleDisplayFrame` + explicit-height workaround exists for, and it is
+SDK-independent below 35, which is why the symptom never depended on the API
+level the original gate keyed off.
+
 **Why the old gate's assumption failed.** `SDK_INT < 30` encoded "API >= 30
 implies a current WebView, because it auto-updates." Not on a custom ROM:
 crDroid ships its own `com.android.webview` (124) and the Play-updated
-`com.google.android.webview` (150) is *installed but disabled*. Settings shows
+`com.google.android.webview` (150) is _installed but disabled_. Settings shows
 150; `dumpsys webviewupdate` shows the **active** provider is 124. Always read
 the `Current WebView package` line, never the Settings screen.
 
@@ -360,14 +371,29 @@ A/B isolating the WebView version, and a direct confirmation of the 140 boundary
 
 **Fix — `NativeInsetShimGate.shouldRunShim(sdkInt, webViewMajor)`**, now shared by
 `adjustWebViewHeightForKeyboard` and `pushStatusBarOverlap` (both lost their
-`BelowApi30` suffix — the gate is no longer SDK 30). It is the exact complement of
+`BelowApi30` suffix — the gate is no longer SDK 30). It is the complement of
 SystemBars' two ownership branches: run iff `sdkInt < 35 && (webViewMajor == null
 || webViewMajor < 140)`. An unreadable version runs the shim, because SystemBars
 treats an unreadable version as `0` and skips its passthrough too — both off would
 strand the device with no inset owner. Unit-covered in `NativeInsetShimGateTest`.
 
+Two caveats on "complement":
+
+- Branch 1 additionally requires **`viewport-fit=cover`**, which SystemBars only
+  learns at `onDOMReady`. `src/index.html` sets it (there is a comment there
+  saying so — keep it), leaving only the pre-DOM-ready window uncovered, where the
+  IME cannot be up yet.
+- The gate must read the **active** provider, the same thing SystemBars reads
+  (`WebView.getCurrentWebViewPackage()`, failure treated as `0`).
+  `WebViewCompatibilityChecker` answers a different question and can fall back to
+  scanning installed packages, which on the crDroid layout above reports the
+  disabled 150 rather than the active 124 — that number would switch the shim off
+  on exactly the devices it is for. `NativeInsetShimGate.activeProviderMajor()`
+  therefore accepts only `getCurrentWebViewPackage()` or user-agent readings and
+  degrades anything else to `null` (→ run the shim).
+
 **Why this does not re-arm #8508.** The rule from that saga is that any inset must
-be *resize-detecting*. This shim already is, structurally: it sets the WebView's
+be _resize-detecting_. This shim already is, structurally: it sets the WebView's
 layout height to an **absolute** target read from the visible frame
 (`rect.bottom − webViewTop`), not a delta. On a device where the window already
 shrank for the IME, the WebView bottom is already at `rect.bottom`, so the
@@ -377,6 +403,24 @@ makes broadening the gate safe; do not replace it with a delta-based inset.
 **Still REQUIRED before release:** the widened band (API 30–34) is not covered by
 any device on hand — validate via a test build with the #9316 reporters, plus the
 matrix below to confirm API >= 35 and WebView >= 140 are untouched.
+
+**Validate the mechanism, not just the symptom.** The shim is a strict no-op
+wherever the window already resizes, so "the bar looks fixed" cannot distinguish a
+working shim from one that never ran — and a coincidental fix would send the next
+regression hunt down the wrong path. `logImeGeometryOnTransition` prints the gate
+inputs and geometry once per keyboard transition; it is off unless enabled, so ask
+the reporter for:
+
+```
+adb shell setprop log.tag.SUPKeyboard DEBUG   # then restart the app
+adb logcat -s SUPKeyboard
+adb shell dumpsys webviewupdate | grep -i 'Current WebView package'
+```
+
+A fixed device must show `shim=true` with `paramsHeight` dropping to roughly
+`rectBottom − webViewTop` while `ime=true`, and the provider version from
+`dumpsys` must match the `wvMajor=` the gate read. If `shim=false`, the version
+source is wrong, not the theory.
 
 ## What NOT to do
 

--- a/docs/android-edge-to-edge-keyboard.md
+++ b/docs/android-edge-to-edge-keyboard.md
@@ -329,9 +329,10 @@ SystemBars on `--safe-area-inset-*`:
 
 ## #9316 — API 34 + old WebView: add-task bar behind the keyboard
 
-**Status: gate widened (`NativeInsetShimGate`), PENDING ON-DEVICE VALIDATION by
-the reporters.** Two users on **Android 14 (API 34)** report the add-task bar (and
-the task-detail notes field) sitting behind the keyboard. This is the "known small
+**Status: gate widened (`NativeInsetShimGate`) and VALIDATED IN CI on both inset
+owners** — `ImeInsetShimInstrumentedTest`, see "Validation" below (measured
+2026-09). Two users on **Android 14 (API 34)** reported the add-task bar (and the
+task-detail notes field) sitting behind the keyboard. This is the "known small
 gap" above, realized.
 
 **Root cause — nobody owns the IME inset.** `SystemBars` installs its
@@ -404,16 +405,44 @@ shrank for the IME, the WebView bottom is already at `rect.bottom`, so the
 computed height equals the current one and nothing moves. That property is what
 makes broadening the gate safe; do not replace it with a delta-based inset.
 
-**Still REQUIRED before release:** the widened band (API 30–34) is not covered by
-any device on hand — validate via a test build with the #9316 reporters, plus the
-matrix below to confirm API >= 35 and WebView >= 140 are untouched.
+**Validation — `ImeInsetShimInstrumentedTest` (CI, both inset owners).** No
+device on hand sits in the widened band, and the reporter who offered to test had
+moved to WebView 153 by then, where the shim is a no-op by construction and a test
+build could only confirm the symptom. The band is reachable in CI instead: an API
+34 `google_apis` emulator image ships a bundled WebView that never auto-updates and
+sits below 140. The `android-tests` job boots a second emulator at API 34
+(`android/run-android-ime-check.sh`) after the API 35 suite
+(`android/run-android-checks.sh`), so every PR exercises both owners:
 
-**Validate the mechanism, not just the symptom.** The shim is a strict no-op
-wherever the window already resizes, so "the bar looks fixed" cannot distinguish a
-working shim from one that never ran — and a coincidental fix would send the next
-regression hunt down the wrong path. `logImeGeometryOnTransition` prints the gate
-inputs and geometry once per keyboard transition; it is off unless enabled, so ask
-the reporter for:
+| Emulator                  | Owner per gate         | Measured (2026-09, 640 px root)                                                                       |
+| ------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------- |
+| API 34, WebView 113.0     | native shim (on)       | `paramsHeight` MATCH_PARENT → **405** = `rect.bottom`; WebView bottom 640 → 405; `innerHeight` 640 → 405 |
+| API 35 (bundled WebView)  | SystemBars (shim off)  | layout params untouched; WebView bottom at `rect.bottom`; `innerHeight` shrinks                       |
+
+The test derives the gate's inputs the way the activity does
+(`NativeInsetShimGate.activeProviderMajor(WebViewCompatibilityChecker.evaluate())`)
+and asserts the **mechanism** the gate selects — an explicit WebView height equal
+to `ImeWebViewHeight.targetHeight(rect.bottom, webViewTop)` under the shim,
+untouched layout params where SystemBars owns the inset — plus, on every API
+level, the **symptom**: WebView bottom at or above the keyboard top,
+`window.innerHeight` shrank (what lifts the `position: fixed` bar), the height
+stable across a later layout pass (no feedback loop), and the resting height
+restored on hide. Emulators report a hardware keyboard, so both scripts run
+`settings put secure show_ime_with_hard_keyboard 1` first; without it the IME
+never opens and the test fails on its first wait rather than passing vacuously.
+
+Still open: the API 34 row also settles the "adjustResize does not resize" inference
+above — the window kept its full 640 px until the shim pinned it (had the framework
+resized, `paramsHeight` would have been a no-op write of the height already in
+effect). Not yet observed on a real device in the band; the reporters' A/B with
+WebView 151/153 remains the field evidence.
+
+**On a reporter's device, validate the mechanism, not just the symptom.** The
+shim is a strict no-op wherever the window already resizes, so "the bar looks
+fixed" cannot distinguish a working shim from one that never ran — and a
+coincidental fix would send the next regression hunt down the wrong path.
+`logImeGeometryOnTransition` prints the gate inputs and geometry once per keyboard
+transition; it is off unless enabled, so ask the reporter for:
 
 ```
 adb shell setprop log.tag.SUPKeyboard DEBUG   # then restart the app

--- a/docs/android-edge-to-edge-keyboard.md
+++ b/docs/android-edge-to-edge-keyboard.md
@@ -347,7 +347,11 @@ the `position: fixed` bar stays at the bottom of a viewport that extends behind
 the IME. The reporters' before/after screenshots are pixel-identical, which is
 exactly this signature.
 
-**Why `adjustResize` does not save us.** The manifest declares
+**Why `adjustResize` does not save us — INFERRED, not yet observed.** This is
+read off the sources below, not measured on a device in the affected band; treat
+it as the working explanation and confirm it before building on it (an API 30–34
+emulator settles it — the window configuration does not depend on the WebView
+version, so any device in the band answers the question). The manifest declares
 `windowSoftInputMode="adjustResize"`, so the obvious question is why the window
 does not simply shrink. Because Capacitor's StatusBar plugin runs with
 `overlaysWebView: true` (`capacitor.config.ts`), which applies
@@ -417,10 +421,19 @@ adb logcat -s SUPKeyboard
 adb shell dumpsys webviewupdate | grep -i 'Current WebView package'
 ```
 
-A fixed device must show `shim=true` with `paramsHeight` dropping to roughly
-`rectBottom − webViewTop` while `ime=true`, and the provider version from
-`dumpsys` must match the `wvMajor=` the gate read. If `shim=false`, the version
-source is wrong, not the theory.
+The line is printed **after** the shim's pass, so on a fixed device the
+`ime=true` line reads `shim=true` with `paramsHeight` equal to `target` (both
+`rectBottom − webViewTop`). Cases to distinguish:
+
+- `shim=false` → the gate is off: compare `wvMajor=` against the `dumpsys`
+  provider. The version source is wrong, not the theory.
+- `target` set but `paramsHeight` unchanged → the shim ran and bailed on a
+  degenerate frame, or the height was already correct (the device resized itself,
+  in which case the shim is a legitimate no-op — see `ImeWebViewHeight`).
+- no line at all → the listener never saw a transition; check the tag is enabled
+  and the app was restarted after `setprop`.
+
+`webViewHeight` lags by one layout pass — that is expected, not a failure.
 
 ## What NOT to do
 

--- a/docs/android-edge-to-edge-keyboard.md
+++ b/docs/android-edge-to-edge-keyboard.md
@@ -8,8 +8,8 @@ area has regressed repeatedly (#8295, then #8508).**
 > Capacitor's built-in `SystemBars`** (`insetsHandling: 'css'`). Edge-to-edge
 > insets + IME padding are now handled by SystemBars on **WebView ≥ 140** (or
 > API ≥ 35); the **WebView < 140 / API < 35** tail is covered by env() + a native
-> keyboard shim (`adjustWebViewHeightForKeyboardBelowApi30`, now gated to
-> WebView < 140 so it never fights SystemBars). Bar backgrounds are no longer
+> keyboard shim (`adjustWebViewHeightForKeyboard`, gated by `NativeInsetShimGate`
+> to exactly that tail so it never fights SystemBars). Bar backgrounds are no longer
 > painted by a plugin (SystemBars has no color API) — the bars are transparent
 > and the theme color shows through via `NavigationBarPlugin.setWebViewBackgroundColor`
 > (window decor + WebView surface). The #8508 sections below describe the _former_
@@ -121,7 +121,7 @@ bar sits just above the keyboard (no behind-keyboard regression).**
 
 ## #8508 follow-up — SDK 28 (Android 9): add-task bar sits BEHIND the keyboard
 
-**Status: fix implemented (`CapacitorMainActivity.adjustWebViewForKeyboardBelowApi30`),
+**Status: fix implemented (`CapacitorMainActivity.adjustWebViewHeightForKeyboard`),
 PENDING ON-DEVICE VALIDATION across the matrix below.** After 18.12.0 (patch
 removed) a user on **Android 9 / API 28** reports the global add-task bar sits
 _below / behind_ the soft keyboard. This is the realization of open item #4
@@ -160,7 +160,7 @@ resize, that double-counts and floats the bar mid-screen. The web layer lacks
 the signal to disambiguate; native has it unambiguously.
 
 **Implemented fix (native, explicit WebView height while the IME is up, scoped to
-API < 30) — `CapacitorMainActivity.adjustWebViewHeightForKeyboardBelowApi30`.**
+API < 30) — `CapacitorMainActivity.adjustWebViewHeightForKeyboard`.**
 Driven from the existing keyboard `OnGlobalLayoutListener`:
 
 - while the keyboard is up: set an explicit WebView **layout height** to the
@@ -271,7 +271,7 @@ an iOS bottom gap appears, drop the term there too.
 
 ## #8508 follow-up — SDK 28 (Android 9): header draws BEHIND the status bar
 
-**Status: fix implemented (`CapacitorMainActivity.pushStatusBarOverlapBelowApi30`),
+**Status: fix implemented (`CapacitorMainActivity.pushStatusBarOverlap`),
 PENDING ON-DEVICE VALIDATION.** Separate from the keyboard — on API 28 the web
 header overlaps the **status bar** (no top gap), reported on #8508.
 
@@ -290,7 +290,7 @@ edge-to-edge under the status bar" from "WebView is already inset below it" —
 `env()` is 0 in both, and adding the status-bar height blindly would double-count
 in the inset case. Native has the geometry.
 
-**Fix (native overlap → SCSS fallback) — `pushStatusBarOverlapBelowApi30`.** From
+**Fix (native overlap → SCSS fallback) — `pushStatusBarOverlap`.** From
 the existing keyboard `OnGlobalLayoutListener`, measure the overlap
 `max(0, rect.top − webViewTopOnScreen)` — `rect.top` is the visible-frame top
 (= status-bar height, reliable on API 28; the same frame the keyboard path reads)
@@ -316,15 +316,67 @@ SystemBars on `--safe-area-inset-*`:
 - JS readers (`_patchCdkViewportForSafeArea`) still parse the `var(max(...))`
   token to 0, so overlay positioning is unchanged — preserving #8283 scoping
   (only the header padding is affected).
-- Known small gap: an **API 30–34** device on an **old WebView < 140** also has
+- ~~Known small gap: an **API 30–34** device on an **old WebView < 140** also has
   env()==0 but is excluded by the SDK < 30 gate; rare (WebView auto-updates above
-  API 30) — broaden the gate to WebView-only if it ever surfaces.
+  API 30) — broaden the gate to WebView-only if it ever surfaces.~~ **It surfaced
+  (#9316); the gate was broadened — see the section below.**
 - The var lives only as an inline style on the document, so a web-side reload
   (`window.location.reload()` — language change, PWA update, sync-conflict
   recovery) wipes it. The native dedupe (`lastStatusBarOverlapCssPx`) is reset in
   `flushPendingShareIntent()` (runs on every frontend (re)load) so the next layout
   pass re-publishes it; without the reset the unchanged value would be skipped and
   the overlap would regress after a reload.
+
+## #9316 — API 34 + old WebView: add-task bar behind the keyboard
+
+**Status: gate widened (`NativeInsetShimGate`), PENDING ON-DEVICE VALIDATION by
+the reporters.** Two users on **Android 14 (API 34)** report the add-task bar (and
+the task-detail notes field) sitting behind the keyboard. This is the "known small
+gap" above, realized.
+
+**Root cause — nobody owns the IME inset.** `SystemBars` installs its
+`OnApplyWindowInsetsListener` on the WebView's parent (the activity content root,
+`capacitor_bridge_layout_main.xml`) on **every** API level, so it — not the
+framework — is the inset owner. But it only applies IME padding on two paths
+(`SystemBars.initWindowInsetsListener`): the passthrough branch, gated
+`webViewMajor >= 140 && viewport-fit=cover`, and an `SDK_INT >= 35` branch. On
+**API < 35 AND WebView < 140** it applies nothing at all — and our shims were
+gated `SDK_INT < 30`, so they did not step in either. Nothing shrinks →
+`obscured = innerHeight − visualViewport.height` is 0 → `--keyboard-height: 0` →
+the `position: fixed` bar stays at the bottom of a viewport that extends behind
+the IME. The reporters' before/after screenshots are pixel-identical, which is
+exactly this signature.
+
+**Why the old gate's assumption failed.** `SDK_INT < 30` encoded "API >= 30
+implies a current WebView, because it auto-updates." Not on a custom ROM:
+crDroid ships its own `com.android.webview` (124) and the Play-updated
+`com.google.android.webview` (150) is *installed but disabled*. Settings shows
+150; `dumpsys webviewupdate` shows the **active** provider is 124. Always read
+the `Current WebView package` line, never the Settings screen.
+
+**Evidence.** Two independent reporters at API 34 / WebView 124 and 126. One of
+them side-loaded WebView 151 with no app change and the bug disappeared — a clean
+A/B isolating the WebView version, and a direct confirmation of the 140 boundary.
+
+**Fix — `NativeInsetShimGate.shouldRunShim(sdkInt, webViewMajor)`**, now shared by
+`adjustWebViewHeightForKeyboard` and `pushStatusBarOverlap` (both lost their
+`BelowApi30` suffix — the gate is no longer SDK 30). It is the exact complement of
+SystemBars' two ownership branches: run iff `sdkInt < 35 && (webViewMajor == null
+|| webViewMajor < 140)`. An unreadable version runs the shim, because SystemBars
+treats an unreadable version as `0` and skips its passthrough too — both off would
+strand the device with no inset owner. Unit-covered in `NativeInsetShimGateTest`.
+
+**Why this does not re-arm #8508.** The rule from that saga is that any inset must
+be *resize-detecting*. This shim already is, structurally: it sets the WebView's
+layout height to an **absolute** target read from the visible frame
+(`rect.bottom − webViewTop`), not a delta. On a device where the window already
+shrank for the IME, the WebView bottom is already at `rect.bottom`, so the
+computed height equals the current one and nothing moves. That property is what
+makes broadening the gate safe; do not replace it with a delta-based inset.
+
+**Still REQUIRED before release:** the widened band (API 30–34) is not covered by
+any device on hand — validate via a test build with the #9316 reporters, plus the
+matrix below to confirm API >= 35 and WebView >= 140 are untouched.
 
 ## What NOT to do
 
@@ -376,6 +428,14 @@ typing a word fast right after tapping +, on:
 - Android 15 (API 35) — we opt out via `windowOptOutEdgeToEdgeEnforcement`
 - Android 16 (API 36) — our target; the system was observed to still resize for
   the IME on a real device
+
+**The WebView version is a second axis, not a detail (#9316).** SystemBars
+branches on it at 140, so an API 30–34 device on WebView < 140 behaves nothing
+like the same device on WebView >= 140 — that combination is what #9316 was, and
+it is the one the SDK-only matrix missed. Read the active provider with
+`adb shell dumpsys webviewupdate` (the `Current WebView package` line) — **not**
+the Settings screen, which can show an installed-but-disabled package. Custom
+ROMs are the realistic source of an old WebView above API 30.
 
 Both gesture-nav and 3-button-nav, light and dark. Confirm: no blank gap above
 the keyboard, bar visible just above the keyboard, and typed characters appear in

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,12 @@
       the same way it does natively. Ignored where it doesn't apply: native
       WebViews (keyboard handled natively), iOS Safari (unsupported → falls back
       to the JS `--keyboard-height` visualViewport tracking), and desktop.
+
+      viewport-fit=cover is load-bearing on Android beyond the notch: Capacitor's
+      SystemBars only passes real insets through when it reads it back from this
+      tag (WebView >= 140). Dropping it strands WebView >= 140 / API < 35 devices
+      with no inset owner — see NativeInsetShimGate and
+      docs/android-edge-to-edge-keyboard.md.
     -->
     <meta
       content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content"


### PR DESCRIPTION
## Problem

Fixes #9316. On Android the global add-task bar (and the notes field in the task detail view) sits behind the soft keyboard on **API 30–34 devices whose active WebView is below 140**. Capacitor's `SystemBars` only applies IME padding on WebView ≥ 140 or API ≥ 35, and our native keyboard shim was gated to `SDK_INT < 30`, so in that band nobody owned the keyboard inset. Two reporters hit it on Android 14 with WebView 124 and 126 (custom ROMs that pin an old `com.android.webview`); one confirmed the boundary by side-loading WebView 151 with no app change.

This supersedes the draft #9581, which carried the same fix but was blocked on validation: no device on hand sits in that band, and the reporter who offered to test has since moved to WebView 153, where the shim is a no-op by construction and a test build could only confirm the symptom, never the mechanism.

## Solution

The three commits from #9581, rebased onto master unchanged (one doc-comment conflict resolved; a reference to a `docs/plans` file master has since removed is dropped):

- `NativeInsetShimGate` derives the gate from what `SystemBars` actually handles — run iff `sdkInt < 35 && webViewMajor < 140` (unknown version → run) — instead of a hardcoded SDK level, and reads only the **active** provider so an installed-but-disabled package cannot switch the shim off on the devices it exists for.
- `ImeWebViewHeight` extracts the absolute-target arithmetic that keeps this from re-creating #8508, with unit tests.
- `logImeGeometryOnTransition` diagnostic, off unless `setprop log.tag.SUPKeyboard DEBUG`.

Plus the validation #9581 was waiting for:

- **`ImeInsetShimInstrumentedTest`** opens the soft keyboard over the real Capacitor shell and asserts the **mechanism** (it computes the gate's inputs the way the activity does and expects the owner the gate selects to be the one that acted: explicit WebView height == keyboard top under the shim, untouched layout params where `SystemBars` owns the inset) and the **symptom** on every API level (WebView bottom at the keyboard top, `window.innerHeight` shrank, height stable across layout passes, resting height restored on hide).
- The `android-tests` job boots a **second emulator at API 34** (`google_apis`, bundled WebView never auto-updates and sits below 140) for that test alone, after the existing API 35 suite. That covers both inset owners in CI: API 35 proves the shim stays out of `SystemBars`' way; API 34 proves it steps in where nothing else does.
- Emulators report a hardware keyboard, which keeps the soft keyboard hidden, so both emulator scripts enable `show_ime_with_hard_keyboard` first.

## Validation

[Android Native Tests run 33941636633](https://github.com/super-productivity/super-productivity/actions/runs/33941636633) — green on both emulators. The API 34 step logged:

```
sdk=34 activeMajor=113 (raw=113 src=PACKAGE current=true) currentWebViewPackage=com.google.android.webview/113.0.5672.136 expectShim=true
resting: rootHeight=640 rectBottom=640 webViewTop=0 webViewBottom=640 paramsHeight=-1  innerHeight=640
open:    rootHeight=640 rectBottom=405 webViewTop=0 webViewBottom=405 paramsHeight=405 imeVisible=true
settled: (same)                                                                          innerHeight=405
```

i.e. in the reported band the window did **not** resize for the IME on its own (root stayed 640 while the visible frame dropped to 405), the gate was on, and the shim pinned the WebView to exactly the keyboard top; the web layout viewport followed. On API 35 the same test passed with the shim off (layout params untouched, SystemBars did the insetting).

`docs/android-edge-to-edge-keyboard.md` records this under the #9316 section.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files (none changed)
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgqSda3NG56kDCjNgnBkDQ