### PR TITLE
fix(sync): genesis-op handling at join time follow-ups #9921

### DIFF
--- a/docs/sync-and-op-log/operation-log-architecture.md
+++ b/docs/sync-and-op-log/operation-log-architecture.md
@@ -339,14 +339,15 @@ join time: it gets the local-data conflict dialog on a non-empty server, or
 seeds an empty server with a `SYNC_IMPORT`
 (`SyncLocalStateService.isNeverSyncedGenesisClient`, #9863). Because that
 download-side decision is what actually ships the state, API-based providers
-(SuperSync) never upload the genesis op itself: once the upload guards have
-passed, `OperationLogUploadService` marks it synced locally and leaves it out
-of the pending set (`isGenesisEntityType`, #9921). While the upload is still
-blocked (no encryption key yet) the op stays pending, because a pending genesis
-op is what keeps the incoming-import gate armed. File-based providers keep
-uploading it: there the ops upload is what writes the state snapshot. Servers
-may still hold genesis ops uploaded by older clients; receivers apply them as
-no-ops as before.
+(SuperSync) never upload the genesis op itself: `OperationLogUploadService`
+leaves it out of the upload set and marks it synced locally once the round's
+full-state ops are settled (`isGenesisEntityType`, #9921). While the upload is
+still blocked (no encryption key yet), or when this client's own `SYNC_IMPORT`
+was just dropped on `SYNC_IMPORT_EXISTS`, the op stays pending, because a
+pending genesis op is what makes the incoming-import gate prompt. File-based
+providers keep uploading it: there the ops upload is what writes the state
+snapshot. Servers may still hold genesis ops uploaded by older clients;
+receivers apply them as no-ops as before.
 
 ## A.4 Compaction
 

--- a/docs/sync-and-op-log/operation-log-architecture.md
+++ b/docs/sync-and-op-log/operation-log-architecture.md
@@ -337,7 +337,12 @@ as a no-op. A client whose history is still only that genesis op (never synced,
 no full-state op) is therefore treated like a fresh client with local data at
 join time: it gets the local-data conflict dialog on a non-empty server, or
 seeds an empty server with a `SYNC_IMPORT`
-(`SyncLocalStateService.isNeverSyncedGenesisClient`, #9863).
+(`SyncLocalStateService.isNeverSyncedGenesisClient`, #9863). Because that
+download-side decision is what actually ships the state, the genesis op itself
+is never uploaded: `OperationLogUploadService` marks it synced locally and
+leaves it out of the pending set (`isGenesisEntityType`, #9921). Servers may
+still hold genesis ops uploaded by older clients; receivers apply them as
+no-ops as before.
 
 ## A.4 Compaction
 

--- a/docs/sync-and-op-log/operation-log-architecture.md
+++ b/docs/sync-and-op-log/operation-log-architecture.md
@@ -338,10 +338,14 @@ no full-state op) is therefore treated like a fresh client with local data at
 join time: it gets the local-data conflict dialog on a non-empty server, or
 seeds an empty server with a `SYNC_IMPORT`
 (`SyncLocalStateService.isNeverSyncedGenesisClient`, #9863). Because that
-download-side decision is what actually ships the state, the genesis op itself
-is never uploaded: `OperationLogUploadService` marks it synced locally and
-leaves it out of the pending set (`isGenesisEntityType`, #9921). Servers may
-still hold genesis ops uploaded by older clients; receivers apply them as
+download-side decision is what actually ships the state, API-based providers
+(SuperSync) never upload the genesis op itself: once the upload guards have
+passed, `OperationLogUploadService` marks it synced locally and leaves it out
+of the pending set (`isGenesisEntityType`, #9921). While the upload is still
+blocked (no encryption key yet) the op stays pending, because a pending genesis
+op is what keeps the incoming-import gate armed. File-based providers keep
+uploading it: there the ops upload is what writes the state snapshot. Servers
+may still hold genesis ops uploaded by older clients; receivers apply them as
 no-ops as before.
 
 ## A.4 Compaction

--- a/e2e/pages/supersync.page.ts
+++ b/e2e/pages/supersync.page.ts
@@ -8,6 +8,7 @@ import {
 } from '@playwright/test';
 import { BasePage } from './base.page';
 import { normalizeDialogMessage, translationRegex } from '../utils/i18n-strings';
+import { confirmSyncConflictOverwriteIfShown } from '../utils/sync-helpers';
 
 export interface SuperSyncConfig {
   baseUrl: string;
@@ -1809,10 +1810,8 @@ export class SuperSyncPage extends BasePage {
   }
 
   /**
-   * Answer the local-data conflict dialog. Either choice may raise the
-   * secondary overwrite warning (`dialog-confirm`) depending on the measured
-   * change counts, so wait for that dialog or the parent closing instead of
-   * probing for a fixed delay.
+   * Answer the local-data conflict dialog, including the conditional overwrite
+   * warning either choice may raise (see confirmSyncConflictOverwriteIfShown).
    */
   async resolveConflictDialog(choice: 'local' | 'remote'): Promise<void> {
     await expect(this.conflictDialog).toBeVisible({ timeout: 5000 });
@@ -1821,31 +1820,7 @@ export class SuperSyncPage extends BasePage {
     } else {
       await this.conflictUseRemoteBtn.click();
     }
-
-    const overwriteConfirm = this.page
-      .locator('dialog-confirm')
-      .filter({ hasText: /WARNING:[\s\S]*overwrit/i });
-    await expect
-      .poll(
-        async () => {
-          if (await overwriteConfirm.isVisible().catch(() => false)) {
-            return 'confirm';
-          }
-          if (!(await this.conflictDialog.isVisible().catch(() => false))) {
-            return 'closed';
-          }
-          return 'pending';
-        },
-        {
-          timeout: 5000,
-          message: 'Expected the sync conflict to close or show its overwrite warning',
-        },
-      )
-      .not.toBe('pending');
-    if (await overwriteConfirm.isVisible().catch(() => false)) {
-      await overwriteConfirm.locator('[e2e="confirmBtn"]').click();
-    }
-    await expect(this.conflictDialog).toBeHidden({ timeout: 5000 });
+    await confirmSyncConflictOverwriteIfShown(this.page, this.conflictDialog);
   }
 
   /**

--- a/e2e/pages/supersync.page.ts
+++ b/e2e/pages/supersync.page.ts
@@ -143,10 +143,15 @@ export class SuperSyncPage extends BasePage {
   /** Fresh client confirmation dialog - appears when a new client first syncs */
   readonly freshClientDialog: Locator;
   readonly freshClientConfirmBtn: Locator;
-  /** Conflict resolution dialog - appears when local and remote have conflicting changes */
+  /**
+   * Local-data conflict dialog (`dialog-sync-conflict`) — appears when a client
+   * that never synced holds meaningful local data and the server already has
+   * ordinary ops (LocalDataConflictError, #9863). "Keep local" force-uploads a
+   * SYNC_IMPORT, "Keep remote" replaces local state with the server's.
+   */
   readonly conflictDialog: Locator;
+  readonly conflictUseLocalBtn: Locator;
   readonly conflictUseRemoteBtn: Locator;
-  readonly conflictApplyBtn: Locator;
   /** Sync import conflict dialog - appears when SYNC_IMPORT filters remote ops */
   readonly syncImportConflictDialog: Locator;
   readonly syncImportUseLocalBtn: Locator;
@@ -184,14 +189,14 @@ export class SuperSyncPage extends BasePage {
     this.freshClientConfirmBtn = this.freshClientDialog.locator(
       'button[mat-flat-button]',
     );
-    // Conflict resolution dialog elements
-    this.conflictDialog = page.locator('dialog-conflict-resolution');
-    this.conflictUseRemoteBtn = page.locator(
-      'dialog-conflict-resolution button:has-text("Use All Remote")',
-    );
-    this.conflictApplyBtn = page.locator(
-      'dialog-conflict-resolution button:has-text("Apply")',
-    );
+    // Local-data conflict dialog elements
+    this.conflictDialog = page.locator('dialog-sync-conflict');
+    this.conflictUseLocalBtn = this.conflictDialog.locator('button', {
+      hasText: /Keep local/i,
+    });
+    this.conflictUseRemoteBtn = this.conflictDialog.locator('button', {
+      hasText: /Keep remote/i,
+    });
     // Sync import conflict dialog elements
     this.syncImportConflictDialog = page.locator('dialog-sync-import-conflict');
     this.syncImportUseLocalBtn = page.locator(
@@ -1804,6 +1809,46 @@ export class SuperSyncPage extends BasePage {
   }
 
   /**
+   * Answer the local-data conflict dialog. Either choice may raise the
+   * secondary overwrite warning (`dialog-confirm`) depending on the measured
+   * change counts, so wait for that dialog or the parent closing instead of
+   * probing for a fixed delay.
+   */
+  async resolveConflictDialog(choice: 'local' | 'remote'): Promise<void> {
+    await expect(this.conflictDialog).toBeVisible({ timeout: 5000 });
+    if (choice === 'local') {
+      await this.conflictUseLocalBtn.click();
+    } else {
+      await this.conflictUseRemoteBtn.click();
+    }
+
+    const overwriteConfirm = this.page
+      .locator('dialog-confirm')
+      .filter({ hasText: /WARNING:[\s\S]*overwrit/i });
+    await expect
+      .poll(
+        async () => {
+          if (await overwriteConfirm.isVisible().catch(() => false)) {
+            return 'confirm';
+          }
+          if (!(await this.conflictDialog.isVisible().catch(() => false))) {
+            return 'closed';
+          }
+          return 'pending';
+        },
+        {
+          timeout: 5000,
+          message: 'Expected the sync conflict to close or show its overwrite warning',
+        },
+      )
+      .not.toBe('pending');
+    if (await overwriteConfirm.isVisible().catch(() => false)) {
+      await overwriteConfirm.locator('[e2e="confirmBtn"]').click();
+    }
+    await expect(this.conflictDialog).toBeHidden({ timeout: 5000 });
+  }
+
+  /**
    * Handle any sync-blocking dialogs (Angular Material or native).
    * Returns true if a dialog was handled, false otherwise.
    * @private
@@ -1817,19 +1862,12 @@ export class SuperSyncPage extends BasePage {
       return true;
     }
 
-    // 2. Conflict resolution dialog
+    // 2. Local-data conflict dialog
     if (await this.conflictDialog.isVisible().catch(() => false)) {
       console.log(
         `[syncAndWait] Conflict dialog detected, using ${useLocal ? 'local' : 'remote'} data...`,
       );
-      if (useLocal) {
-        await this.conflictApplyBtn.click();
-      } else {
-        await this.conflictUseRemoteBtn.click();
-        await this.page.waitForTimeout(200);
-        await this.conflictApplyBtn.click();
-      }
-      await this.conflictDialog.waitFor({ state: 'hidden', timeout: 5000 });
+      await this.resolveConflictDialog(useLocal ? 'local' : 'remote');
       return true;
     }
 

--- a/e2e/tests/sync/supersync-legacy-migration-sync.spec.ts
+++ b/e2e/tests/sync/supersync-legacy-migration-sync.spec.ts
@@ -570,8 +570,8 @@ test.describe('@supersync @migration SuperSync Legacy Migration Sync', () => {
       await expect(clientB.page.locator('task', { hasText: 'Task B1' })).toBeVisible();
       await expect(clientB.page.locator('task', { hasText: 'Task B2' })).toBeVisible();
 
-      // B's state now ships as a SYNC_IMPORT, which settles every earlier op
-      // including the genesis (the no-upload rule itself is unit-tested).
+      // B's state now ships as a SYNC_IMPORT; the genesis op is settled locally
+      // once that upload succeeded (the no-upload rule itself is unit-tested).
       const opsBAfter = await getLocalOpLogSummary(clientB.page);
       expect(opsBAfter.find((op) => op.entityType === 'MIGRATION')?.isSynced).toBe(true);
       expect(opsBAfter.some(isFullStateOp)).toBe(true);

--- a/e2e/tests/sync/supersync-legacy-migration-sync.spec.ts
+++ b/e2e/tests/sync/supersync-legacy-migration-sync.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../../fixtures/supersync.fixture';
+import type { Page } from '@playwright/test';
 import { SuperSyncPage } from '../../pages/supersync.page';
 import { WorkViewPage } from '../../pages/work-view.page';
 import { waitForStatePersistence } from '../../utils/waits';
@@ -6,7 +7,9 @@ import {
   closeClient,
   createSimulatedClient,
   createTestUser,
+  getLocalOpLogSummary,
   getSuperSyncConfig,
+  seedSuperSyncCredentials,
   type SimulatedE2EClient,
 } from '../../utils/supersync-helpers';
 import {
@@ -447,6 +450,154 @@ test.describe('@supersync @migration SuperSync Legacy Migration Sync', () => {
       }
     } finally {
       if (clientA) await closeLegacyClient(clientA).catch(() => {});
+      if (clientB) await closeLegacyClient(clientB).catch(() => {});
+    }
+  });
+
+  /**
+   * Test: genesis-only client joins a server that holds ordinary ops only (#9863)
+   *
+   * The silent join path: Client B holds nothing but its MIGRATION genesis op
+   * (no post-migration edits), the server holds Client A's ordinary ops and no
+   * full-state op. Before #9863 both sides reported IN_SYNC and B's migrated
+   * tasks stayed stranded on B. Expected now: B gets the local-data conflict
+   * dialog; "Keep local" ships B's state as a SYNC_IMPORT that A then adopts.
+   *
+   * The server state is only reachable by pre-seeding both clients' encryption
+   * key before the app boots: the post-setup encryption modal that the normal
+   * setup flow goes through deletes and re-uploads a snapshot (a SYNC_IMPORT),
+   * which would route B through the incoming-import gate instead (#9921).
+   */
+  test('genesis-only client joining a server with ordinary ops gets the conflict dialog', async ({
+    browser,
+    baseURL,
+    testRunId,
+  }) => {
+    test.slow();
+    const url = baseURL || 'http://localhost:4242';
+
+    const user = await createTestUser(testRunId);
+    const syncConfig = getSuperSyncConfig(user);
+    const seedCredentials = (page: Page): Promise<void> =>
+      seedSuperSyncCredentials(page, {
+        baseUrl: syncConfig.baseUrl,
+        accessToken: syncConfig.accessToken,
+        encryptKey: syncConfig.password!,
+      });
+    const isFullStateOp = (op: { opType: string }): boolean =>
+      ['SYNC_IMPORT', 'BACKUP_IMPORT', 'REPAIR'].includes(op.opType);
+
+    let clientA: SimulatedE2EClient | null = null;
+    let clientB: {
+      context: Awaited<ReturnType<typeof browser.newContext>>;
+      page: Awaited<ReturnType<typeof browser.newPage>>;
+    } | null = null;
+
+    try {
+      // === Client A: fresh client, key pre-seeded, uploads ordinary ops only ===
+      console.log('[Test] Creating fresh Client A with pre-seeded encryption key...');
+      clientA = await createSimulatedClient(browser, url, 'A', testRunId, {
+        seedBeforeBoot: seedCredentials,
+      });
+      await clientA.workView.waitForTaskList();
+      await clientA.workView.addTask('Task A1 - Fresh');
+      await clientA.workView.addTask('Task A2 - Fresh');
+      await waitForStatePersistence(clientA.page);
+
+      await clientA.sync.setupSuperSync({ ...syncConfig, waitForInitialSync: false });
+      await clientA.sync.syncAndWait();
+      console.log('[Test] Client A: ordinary ops uploaded');
+
+      // Precondition of the silent path: A left no full-state op behind. If the
+      // harness ever re-introduces the snapshot re-upload, fail here rather than
+      // silently testing the incoming-import gate instead.
+      const opsA = await getLocalOpLogSummary(clientA.page);
+      expect(opsA.some((op) => op.entityType === 'TASK' && op.isSynced)).toBe(true);
+      expect(opsA.filter(isFullStateOp)).toEqual([]);
+
+      // === Client B: legacy migration, genesis op only ===
+      console.log(
+        '[Test] Creating Client B with legacy data (no post-migration edits)...',
+      );
+      clientB = await createLegacyMigratedClient(
+        browser,
+        url,
+        legacyDataClientB.data,
+        'B',
+        { seedBeforeBoot: seedCredentials },
+      );
+      const syncPageB = new SuperSyncPage(clientB.page);
+      const workViewB = new WorkViewPage(clientB.page);
+
+      const sidenavB = clientB.page.locator('magic-side-nav');
+      await sidenavB.locator('nav-item', { hasText: 'Client B Project' }).click();
+      await clientB.page.waitForLoadState('networkidle').catch(() => {});
+      await workViewB.waitForTaskList();
+      await expect(clientB.page.locator('task', { hasText: 'Task B1' })).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Precondition: B's history starts with its own genesis op and holds no
+      // full-state op — the shape the #9863 fix keys on.
+      const opsB = await getLocalOpLogSummary(clientB.page);
+      expect(opsB[0]?.entityType).toBe('MIGRATION');
+      expect(opsB.filter(isFullStateOp)).toEqual([]);
+
+      // Deliberately NO task added after migration (unlike the other flows).
+      // The key is already seeded, so hand the page object no password: that
+      // keeps its encryption-setup handling (which re-triggers sync) out of the
+      // way while the conflict dialog is up.
+      console.log(
+        '[Test] Client B setting up sync — expecting the local-data conflict dialog',
+      );
+      await syncPageB.setupSuperSync({
+        baseUrl: syncConfig.baseUrl,
+        accessToken: syncConfig.accessToken,
+        waitForInitialSync: false,
+      });
+
+      // The regression pin: the setup sync must prompt instead of silently
+      // reporting IN_SYNC with B's migrated tasks stranded.
+      await expect(syncPageB.conflictDialog).toBeVisible({ timeout: 30000 });
+      await syncPageB.resolveConflictDialog('local');
+      await syncPageB.syncAndWait({ useLocal: true });
+      console.log('[Test] Client B: kept local data via SYNC_IMPORT');
+
+      await sidenavB.locator('nav-item', { hasText: 'Client B Project' }).click();
+      await clientB.page.waitForLoadState('networkidle').catch(() => {});
+      await workViewB.waitForTaskList();
+      await expect(clientB.page.locator('task', { hasText: 'Task B1' })).toBeVisible();
+      await expect(clientB.page.locator('task', { hasText: 'Task B2' })).toBeVisible();
+
+      // The genesis op is settled locally without ever being uploaded (#9921).
+      const opsBAfter = await getLocalOpLogSummary(clientB.page);
+      expect(opsBAfter.find((op) => op.entityType === 'MIGRATION')?.isSynced).toBe(true);
+      expect(opsBAfter.some(isFullStateOp)).toBe(true);
+
+      // === Client A syncs and adopts B's full state ===
+      console.log('[Test] Client A syncing...');
+      await clientA.sync.syncAndWait();
+
+      const sidenavA = clientA.page.locator('magic-side-nav');
+      await expect(
+        sidenavA.locator('nav-item', { hasText: 'Client B Project' }),
+      ).toBeVisible({ timeout: 10000 });
+      await sidenavA.locator('nav-item', { hasText: 'Client B Project' }).click();
+      await clientA.page.waitForLoadState('networkidle').catch(() => {});
+      await clientA.workView.waitForTaskList();
+      await expect(clientA.page.locator('task', { hasText: 'Task B1' })).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(
+        clientA.page.locator('task', { hasText: 'Task A1 - Fresh' }),
+      ).not.toBeVisible();
+
+      // B's genesis op never reached the server, so A never downloaded one.
+      const opsAAfter = await getLocalOpLogSummary(clientA.page);
+      expect(opsAAfter.filter((op) => op.entityType === 'MIGRATION')).toEqual([]);
+      console.log("[Test] SUCCESS: silent join path prompts and B's state reaches A");
+    } finally {
+      if (clientA) await closeClient(clientA).catch(() => {});
       if (clientB) await closeLegacyClient(clientB).catch(() => {});
     }
   });

--- a/e2e/tests/sync/supersync-legacy-migration-sync.spec.ts
+++ b/e2e/tests/sync/supersync-legacy-migration-sync.spec.ts
@@ -9,6 +9,7 @@ import {
   createTestUser,
   getLocalOpLogSummary,
   getSuperSyncConfig,
+  isFullStateOpType,
   seedSuperSyncCredentials,
   type SimulatedE2EClient,
 } from '../../utils/supersync-helpers';
@@ -485,7 +486,7 @@ test.describe('@supersync @migration SuperSync Legacy Migration Sync', () => {
         encryptKey: syncConfig.password!,
       });
     const isFullStateOp = (op: { opType: string }): boolean =>
-      ['SYNC_IMPORT', 'BACKUP_IMPORT', 'REPAIR'].includes(op.opType);
+      isFullStateOpType(op.opType);
 
     let clientA: SimulatedE2EClient | null = null;
     let clientB: {
@@ -569,7 +570,8 @@ test.describe('@supersync @migration SuperSync Legacy Migration Sync', () => {
       await expect(clientB.page.locator('task', { hasText: 'Task B1' })).toBeVisible();
       await expect(clientB.page.locator('task', { hasText: 'Task B2' })).toBeVisible();
 
-      // The genesis op is settled locally without ever being uploaded (#9921).
+      // B's state now ships as a SYNC_IMPORT, which settles every earlier op
+      // including the genesis (the no-upload rule itself is unit-tested).
       const opsBAfter = await getLocalOpLogSummary(clientB.page);
       expect(opsBAfter.find((op) => op.entityType === 'MIGRATION')?.isSynced).toBe(true);
       expect(opsBAfter.some(isFullStateOp)).toBe(true);
@@ -592,7 +594,7 @@ test.describe('@supersync @migration SuperSync Legacy Migration Sync', () => {
         clientA.page.locator('task', { hasText: 'Task A1 - Fresh' }),
       ).not.toBeVisible();
 
-      // B's genesis op never reached the server, so A never downloaded one.
+      // A adopted B's import and never received a genesis op from B.
       const opsAAfter = await getLocalOpLogSummary(clientA.page);
       expect(opsAAfter.filter((op) => op.entityType === 'MIGRATION')).toEqual([]);
       console.log("[Test] SUCCESS: silent join path prompts and B's state reaches A");

--- a/e2e/utils/legacy-migration-helpers.ts
+++ b/e2e/utils/legacy-migration-helpers.ts
@@ -111,12 +111,16 @@ export const seedLegacyDatabase = async (
  * @param baseURL - App base URL (e.g., http://localhost:4242)
  * @param legacyData - Legacy data to seed (the 'data' property from backup JSON)
  * @param clientName - Human-readable name for debugging (e.g., "A", "B")
+ * @param options.seedBeforeBoot - Extra seeding that runs in the same JS-blocked
+ *   phase as the legacy database (e.g. `seedSuperSyncCredentials`), before the
+ *   reload that triggers the migration.
  */
 export const createLegacyMigratedClient = async (
   browser: Browser,
   baseURL: string,
   legacyData: Record<string, unknown>,
   clientName: string,
+  options: { seedBeforeBoot?: (page: Page) => Promise<void> } = {},
 ): Promise<{ context: BrowserContext; page: Page }> => {
   const effectiveBaseURL = baseURL || 'http://localhost:4242';
 
@@ -150,6 +154,10 @@ export const createLegacyMigratedClient = async (
   // Seed the legacy 'pf' database
   await seedLegacyDatabase(page, legacyData);
   console.log(`[Legacy Client ${clientName}] Legacy database seeded`);
+  if (options.seedBeforeBoot) {
+    await options.seedBeforeBoot(page);
+    console.log(`[Legacy Client ${clientName}] Extra pre-boot seed applied`);
+  }
 
   // Unblock JS so app can load
   await page.unroute('**/*.js');

--- a/e2e/utils/supersync-helpers.ts
+++ b/e2e/utils/supersync-helpers.ts
@@ -272,10 +272,16 @@ export const seedSuperSyncCredentials = async (
   );
 };
 
+/** Full-state op types (mirrors FULL_STATE_OP_TYPES in the app). */
+export const isFullStateOpType = (opType: string): boolean =>
+  ['SYNC_IMPORT', 'BACKUP_IMPORT', 'REPAIR'].includes(opType);
+
 /**
  * Summary of every entry in this client's local op log (`SUP_OPS`/`ops`).
  * Entries are stored in the compact format, where `o` is the opType and `e`
- * the entityType — the same string values as the full format.
+ * the entityType — the same string values as the full format. Call it only
+ * after the app has booted (the DB is opened without a version and would
+ * otherwise be created empty).
  */
 export const getLocalOpLogSummary = async (
   page: Page,

--- a/e2e/utils/supersync-helpers.ts
+++ b/e2e/utils/supersync-helpers.ts
@@ -226,6 +226,92 @@ export const getSuperSyncConfig = (user: TestUser): SuperSyncConfig => {
 };
 
 /**
+ * Seed the SuperSync provider's private config straight into the `sup-sync`
+ * credentials database, the way `seedLegacyDatabase` seeds `pf`.
+ *
+ * Must run BEFORE the app boots (JS blocked): the credential store caches the
+ * config in memory once loaded. With `encryptKey` already present, the config
+ * dialog's Save keeps it (SuperSync never takes the key from the form) and the
+ * post-setup encryption modal is skipped — so the setup sync uploads plain
+ * ordinary ops and no snapshot is deleted and re-uploaded as a SYNC_IMPORT.
+ * That is the only way the harness can leave a server holding ordinary ops and
+ * no full-state op (#9921).
+ */
+export const seedSuperSyncCredentials = async (
+  page: Page,
+  cfg: { baseUrl: string; accessToken: string; encryptKey: string },
+): Promise<void> => {
+  await page.evaluate(
+    async (privateCfg) =>
+      new Promise<void>((resolve, reject) => {
+        // Mirrors SyncCredentialStore: db 'sup-sync' v1, out-of-line-key store
+        // 'credentials', key PRIVATE_CFG_PREFIX + providerId.
+        const request = indexedDB.open('sup-sync', 1);
+        request.onupgradeneeded = (event) => {
+          const db = (event.target as IDBOpenDBRequest).result;
+          if (!db.objectStoreNames.contains('credentials')) {
+            db.createObjectStore('credentials');
+          }
+        };
+        request.onsuccess = (event) => {
+          const db = (event.target as IDBOpenDBRequest).result;
+          const tx = db.transaction('credentials', 'readwrite');
+          tx.objectStore('credentials').put(privateCfg, '__sp_cred_SuperSync');
+          tx.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          tx.onerror = () => {
+            db.close();
+            reject(tx.error);
+          };
+        };
+        request.onerror = () => reject(request.error);
+      }),
+    { ...cfg, isEncryptionEnabled: true },
+  );
+};
+
+/**
+ * Summary of every entry in this client's local op log (`SUP_OPS`/`ops`).
+ * Entries are stored in the compact format, where `o` is the opType and `e`
+ * the entityType — the same string values as the full format.
+ */
+export const getLocalOpLogSummary = async (
+  page: Page,
+): Promise<{ opType: string; entityType: string; isSynced: boolean }[]> =>
+  page.evaluate(async () => {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('SUP_OPS');
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    try {
+      if (!db.objectStoreNames.contains('ops')) {
+        return [];
+      }
+      const entries = await new Promise<
+        {
+          op: { o?: string; e?: string; opType?: string; entityType?: string };
+          syncedAt?: number;
+        }[]
+      >((resolve, reject) => {
+        const tx = db.transaction('ops', 'readonly');
+        const request = tx.objectStore('ops').getAll();
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+      return entries.map((entry) => ({
+        opType: entry.op.o ?? entry.op.opType ?? '',
+        entityType: entry.op.e ?? entry.op.entityType ?? '',
+        isSynced: !!entry.syncedAt,
+      }));
+    } finally {
+      db.close();
+    }
+  });
+
+/**
  * Create a simulated E2E client with its own isolated browser context.
  *
  * Each client has:
@@ -244,9 +330,16 @@ export const createSimulatedClient = async (
   baseURL: string,
   clientName: string,
   testPrefix: string,
-  options: { allowExampleTasks?: boolean } = {},
+  options: {
+    allowExampleTasks?: boolean;
+    /**
+     * Runs on the app origin with all JavaScript blocked, before the app boots
+     * for the first time — for seeding IndexedDB (e.g. seedSuperSyncCredentials).
+     */
+    seedBeforeBoot?: (page: Page) => Promise<void>;
+  } = {},
 ): Promise<SimulatedE2EClient> => {
-  const { allowExampleTasks = false } = options;
+  const { allowExampleTasks = false, seedBeforeBoot } = options;
   // Use provided baseURL or fall back to localhost:4242 (Playwright fixture may be undefined)
   const effectiveBaseURL = baseURL || 'http://localhost:4242';
 
@@ -292,6 +385,15 @@ export const createSimulatedClient = async (
     }
   });
 
+  if (seedBeforeBoot) {
+    // Block JS so the seed lands before the app initializes (the aborted
+    // *.js loads only surface as console noise; the error collector above
+    // listens to pageerror only).
+    await page.route('**/*.js', async (route) => {
+      await route.abort();
+    });
+  }
+
   // Navigate to app with retry for transient ERR_CONNECTION_REFUSED.
   // Under parallel load (many workers × 2-3 browser contexts each), the Angular
   // dev server can temporarily refuse connections. Retrying recovers from this
@@ -319,6 +421,13 @@ export const createSimulatedClient = async (
     }
   }
   if (lastGotoError) throw lastGotoError;
+
+  if (seedBeforeBoot) {
+    console.log(`[Client ${clientName}] Seeding before first boot...`);
+    await seedBeforeBoot(page);
+    await page.unroute('**/*.js');
+    await page.reload({ waitUntil: 'domcontentloaded' });
+  }
 
   await waitForAppReady(page);
 

--- a/src/app/imex/sync/sync-wrapper.service.spec.ts
+++ b/src/app/imex/sync/sync-wrapper.service.spec.ts
@@ -935,6 +935,22 @@ describe('SyncWrapperService', () => {
       expect(mockProviderManager.setLastSyncedProviderId).not.toHaveBeenCalled();
       expect(mockSyncService.uploadPendingOps).not.toHaveBeenCalled();
     });
+
+    it('should skip the upload phase when empty-server seeding created no SYNC_IMPORT (#9921)', async () => {
+      mockSyncService.downloadRemoteOps.and.resolveTo({
+        kind: 'server_migration_skipped',
+      });
+
+      const result = await service.sync();
+
+      expect(result).toBe('HANDLED_ERROR');
+      expect(mockProviderManager.setSyncStatus).toHaveBeenCalledWith(
+        'UNKNOWN_OR_CHANGED',
+      );
+      expect(mockProviderManager.setSyncStatus).not.toHaveBeenCalledWith('IN_SYNC');
+      expect(mockProviderManager.setLastSyncedProviderId).not.toHaveBeenCalled();
+      expect(mockSyncService.uploadPendingOps).not.toHaveBeenCalled();
+    });
   });
 
   describe('_sync() - Sync flow', () => {

--- a/src/app/imex/sync/sync-wrapper.service.ts
+++ b/src/app/imex/sync/sync-wrapper.service.ts
@@ -632,11 +632,17 @@ export class SyncWrapperService {
       this._consecutiveSuperSyncAuthFailures = 0;
       SyncLog.log(`SyncWrapperService: Download complete. kind=${downloadResult.kind}`);
 
-      // If user cancelled the sync import conflict dialog, skip upload entirely.
-      // This keeps the local state unchanged and doesn't push it to the server.
-      // Don't update lastSyncedProvider so the next sync retries with forceFromSeq0.
-      if (downloadResult.kind === 'cancelled') {
-        SyncLog.log('SyncWrapperService: Sync cancelled by user. Skipping upload phase.');
+      // Skip the upload entirely when the user cancelled the sync import conflict
+      // dialog, or when empty-server seeding created no SYNC_IMPORT (#9921, an
+      // upload would strand the pre-op-log / genesis state). Local state stays
+      // unchanged and lastSyncedProvider is not updated, so the next sync retries.
+      if (
+        downloadResult.kind === 'cancelled' ||
+        downloadResult.kind === 'server_migration_skipped'
+      ) {
+        SyncLog.log(
+          `SyncWrapperService: Download ended with ${downloadResult.kind}. Skipping upload phase.`,
+        );
         this._providerManager.setSyncStatus('UNKNOWN_OR_CHANGED');
         return 'HANDLED_ERROR';
       }
@@ -645,16 +651,6 @@ export class SyncWrapperService {
           'SyncWrapperService: Download blocked by an incompatible operation.',
         );
         this._providerManager.setSyncStatus('ERROR');
-        return 'HANDLED_ERROR';
-      }
-      // Empty-server seeding created no SYNC_IMPORT (#9921): uploading now would
-      // accept this client's ordinary ops and silently strand its pre-op-log /
-      // genesis state. Leave everything pending; the next sync re-downloads.
-      if (downloadResult.kind === 'server_migration_skipped') {
-        SyncLog.warn(
-          'SyncWrapperService: Empty-server seeding created no SYNC_IMPORT. Skipping upload phase.',
-        );
-        this._providerManager.setSyncStatus('UNKNOWN_OR_CHANGED');
         return 'HANDLED_ERROR';
       }
 

--- a/src/app/imex/sync/sync-wrapper.service.ts
+++ b/src/app/imex/sync/sync-wrapper.service.ts
@@ -647,6 +647,16 @@ export class SyncWrapperService {
         this._providerManager.setSyncStatus('ERROR');
         return 'HANDLED_ERROR';
       }
+      // Empty-server seeding created no SYNC_IMPORT (#9921): uploading now would
+      // accept this client's ordinary ops and silently strand its pre-op-log /
+      // genesis state. Leave everything pending; the next sync re-downloads.
+      if (downloadResult.kind === 'server_migration_skipped') {
+        SyncLog.warn(
+          'SyncWrapperService: Empty-server seeding created no SYNC_IMPORT. Skipping upload phase.',
+        );
+        this._providerManager.setSyncStatus('UNKNOWN_OR_CHANGED');
+        return 'HANDLED_ERROR';
+      }
 
       // Track the successfully synced provider for switch detection on next sync
       this._providerManager.setLastSyncedProviderId(providerId);

--- a/src/app/op-log/core/operation.types.ts
+++ b/src/app/op-log/core/operation.types.ts
@@ -38,6 +38,20 @@ export const FULL_STATE_OP_TYPES = fullStateOpTypeHelpers.FULL_STATE_OP_TYPES;
 export const isFullStateOpType = fullStateOpTypeHelpers.isFullStateOpType;
 
 /**
+ * Genesis entity types: the MIGRATION (legacy `pf` → op-log) and RECOVERY
+ * (disaster recovery) Batch op that opens a client's log carrying its whole
+ * state. A genesis op is local bookkeeping, not sync history — it replays as a
+ * no-op on every other client, is never counted by `hasSyncedOps()`, and is
+ * never uploaded (#9921). Single source of truth for that classification.
+ */
+export const GENESIS_ENTITY_TYPES: ReadonlySet<EntityType> = new Set<EntityType>([
+  'MIGRATION',
+  'RECOVERY',
+]);
+export const isGenesisEntityType = (entityType: string): boolean =>
+  GENESIS_ENTITY_TYPES.has(entityType as EntityType);
+
+/**
  * Entity type — Super Productivity's domain set, sourced from `@sp/shared-schema`
  * so client and server agree on the union.
  */

--- a/src/app/op-log/core/operation.types.ts
+++ b/src/app/op-log/core/operation.types.ts
@@ -41,10 +41,10 @@ export const isFullStateOpType = fullStateOpTypeHelpers.isFullStateOpType;
  * Genesis entity types: the MIGRATION (legacy `pf` → op-log) and RECOVERY
  * (disaster recovery) Batch op that opens a client's log carrying its whole
  * state. A genesis op is local bookkeeping, not sync history — it replays as a
- * no-op on every other client, is never counted by `hasSyncedOps()`, and is
- * never uploaded (#9921). Single source of truth for that classification.
+ * no-op on every other client, is never counted by `hasSyncedOps()`, and on
+ * API-based providers is never uploaded (#9921). Single source of truth.
  */
-export const GENESIS_ENTITY_TYPES: ReadonlySet<EntityType> = new Set<EntityType>([
+const GENESIS_ENTITY_TYPES: ReadonlySet<EntityType> = new Set<EntityType>([
   'MIGRATION',
   'RECOVERY',
 ]);

--- a/src/app/op-log/core/types/sync-results.types.ts
+++ b/src/app/op-log/core/types/sync-results.types.ts
@@ -289,6 +289,17 @@ export type DownloadOutcome =
       kind: 'server_migration_handled';
     }
   | {
+      /**
+       * Empty-server seeding of a fresh / never-synced genesis client ran but
+       * created no SYNC_IMPORT (server no longer empty, state judged empty,
+       * validation failed, no client id). Nothing shipped the local state, so
+       * the caller must skip this cycle's upload — accepting the client's
+       * ordinary ops would flip hasSyncedOps() and strand that state for good.
+       * The next cycle re-downloads and reaches the conflict branch. (#9921)
+       */
+      kind: 'server_migration_skipped';
+    }
+  | {
       /** No new operations on server. */
       kind: 'no_new_ops';
       allOpClocks?: VectorClock[];

--- a/src/app/op-log/persistence/operation-log-migration.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-migration.service.spec.ts
@@ -31,7 +31,8 @@ describe('OperationLogMigrationService', () => {
   beforeEach(() => {
     mockOpLogStore = jasmine.createSpyObj('OperationLogStoreService', [
       'loadStateCache',
-      'getOpsAfterSeq',
+      'getFirstOpEntry',
+      'countOps',
       'deleteOpsWhere',
       'clearAllOperations',
       'appendOperationAndSnapshot',
@@ -97,7 +98,7 @@ describe('OperationLogMigrationService', () => {
         await service.checkAndMigrate();
 
         expect(mockOpLogStore.loadStateCache).toHaveBeenCalled();
-        expect(mockOpLogStore.getOpsAfterSeq).not.toHaveBeenCalled();
+        expect(mockOpLogStore.getFirstOpEntry).not.toHaveBeenCalled();
       });
     });
 
@@ -107,24 +108,23 @@ describe('OperationLogMigrationService', () => {
       });
 
       it('should skip if Genesis operation exists', async () => {
-        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
-          {
-            seq: 1,
-            op: {
-              id: 'genesis-op',
-              entityType: 'MIGRATION',
-              actionType: '[Migration] Genesis Import' as ActionType,
-              opType: OpType.Batch,
-              clientId: 'client1',
-              vectorClock: { client1: 1 },
-              timestamp: Date.now(),
-              payload: { task: { ids: ['t1'] } },
-              schemaVersion: 1,
-            },
-            appliedAt: Date.now(),
-            source: 'local',
+        mockOpLogStore.getFirstOpEntry.and.resolveTo({
+          seq: 1,
+          op: {
+            id: 'genesis-op',
+            entityType: 'MIGRATION',
+            actionType: '[Migration] Genesis Import' as ActionType,
+            opType: OpType.Batch,
+            clientId: 'client1',
+            vectorClock: { client1: 1 },
+            timestamp: Date.now(),
+            payload: { task: { ids: ['t1'] } },
+            schemaVersion: 1,
           },
-        ]);
+          appliedAt: Date.now(),
+          source: 'local',
+        });
+        mockOpLogStore.countOps.and.resolveTo(1);
 
         await service.checkAndMigrate();
 
@@ -135,24 +135,23 @@ describe('OperationLogMigrationService', () => {
       });
 
       it('should skip if Recovery operation exists', async () => {
-        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
-          {
-            seq: 1,
-            op: {
-              id: 'recovery-op',
-              entityType: 'RECOVERY',
-              actionType: '[Recovery] Data Recovery Import' as ActionType,
-              opType: OpType.Batch,
-              clientId: 'client1',
-              vectorClock: { client1: 1 },
-              timestamp: Date.now(),
-              payload: { task: { ids: ['t1'] } },
-              schemaVersion: 1,
-            },
-            appliedAt: Date.now(),
-            source: 'local',
+        mockOpLogStore.getFirstOpEntry.and.resolveTo({
+          seq: 1,
+          op: {
+            id: 'recovery-op',
+            entityType: 'RECOVERY',
+            actionType: '[Recovery] Data Recovery Import' as ActionType,
+            opType: OpType.Batch,
+            clientId: 'client1',
+            vectorClock: { client1: 1 },
+            timestamp: Date.now(),
+            payload: { task: { ids: ['t1'] } },
+            schemaVersion: 1,
           },
-        ]);
+          appliedAt: Date.now(),
+          source: 'local',
+        });
+        mockOpLogStore.countOps.and.resolveTo(1);
 
         await service.checkAndMigrate();
 
@@ -160,40 +159,23 @@ describe('OperationLogMigrationService', () => {
       });
 
       it('should clear orphan operations when legacy data exists', async () => {
-        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
-          {
-            seq: 1,
-            op: {
-              id: 'orphan-op-1',
-              entityType: 'TASK',
-              actionType: '[Task] Update Task' as ActionType,
-              opType: OpType.Update,
-              clientId: 'client1',
-              vectorClock: { client1: 1 },
-              timestamp: Date.now(),
-              payload: { id: 't1', title: 'Test' },
-              schemaVersion: 1,
-            },
-            appliedAt: Date.now(),
-            source: 'local',
+        mockOpLogStore.getFirstOpEntry.and.resolveTo({
+          seq: 1,
+          op: {
+            id: 'orphan-op-1',
+            entityType: 'TASK',
+            actionType: '[Task] Update Task' as ActionType,
+            opType: OpType.Update,
+            clientId: 'client1',
+            vectorClock: { client1: 1 },
+            timestamp: Date.now(),
+            payload: { id: 't1', title: 'Test' },
+            schemaVersion: 1,
           },
-          {
-            seq: 2,
-            op: {
-              id: 'orphan-op-2',
-              entityType: 'TAG',
-              actionType: '[Tag] Update Tag' as ActionType,
-              opType: OpType.Update,
-              clientId: 'client1',
-              vectorClock: { client1: 2 },
-              timestamp: Date.now(),
-              payload: { id: 'tag1', name: 'Test Tag' },
-              schemaVersion: 1,
-            },
-            appliedAt: Date.now(),
-            source: 'local',
-          },
-        ]);
+          appliedAt: Date.now(),
+          source: 'local',
+        });
+        mockOpLogStore.countOps.and.resolveTo(2);
         mockOpLogStore.clearAllOperations.and.resolveTo();
         // Legacy data exists - orphan ops should be cleared before migration
         mockLegacyPfDb.hasUsableEntityData.and.resolveTo(true);
@@ -211,24 +193,23 @@ describe('OperationLogMigrationService', () => {
       });
 
       it('should NOT clear orphan operations when no legacy data exists (fresh install)', async () => {
-        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
-          {
-            seq: 1,
-            op: {
-              id: 'orphan-op-1',
-              entityType: 'TASK',
-              actionType: '[Task] Update Task' as ActionType,
-              opType: OpType.Update,
-              clientId: 'client1',
-              vectorClock: { client1: 1 },
-              timestamp: Date.now(),
-              payload: { id: 't1', title: 'Test' },
-              schemaVersion: 1,
-            },
-            appliedAt: Date.now(),
-            source: 'local',
+        mockOpLogStore.getFirstOpEntry.and.resolveTo({
+          seq: 1,
+          op: {
+            id: 'orphan-op-1',
+            entityType: 'TASK',
+            actionType: '[Task] Update Task' as ActionType,
+            opType: OpType.Update,
+            clientId: 'client1',
+            vectorClock: { client1: 1 },
+            timestamp: Date.now(),
+            payload: { id: 't1', title: 'Test' },
+            schemaVersion: 1,
           },
-        ]);
+          appliedAt: Date.now(),
+          source: 'local',
+        });
+        mockOpLogStore.countOps.and.resolveTo(1);
         // No legacy data - orphan ops are kept (fresh install scenario)
         mockLegacyPfDb.hasUsableEntityData.and.resolveTo(false);
 
@@ -244,7 +225,7 @@ describe('OperationLogMigrationService', () => {
     describe('when no snapshot and no operations exist (fresh install)', () => {
       beforeEach(() => {
         mockOpLogStore.loadStateCache.and.resolveTo(null);
-        mockOpLogStore.getOpsAfterSeq.and.resolveTo([]);
+        mockOpLogStore.getFirstOpEntry.and.resolveTo(undefined);
         mockLegacyPfDb.hasUsableEntityData.and.resolveTo(false);
       });
 
@@ -252,7 +233,7 @@ describe('OperationLogMigrationService', () => {
         await service.checkAndMigrate();
 
         expect(mockOpLogStore.loadStateCache).toHaveBeenCalled();
-        expect(mockOpLogStore.getOpsAfterSeq).toHaveBeenCalledWith(0);
+        expect(mockOpLogStore.getFirstOpEntry).toHaveBeenCalled();
         expect(mockLegacyPfDb.hasUsableEntityData).toHaveBeenCalled();
         expect(OpLog.normal).toHaveBeenCalledWith(
           jasmine.stringContaining('No legacy data found'),
@@ -263,7 +244,7 @@ describe('OperationLogMigrationService', () => {
     describe('when legacy data exists', () => {
       beforeEach(() => {
         mockOpLogStore.loadStateCache.and.resolveTo(null);
-        mockOpLogStore.getOpsAfterSeq.and.resolveTo([]);
+        mockOpLogStore.getFirstOpEntry.and.resolveTo(undefined);
         mockLegacyPfDb.hasUsableEntityData.and.resolveTo(true);
       });
 
@@ -342,7 +323,7 @@ describe('OperationLogMigrationService', () => {
       beforeEach(() => {
         // Set up pre-conditions: no snapshot, no ops, legacy data exists, lock acquired
         mockOpLogStore.loadStateCache.and.resolveTo(null);
-        mockOpLogStore.getOpsAfterSeq.and.resolveTo([]);
+        mockOpLogStore.getFirstOpEntry.and.resolveTo(undefined);
         mockLegacyPfDb.hasUsableEntityData.and.resolveTo(true);
         mockLegacyPfDb.acquireMigrationLock.and.resolveTo(true);
         mockLegacyPfDb.releaseMigrationLock.and.resolveTo();
@@ -466,7 +447,7 @@ describe('OperationLogMigrationService', () => {
 
       beforeEach(() => {
         mockOpLogStore.loadStateCache.and.resolveTo(null);
-        mockOpLogStore.getOpsAfterSeq.and.resolveTo([]);
+        mockOpLogStore.getFirstOpEntry.and.resolveTo(undefined);
         mockOpLogStore.appendOperationAndSnapshot.and.resolveTo(1);
         mockLegacyPfDb.hasUsableEntityData.and.resolveTo(true);
         mockLegacyPfDb.acquireMigrationLock.and.resolveTo(true);

--- a/src/app/op-log/persistence/operation-log-migration.service.ts
+++ b/src/app/op-log/persistence/operation-log-migration.service.ts
@@ -125,17 +125,17 @@ export class OperationLogMigrationService {
               return false;
             }
 
-            const opCount = await this.opLogStore.countOps();
             if (hasLegacyData) {
+              const orphanCount = await this.opLogStore.countOps();
               OpLog.warn(
-                `OperationLogMigrationService: Found ${opCount} orphan operations. ` +
+                `OperationLogMigrationService: Found ${orphanCount} orphan operations. ` +
                   `Clearing them before legacy migration.`,
               );
               await this.opLogStore.clearAllOperations();
             } else {
               OpLog.normal(
-                `OperationLogMigrationService: Found ${opCount} operations (fresh install). ` +
-                  `Skipping migration - hydrator will replay them.`,
+                'OperationLogMigrationService: Found existing operations (fresh install). ' +
+                  'Skipping migration - hydrator will replay them.',
               );
               return false;
             }

--- a/src/app/op-log/persistence/operation-log-migration.service.ts
+++ b/src/app/op-log/persistence/operation-log-migration.service.ts
@@ -18,7 +18,12 @@ import { download } from '../../util/download';
 import { isDataRepairPossible } from '../validation/is-data-repair-possible.util';
 import { recordCriticalErrorTime } from '../../util/critical-error-signal';
 import { uuidv7 } from '../../util/uuid-v7';
-import { ActionType, Operation, OpType } from '../core/operation.types';
+import {
+  ActionType,
+  isGenesisEntityType,
+  Operation,
+  OpType,
+} from '../core/operation.types';
 import { SINGLETON_ENTITY_ID } from '../core/entity-registry';
 import { CURRENT_SCHEMA_VERSION } from './schema-migration.service';
 import { AppDataComplete, withDefaultModelSlices } from '../model/model-config';
@@ -109,25 +114,27 @@ export class OperationLogMigrationService {
             return false;
           }
 
-          const allOps = await this.opLogStore.getOpsAfterSeq(0);
-          if (allOps.length > 0) {
-            const firstOp = allOps[0].op;
-            if (firstOp.entityType === 'MIGRATION' || firstOp.entityType === 'RECOVERY') {
+          // Only the first row decides; a full-log read here would decode
+          // every op on every boot (#9921).
+          const firstEntry = await this.opLogStore.getFirstOpEntry();
+          if (firstEntry) {
+            if (isGenesisEntityType(firstEntry.op.entityType)) {
               OpLog.normal(
                 'OperationLogMigrationService: Genesis operation found. Skipping migration.',
               );
               return false;
             }
 
+            const opCount = await this.opLogStore.countOps();
             if (hasLegacyData) {
               OpLog.warn(
-                `OperationLogMigrationService: Found ${allOps.length} orphan operations. ` +
+                `OperationLogMigrationService: Found ${opCount} orphan operations. ` +
                   `Clearing them before legacy migration.`,
               );
               await this.opLogStore.clearAllOperations();
             } else {
               OpLog.normal(
-                `OperationLogMigrationService: Found ${allOps.length} operations (fresh install). ` +
+                `OperationLogMigrationService: Found ${opCount} operations (fresh install). ` +
                   `Skipping migration - hydrator will replay them.`,
               );
               return false;

--- a/src/app/op-log/persistence/operation-log-store.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.spec.ts
@@ -760,6 +760,26 @@ describe('OperationLogStoreService', () => {
     });
   });
 
+  describe('getFirstOpEntry', () => {
+    it('should return undefined when no operations exist', async () => {
+      expect(await service.getFirstOpEntry()).toBeUndefined();
+    });
+
+    it('should return the lowest-seq entry, decoded', async () => {
+      const first = createTestOperation({ entityId: 'task1' });
+      const second = createTestOperation({ entityId: 'task2' });
+      const firstSeq = await service.append(first, 'local');
+      await service.append(second, 'local');
+
+      const entry = await service.getFirstOpEntry();
+
+      expect(entry?.seq).toBe(firstSeq);
+      expect(entry?.op.id).toBe(first.id);
+      expect(entry?.op.entityId).toBe('task1');
+      expect(entry?.source).toBe('local');
+    });
+  });
+
   describe('getLatestFullStateOpEntry', () => {
     it('should read latest full-state op via metadata without scanning ops', async () => {
       const oldImport = createTestOperation({

--- a/src/app/op-log/persistence/operation-log-store.service.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.ts
@@ -2083,11 +2083,7 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
     return lastSeq;
   }
 
-  /**
-   * Returns the first (lowest-seq) entry in the log, or undefined when empty.
-   * One early-stopped cursor read like getLastSeq — never decodes the whole
-   * log. Serves the genesis-client checks at boot and at join time (#9921).
-   */
+  /** First (lowest-seq) entry, or undefined when empty. Decodes one row (#9921). */
   async getFirstOpEntry(): Promise<OperationLogEntry | undefined> {
     await this._ensureInit();
     let firstEntry: OperationLogEntry | undefined;
@@ -2115,20 +2111,14 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
   }
 
   /**
-   * Checks if there are any operations that have been synced to the server.
-   * Used to distinguish between:
-   * - Fresh client (only local ops, never synced) → NOT a server migration
-   * - Client that previously synced (has synced ops) → Server migration scenario
-   *
-   * NOTE: Excludes genesis (MIGRATION / RECOVERY) ops from the check. They are
-   * created during local migration from legacy data and don't represent real
-   * sync history with a remote server (see isGenesisEntityType). Including them
-   * would incorrectly trigger server migration when multiple clients with
-   * legacy data join a new sync group.
+   * Whether any op was ever synced with a server: false for a fresh client
+   * (local ops only), true for one that synced before (server-migration case).
+   * Genesis ops (isGenesisEntityType) don't count — they come from the local
+   * legacy migration, and counting them would trigger server migration when
+   * several legacy clients join a new sync group.
    */
   async hasSyncedOps(): Promise<boolean> {
     await this._ensureInit();
-    // Use the bySyncedAt index to find synced ops, but exclude genesis ops
     let foundRealSyncedOp = false;
     await this._adapter.iterate<StoredOperationLogEntry>(
       STORE_NAMES.OPS,

--- a/src/app/op-log/persistence/operation-log-store.service.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.ts
@@ -6,6 +6,7 @@ import {
   OperationLogEntry,
   VectorClock,
   isFullStateOpType,
+  isGenesisEntityType,
   FULL_STATE_OP_TYPES,
 } from '../core/operation.types';
 import { StorageQuotaExceededError } from '../core/errors/sync-errors';
@@ -2083,6 +2084,25 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
   }
 
   /**
+   * Returns the first (lowest-seq) entry in the log, or undefined when empty.
+   * One early-stopped cursor read like getLastSeq — never decodes the whole
+   * log. Serves the genesis-client checks at boot and at join time (#9921).
+   */
+  async getFirstOpEntry(): Promise<OperationLogEntry | undefined> {
+    await this._ensureInit();
+    let firstEntry: OperationLogEntry | undefined;
+    await this._adapter.iterate<StoredOperationLogEntry>(
+      STORE_NAMES.OPS,
+      { mode: 'readonly' },
+      (value) => {
+        firstEntry = decodeStoredEntry(value);
+        return 'stop';
+      },
+    );
+    return firstEntry;
+  }
+
+  /**
    * Returns the total number of operations currently in the op-log store.
    * Backed by the adapter's `count()` — a single native count query (an engine-side
    * key walk on IndexedDB, COUNT(*) on SQLite), milliseconds even at 100k+ ops — so
@@ -2100,15 +2120,15 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
    * - Fresh client (only local ops, never synced) → NOT a server migration
    * - Client that previously synced (has synced ops) → Server migration scenario
    *
-   * NOTE: Excludes MIGRATION and RECOVERY entity types from the check.
-   * These are special ops created during local migration from legacy data and
-   * don't represent real sync history with a remote server. Including them
+   * NOTE: Excludes genesis (MIGRATION / RECOVERY) ops from the check. They are
+   * created during local migration from legacy data and don't represent real
+   * sync history with a remote server (see isGenesisEntityType). Including them
    * would incorrectly trigger server migration when multiple clients with
    * legacy data join a new sync group.
    */
   async hasSyncedOps(): Promise<boolean> {
     await this._ensureInit();
-    // Use the bySyncedAt index to find synced ops, but exclude MIGRATION/RECOVERY
+    // Use the bySyncedAt index to find synced ops, but exclude genesis ops
     let foundRealSyncedOp = false;
     await this._adapter.iterate<StoredOperationLogEntry>(
       STORE_NAMES.OPS,
@@ -2118,8 +2138,7 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
         const op = value.op;
         // Handle both compact format ('e') and full format ('entityType')
         const entityType = isCompactOperation(op) ? op.e : (op as Operation).entityType;
-        // Skip MIGRATION and RECOVERY entity types - they're not real sync history
-        if (entityType !== 'MIGRATION' && entityType !== 'RECOVERY') {
+        if (!isGenesisEntityType(entityType)) {
           foundRealSyncedOp = true;
           return 'stop';
         }

--- a/src/app/op-log/sync/operation-log-sync.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.spec.ts
@@ -136,6 +136,7 @@ describe('OperationLogSyncService', () => {
       'hasSyncedOps',
       'getLatestFullStateOpEntry',
       'getOpsAfterSeq',
+      'getFirstOpEntry',
       'runRemoteStateReplacement',
       'isRawRebuildIncomplete',
       'loadRawRebuildIncomplete',
@@ -148,6 +149,7 @@ describe('OperationLogSyncService', () => {
     opLogStoreSpy.hasSyncedOps.and.resolveTo(true);
     opLogStoreSpy.getLatestFullStateOpEntry.and.resolveTo(undefined);
     opLogStoreSpy.getOpsAfterSeq.and.resolveTo([]);
+    opLogStoreSpy.getFirstOpEntry.and.resolveTo(undefined);
     // 0 = empty store; establishFrontier(0) resets to default-open (#9438).
     opLogStoreSpy.getLastSeq.and.resolveTo(0);
     opLogStoreSpy.getUnsynced.and.resolveTo([]);
@@ -6214,6 +6216,7 @@ describe('OperationLogSyncService', () => {
         failedFileCount: 0,
         latestServerSeq: 0, // Empty server
       });
+      serverMigrationServiceSpy.handleServerMigration.and.resolveTo('sync-import-1');
 
       const mockProvider = {
         supportsOperationSync: true,
@@ -6227,6 +6230,37 @@ describe('OperationLogSyncService', () => {
         { syncImportReason: 'SERVER_MIGRATION' },
       );
       expect(result.kind).toBe('server_migration_handled');
+    });
+
+    it('reports server_migration_skipped and leaves lastServerSeq alone when seeding created no SYNC_IMPORT (#9921)', async () => {
+      stateSnapshotServiceSpy.getStateSnapshot.and.returnValue({
+        task: { ids: ['task-1'] },
+        project: { ids: [INBOX_PROJECT.id] },
+        tag: { ids: [TODAY_TAG.id] },
+        note: { ids: [] },
+      } as any);
+
+      downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+        newOps: [],
+        needsFullStateUpload: false,
+        success: true,
+        providerMode: 'superSyncOps',
+        failedFileCount: 0,
+        latestServerSeq: 0,
+      });
+      // Server no longer empty on the fresh check / validation failed / no client id
+      serverMigrationServiceSpy.handleServerMigration.and.resolveTo(undefined);
+
+      const mockProvider = {
+        supportsOperationSync: true,
+        setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+      } as any;
+
+      const result = await service.downloadRemoteOps(mockProvider);
+
+      expect(serverMigrationServiceSpy.handleServerMigration).toHaveBeenCalled();
+      expect(result.kind).toBe('server_migration_skipped');
+      expect(mockProvider.setLastServerSeq).not.toHaveBeenCalled();
     });
 
     it('should NOT create SYNC_IMPORT when fresh client has no meaningful data on empty server', async () => {
@@ -6382,7 +6416,7 @@ describe('OperationLogSyncService', () => {
       opLogStoreSpy.getLastSeq.and.resolveTo(1);
       opLogStoreSpy.hasSyncedOps.and.resolveTo(false);
       opLogStoreSpy.getLatestFullStateOpEntry.and.resolveTo(undefined);
-      opLogStoreSpy.getOpsAfterSeq.and.resolveTo([genesisEntry]);
+      opLogStoreSpy.getFirstOpEntry.and.resolveTo(genesisEntry);
 
       // The migrated tasks exist in the store (they live only in the genesis payload)
       stateSnapshotServiceSpy.getStateSnapshot.and.returnValue({
@@ -6417,6 +6451,7 @@ describe('OperationLogSyncService', () => {
         failedFileCount: 0,
         latestServerSeq: 0,
       });
+      serverMigrationServiceSpy.handleServerMigration.and.resolveTo('sync-import-1');
       const provider = mockProvider();
 
       const result = await service.downloadRemoteOps(provider);
@@ -6426,6 +6461,24 @@ describe('OperationLogSyncService', () => {
         { syncImportReason: 'SERVER_MIGRATION' },
       );
       expect(result.kind).toBe('server_migration_handled');
+    });
+
+    it('does not report the seeding as handled when no SYNC_IMPORT was created (#9921)', async () => {
+      downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+        newOps: [],
+        needsFullStateUpload: false,
+        success: true,
+        providerMode: 'superSyncOps',
+        failedFileCount: 0,
+        latestServerSeq: 0,
+      });
+      serverMigrationServiceSpy.handleServerMigration.and.resolveTo(undefined);
+      const provider = mockProvider();
+
+      const result = await service.downloadRemoteOps(provider);
+
+      expect(result.kind).toBe('server_migration_skipped');
+      expect(provider.setLastServerSeq).not.toHaveBeenCalled();
     });
 
     it('does not loop once a local full-state op exists', async () => {
@@ -6473,13 +6526,14 @@ describe('OperationLogSyncService', () => {
       await expectAsync(
         service.downloadRemoteOps(mockProvider()),
       ).not.toBeRejectedWithError(LocalDataConflictError);
-      expect(opLogStoreSpy.getOpsAfterSeq).not.toHaveBeenCalled();
+      expect(opLogStoreSpy.getFirstOpEntry).not.toHaveBeenCalled();
     });
 
     it('does not prompt a client whose log starts with an ordinary op', async () => {
-      opLogStoreSpy.getOpsAfterSeq.and.resolveTo([
-        { ...genesisEntry, op: { ...remoteTaskOp, clientId: 'client-A' } },
-      ]);
+      opLogStoreSpy.getFirstOpEntry.and.resolveTo({
+        ...genesisEntry,
+        op: { ...remoteTaskOp, clientId: 'client-A' },
+      });
       downloadServiceSpy.downloadRemoteOps.and.resolveTo({
         newOps: [remoteTaskOp],
         needsFullStateUpload: false,

--- a/src/app/op-log/sync/operation-log-sync.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.spec.ts
@@ -54,6 +54,7 @@ import {
   SyncEpochChangedError,
 } from '../core/errors/sync-errors';
 import { SyncProviderManager } from '../sync-providers/provider-manager.service';
+import { DownloadResultForRejection } from '../core/types/sync-results.types';
 import { SyncHydrationService } from '../persistence/sync-hydration.service';
 import { SyncImportConflictDialogService } from './sync-import-conflict-dialog.service';
 import { StateSnapshotService } from '../backup/state-snapshot.service';
@@ -926,6 +927,40 @@ describe('OperationLogSyncService', () => {
           const result = await service.uploadPendingOps(mockProvider);
 
           expect(result.kind).toBe('cancelled');
+        });
+
+        it('should treat a skipped empty-server seeding in a nested download as a completed no-op download (#9921)', async () => {
+          uploadServiceSpy.uploadPendingOps.and.resolveTo({
+            uploadedCount: 0,
+            piggybackedOps: [],
+            rejectedCount: 1,
+            rejectedOps: [
+              {
+                opId: 'local-op-1',
+                error: 'Concurrent',
+                errorCode: 'CONFLICT_CONCURRENT',
+              },
+            ],
+          });
+          spyOn(service, 'downloadRemoteOps').and.resolveTo({
+            kind: 'server_migration_skipped',
+          });
+          let nestedResult: DownloadResultForRejection | undefined;
+          rejectedOpsHandlerServiceSpy.handleRejectedOps.and.callFake(
+            async (_ops, callback) => {
+              nestedResult = await callback?.();
+              return {
+                kind: 'completed',
+                mergedOpsCreated: 0,
+                permanentRejectionCount: 0,
+              };
+            },
+          );
+
+          const result = await service.uploadPendingOps(mockProvider);
+
+          expect(nestedResult).toEqual({ kind: 'completed', newOpsCount: 0 });
+          expect(result.kind).toBe('completed');
         });
 
         it('should add mergedOpsFromRejection to localWinOpsCreated in result', async () => {

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -1068,14 +1068,11 @@ export class OperationLogSyncService {
             syncProvider,
             { syncImportReason: 'SERVER_MIGRATION' },
           );
+          // No SYNC_IMPORT → nothing shipped the state → skip this cycle's upload
+          // (see DownloadOutcome) so the next download re-evaluates. (#9921)
           if (!createdOpId) {
-            // Nothing shipped the local state. Do not persist lastServerSeq and
-            // do not let the wrapper upload: accepted ordinary ops would flip
-            // hasSyncedOps() and this client would never get a full-state
-            // decision again. The next cycle re-downloads from scratch. (#9921)
             OpLog.warn(
-              'OperationLogSyncService: Empty-server seeding created no SYNC_IMPORT. ' +
-                'Skipping upload this cycle; the next sync re-evaluates.',
+              'OperationLogSyncService: Empty-server seeding created no SYNC_IMPORT.',
             );
             return { kind: 'server_migration_skipped' };
           }

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -541,6 +541,7 @@ export class OperationLogSyncService {
             latestServerSeq,
           };
         case 'server_migration_handled':
+        case 'server_migration_skipped':
           return { kind: 'completed', newOpsCount: 0 };
         case 'cancelled':
           return { kind: 'cancelled' };
@@ -1063,9 +1064,21 @@ export class OperationLogSyncService {
             options?.fenceEpoch,
             'empty-server migration',
           );
-          await this.serverMigrationService.handleServerMigration(syncProvider, {
-            syncImportReason: 'SERVER_MIGRATION',
-          });
+          const createdOpId = await this.serverMigrationService.handleServerMigration(
+            syncProvider,
+            { syncImportReason: 'SERVER_MIGRATION' },
+          );
+          if (!createdOpId) {
+            // Nothing shipped the local state. Do not persist lastServerSeq and
+            // do not let the wrapper upload: accepted ordinary ops would flip
+            // hasSyncedOps() and this client would never get a full-state
+            // decision again. The next cycle re-downloads from scratch. (#9921)
+            OpLog.warn(
+              'OperationLogSyncService: Empty-server seeding created no SYNC_IMPORT. ' +
+                'Skipping upload this cycle; the next sync re-evaluates.',
+            );
+            return { kind: 'server_migration_skipped' };
+          }
           // The SYNC_IMPORT makes the client non-fresh; upload proceeds normally.
           return { kind: 'server_migration_handled' };
         }

--- a/src/app/op-log/sync/operation-log-upload.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.spec.ts
@@ -458,6 +458,45 @@ describe('OperationLogUploadService', () => {
           expect(result.uploadedCount).toBe(1);
         });
 
+        it('keeps the genesis op pending when its own SYNC_IMPORT is dropped on SYNC_IMPORT_EXISTS', async () => {
+          // Two legacy clients seed the same empty server at once: the loser's
+          // import is dropped, and its still-pending genesis op is what makes the
+          // next cycle's incoming-import gate prompt instead of applying the
+          // winner's import silently.
+          const genesis = createGenesisEntry(1, 'MIGRATION');
+          const ownImport: OperationLogEntry = {
+            ...createMockEntry(2, 'my-import', 'client-1'),
+            op: {
+              ...createMockEntry(2, 'my-import', 'client-1').op,
+              actionType: ActionType.LOAD_ALL_DATA,
+              opType: OpType.SyncImport,
+              entityType: 'ALL',
+              entityId: undefined,
+              payload: {
+                task: { ids: [], entities: {} },
+                project: { ids: [], entities: {} },
+                tag: { ids: [], entities: {} },
+                globalConfig: {},
+              },
+            },
+          };
+          mockOpLogStore.getUnsynced.and.resolveTo([genesis, ownImport]);
+          (mockApiProvider as any).uploadSnapshot = jasmine
+            .createSpy('uploadSnapshot')
+            .and.resolveTo({
+              accepted: false,
+              error: 'A SYNC_IMPORT already exists',
+              errorCode: 'SYNC_IMPORT_EXISTS',
+            });
+
+          const result = await service.uploadPendingOps(mockApiProvider);
+
+          expect(mockOpLogStore.deleteOpsWhere).toHaveBeenCalled();
+          expect(mockOpLogStore.markSynced).not.toHaveBeenCalled();
+          expect(mockApiProvider.uploadOps).not.toHaveBeenCalled();
+          expect(result.uploadedCount).toBe(0);
+        });
+
         it('routes the genesis acknowledgement through the deferred-ack path', async () => {
           const genesis = createGenesisEntry(1, 'MIGRATION');
           const regular = createMockEntry(2, 'op-2', 'client-1');

--- a/src/app/op-log/sync/operation-log-upload.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.spec.ts
@@ -370,6 +370,75 @@ describe('OperationLogUploadService', () => {
         expect(mockOpLogStore.markSynced).toHaveBeenCalledWith([1, 2]);
       });
 
+      describe('genesis ops are never uploaded (#9921)', () => {
+        const createGenesisEntry = (
+          seq: number,
+          entityType: 'MIGRATION' | 'RECOVERY',
+        ): OperationLogEntry => {
+          const entry = createMockEntry(seq, `genesis-${seq}`, 'client-1');
+          return {
+            ...entry,
+            op: {
+              ...entry.op,
+              actionType: ActionType.MIGRATION_GENESIS_IMPORT,
+              opType: OpType.Batch,
+              entityType,
+              entityId: '*',
+            },
+          };
+        };
+
+        it('marks genesis ops synced locally and uploads only the ordinary ops', async () => {
+          const genesis = createGenesisEntry(1, 'MIGRATION');
+          const regular = createMockEntry(2, 'op-2', 'client-1');
+          mockOpLogStore.getUnsynced.and.resolveTo([genesis, regular]);
+          mockApiProvider.uploadOps.and.resolveTo({
+            results: [{ opId: 'op-2', accepted: true }],
+            latestSeq: 10,
+            newOps: [],
+          });
+
+          const result = await service.uploadPendingOps(mockApiProvider);
+
+          const uploadedIds = (
+            mockApiProvider.uploadOps.calls.mostRecent().args[0] as { id: string }[]
+          ).map((op) => op.id);
+          expect(uploadedIds).toEqual(['op-2']);
+          expect(mockOpLogStore.markSynced).toHaveBeenCalledWith([1]);
+          expect(mockOpLogStore.markSynced).toHaveBeenCalledWith([2]);
+          expect(result.uploadedCount).toBe(1);
+        });
+
+        it('uploads nothing for a client whose only pending op is a RECOVERY genesis', async () => {
+          mockOpLogStore.getUnsynced.and.resolveTo([createGenesisEntry(1, 'RECOVERY')]);
+
+          const result = await service.uploadPendingOps(mockApiProvider);
+
+          expect(mockApiProvider.uploadOps).not.toHaveBeenCalled();
+          expect(mockOpLogStore.markSynced).toHaveBeenCalledWith([1]);
+          expect(result.uploadedCount).toBe(0);
+        });
+
+        it('routes the genesis acknowledgement through the deferred-ack path', async () => {
+          const genesis = createGenesisEntry(1, 'MIGRATION');
+          const regular = createMockEntry(2, 'op-2', 'client-1');
+          mockOpLogStore.getUnsynced.and.resolveTo([genesis, regular]);
+          mockApiProvider.uploadOps.and.resolveTo({
+            results: [{ opId: 'op-2', accepted: true }],
+            latestSeq: 10,
+            newOps: [],
+          });
+
+          const result = await service.uploadPendingOps(mockApiProvider, {
+            deferAcknowledgement: true,
+          });
+
+          expect(mockOpLogStore.markSynced).not.toHaveBeenCalled();
+          expect(result.selectedPendingOps).toEqual([regular]);
+          expect(result.pendingAcknowledgementSeqs).toEqual([1, 2]);
+        });
+      });
+
       it('should defer acknowledgements and return the exact selected batch for piggyback resolution', async () => {
         const pendingOps = [
           createMockEntry(1, 'op-1', 'client-1'),

--- a/src/app/op-log/sync/operation-log-upload.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.spec.ts
@@ -419,6 +419,45 @@ describe('OperationLogUploadService', () => {
           expect(result.uploadedCount).toBe(0);
         });
 
+        it('leaves the genesis op pending while the mandatory-encryption guard blocks the upload', async () => {
+          // The pending genesis op is what keeps the incoming-import gate armed
+          // until this client can actually upload; acknowledging it before the
+          // guard would let a later remote SYNC_IMPORT replace local state silently.
+          (mockApiProvider as any).isEncryptionMandatory = true;
+          (mockApiProvider as any).getEncryptKey = jasmine
+            .createSpy('getEncryptKey')
+            .and.resolveTo(undefined);
+          mockOpLogStore.getUnsynced.and.resolveTo([
+            createGenesisEntry(1, 'MIGRATION'),
+            createMockEntry(2, 'op-2', 'client-1'),
+          ]);
+
+          const result = await service.uploadPendingOps(mockApiProvider);
+
+          expect(mockApiProvider.uploadOps).not.toHaveBeenCalled();
+          expect(mockOpLogStore.markSynced).not.toHaveBeenCalled();
+          expect(result.encryptionRequiredKeyMissing).toBe(true);
+        });
+
+        it('keeps uploading genesis ops on file-based providers (the ops upload writes the snapshot)', async () => {
+          mockApiProvider.providerMode = 'fileSnapshotOps';
+          mockOpLogStore.getUnsynced.and.resolveTo([createGenesisEntry(1, 'MIGRATION')]);
+          mockApiProvider.uploadOps.and.resolveTo({
+            results: [{ opId: 'genesis-1', accepted: true }],
+            latestSeq: 1,
+            newOps: [],
+          });
+
+          const result = await service.uploadPendingOps(mockApiProvider);
+
+          const uploadedIds = (
+            mockApiProvider.uploadOps.calls.mostRecent().args[0] as { id: string }[]
+          ).map((op) => op.id);
+          expect(uploadedIds).toEqual(['genesis-1']);
+          expect(mockOpLogStore.markSynced).toHaveBeenCalledWith([1]);
+          expect(result.uploadedCount).toBe(1);
+        });
+
         it('routes the genesis acknowledgement through the deferred-ack path', async () => {
           const genesis = createGenesisEntry(1, 'MIGRATION');
           const regular = createMockEntry(2, 'op-2', 'client-1');
@@ -434,7 +473,9 @@ describe('OperationLogUploadService', () => {
           });
 
           expect(mockOpLogStore.markSynced).not.toHaveBeenCalled();
-          expect(result.selectedPendingOps).toEqual([regular]);
+          // The pre-captured snapshot keeps the genesis op so the piggyback
+          // conflict gate still counts it as pending local work this round.
+          expect(result.selectedPendingOps).toEqual([genesis, regular]);
           expect(result.pendingAcknowledgementSeqs).toEqual([1, 2]);
         });
       });

--- a/src/app/op-log/sync/operation-log-upload.service.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.ts
@@ -252,30 +252,14 @@ export class OperationLogUploadService {
       }
 
       // Genesis ops (MIGRATION / RECOVERY) replay as a no-op on every other
-      // client, so on API-based providers sending them only costs server storage
-      // and download time for every later joiner: mark them synced instead. Done
-      // only here, past every abort above — while the upload is still blocked the
-      // pending genesis op is what keeps the incoming-import gate armed. File-
-      // based providers keep uploading them: there the ops upload is what writes
-      // the state snapshot, which a genesis-only client must still do. (#9921)
+      // client, so API-based providers never upload them (acknowledged below once
+      // this round's full-state ops are settled). File-based providers keep
+      // uploading them: there the ops upload is what writes the state snapshot,
+      // which a genesis-only client must still do. (#9921)
       const isGenesisToSkip = (entry: OperationLogEntry): boolean =>
         syncProvider.providerMode !== 'fileSnapshotOps' &&
         isGenesisEntityType(entry.op.entityType);
-      const genesisSeqs = pendingOps.filter(isGenesisToSkip).map((entry) => entry.seq);
-      if (genesisSeqs.length > 0) {
-        OpLog.normal(
-          `OperationLogUploadService: Marking ${genesisSeqs.length} genesis op(s) synced ` +
-            'without uploading them (no receiver on any other client).',
-        );
-        await acknowledge(genesisSeqs);
-      }
       const uploadableOps = pendingOps.filter((entry) => !isGenesisToSkip(entry));
-      if (uploadableOps.length === 0) {
-        OpLog.normal(
-          'OperationLogUploadService: Only genesis ops were pending; nothing to upload.',
-        );
-        return;
-      }
 
       // Separate full-state operations (backup imports, repairs) from regular ops
       // Full-state ops are uploaded via snapshot endpoint for better efficiency
@@ -305,6 +289,7 @@ export class OperationLogUploadService {
       // can order a post-snapshot op BEFORE the full-state op after a clock
       // rollback, which would mark it synced without ever uploading it.
       let lastUploadedFullStateOpSeq: number | undefined;
+      let droppedFullStateOnExists = false;
       for (const entry of fullStateOps) {
         // BACKUP_IMPORT is an explicit restore and intentionally wipes remote
         // history. SYNC_IMPORT only does so when explicitly requested. REPAIR
@@ -354,6 +339,7 @@ export class OperationLogUploadService {
             await this.opLogStore.deleteOpsWhere(
               (logEntry) => logEntry.op.id === entry.op.id,
             );
+            droppedFullStateOnExists = true;
             // Don't count as rejected - this is expected behavior when joining existing group
             continue;
           }
@@ -391,6 +377,25 @@ export class OperationLogUploadService {
 
       if (fullStateUploadBlocked) {
         return;
+      }
+
+      // Settle the skipped genesis ops (see isGenesisToSkip) only now: while the
+      // upload was still blocked above, or when this client's own SYNC_IMPORT was
+      // just dropped in favour of a remote one, the pending genesis op is what
+      // makes the incoming-import gate prompt on the next cycle instead of
+      // silently replacing this client's state. (#9921)
+      const genesisSeqs = pendingOps.filter(isGenesisToSkip).map((entry) => entry.seq);
+      if (genesisSeqs.length > 0 && droppedFullStateOnExists) {
+        OpLog.normal(
+          'OperationLogUploadService: Keeping genesis op(s) pending — the local SYNC_IMPORT ' +
+            'was superseded by a remote one.',
+        );
+      } else if (genesisSeqs.length > 0) {
+        OpLog.normal(
+          `OperationLogUploadService: Marking ${genesisSeqs.length} genesis op(s) synced ` +
+            'without uploading them (no receiver on any other client).',
+        );
+        await acknowledge(genesisSeqs);
       }
 
       // Skip regular ops processing if none exist

--- a/src/app/op-log/sync/operation-log-upload.service.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.ts
@@ -156,8 +156,9 @@ export class OperationLogUploadService {
       // Fix the pending-op set and the file snapshot under the same operation-log
       // boundary. A task-time action applied by reducers while waiting for this
       // lock remains visible to snapshot projection as an in-flight delta.
-      const { pendingOps: allPendingOps, localStateSnapshot } =
-        await this.lockService.request(LOCK_NAMES.OPERATION_LOG, async () => {
+      const { pendingOps, localStateSnapshot } = await this.lockService.request(
+        LOCK_NAMES.OPERATION_LOG,
+        async () => {
           const capturedPendingOps = await this.opLogStore.getUnsynced();
           return {
             pendingOps: capturedPendingOps,
@@ -166,28 +167,7 @@ export class OperationLogUploadService {
                 ? this.stateSnapshotService.getStateSnapshotForOperationLog()
                 : undefined,
           };
-        });
-
-      // Genesis ops (MIGRATION / RECOVERY) carry this client's whole pre-op-log
-      // state but replay as a no-op on every other client, so sending them only
-      // costs server storage and download time for every later joiner. Whatever
-      // that state had to contribute was already decided on the download side
-      // of this cycle, where the op is still pending and counts as local work:
-      // it shipped as a SYNC_IMPORT, or the user chose a side. Mark them synced
-      // locally instead of uploading; hasSyncedOps() ignores them either way.
-      // (#9921)
-      const genesisSeqs = allPendingOps
-        .filter((entry) => isGenesisEntityType(entry.op.entityType))
-        .map((entry) => entry.seq);
-      if (genesisSeqs.length > 0) {
-        OpLog.normal(
-          `OperationLogUploadService: Marking ${genesisSeqs.length} genesis op(s) synced ` +
-            'without uploading them (no receiver on any other client).',
-        );
-        await acknowledge(genesisSeqs);
-      }
-      const pendingOps = allPendingOps.filter(
-        (entry) => !isGenesisEntityType(entry.op.entityType),
+        },
       );
       selectedPendingOps = pendingOps;
 
@@ -271,12 +251,38 @@ export class OperationLogUploadService {
         );
       }
 
+      // Genesis ops (MIGRATION / RECOVERY) replay as a no-op on every other
+      // client, so on API-based providers sending them only costs server storage
+      // and download time for every later joiner: mark them synced instead. Done
+      // only here, past every abort above — while the upload is still blocked the
+      // pending genesis op is what keeps the incoming-import gate armed. File-
+      // based providers keep uploading them: there the ops upload is what writes
+      // the state snapshot, which a genesis-only client must still do. (#9921)
+      const isGenesisToSkip = (entry: OperationLogEntry): boolean =>
+        syncProvider.providerMode !== 'fileSnapshotOps' &&
+        isGenesisEntityType(entry.op.entityType);
+      const genesisSeqs = pendingOps.filter(isGenesisToSkip).map((entry) => entry.seq);
+      if (genesisSeqs.length > 0) {
+        OpLog.normal(
+          `OperationLogUploadService: Marking ${genesisSeqs.length} genesis op(s) synced ` +
+            'without uploading them (no receiver on any other client).',
+        );
+        await acknowledge(genesisSeqs);
+      }
+      const uploadableOps = pendingOps.filter((entry) => !isGenesisToSkip(entry));
+      if (uploadableOps.length === 0) {
+        OpLog.normal(
+          'OperationLogUploadService: Only genesis ops were pending; nothing to upload.',
+        );
+        return;
+      }
+
       // Separate full-state operations (backup imports, repairs) from regular ops
       // Full-state ops are uploaded via snapshot endpoint for better efficiency
-      const fullStateOps = pendingOps.filter((entry) =>
+      const fullStateOps = uploadableOps.filter((entry) =>
         FULL_STATE_OP_TYPES.has(entry.op.opType as OpType),
       );
-      let regularOps = pendingOps.filter(
+      let regularOps = uploadableOps.filter(
         (entry) => !FULL_STATE_OP_TYPES.has(entry.op.opType as OpType),
       );
 

--- a/src/app/op-log/sync/operation-log-upload.service.ts
+++ b/src/app/op-log/sync/operation-log-upload.service.ts
@@ -13,6 +13,7 @@ import {
   extractFullStateFromPayload,
   assertValidFullStatePayload,
   ActionType,
+  isGenesisEntityType,
   isMultiEntityPayload,
 } from '../core/operation.types';
 import { OpLog } from '../../core/log';
@@ -155,9 +156,8 @@ export class OperationLogUploadService {
       // Fix the pending-op set and the file snapshot under the same operation-log
       // boundary. A task-time action applied by reducers while waiting for this
       // lock remains visible to snapshot projection as an in-flight delta.
-      const { pendingOps, localStateSnapshot } = await this.lockService.request(
-        LOCK_NAMES.OPERATION_LOG,
-        async () => {
+      const { pendingOps: allPendingOps, localStateSnapshot } =
+        await this.lockService.request(LOCK_NAMES.OPERATION_LOG, async () => {
           const capturedPendingOps = await this.opLogStore.getUnsynced();
           return {
             pendingOps: capturedPendingOps,
@@ -166,7 +166,28 @@ export class OperationLogUploadService {
                 ? this.stateSnapshotService.getStateSnapshotForOperationLog()
                 : undefined,
           };
-        },
+        });
+
+      // Genesis ops (MIGRATION / RECOVERY) carry this client's whole pre-op-log
+      // state but replay as a no-op on every other client, so sending them only
+      // costs server storage and download time for every later joiner. Whatever
+      // that state had to contribute was already decided on the download side
+      // of this cycle, where the op is still pending and counts as local work:
+      // it shipped as a SYNC_IMPORT, or the user chose a side. Mark them synced
+      // locally instead of uploading; hasSyncedOps() ignores them either way.
+      // (#9921)
+      const genesisSeqs = allPendingOps
+        .filter((entry) => isGenesisEntityType(entry.op.entityType))
+        .map((entry) => entry.seq);
+      if (genesisSeqs.length > 0) {
+        OpLog.normal(
+          `OperationLogUploadService: Marking ${genesisSeqs.length} genesis op(s) synced ` +
+            'without uploading them (no receiver on any other client).',
+        );
+        await acknowledge(genesisSeqs);
+      }
+      const pendingOps = allPendingOps.filter(
+        (entry) => !isGenesisEntityType(entry.op.entityType),
       );
       selectedPendingOps = pendingOps;
 

--- a/src/app/op-log/sync/server-migration.service.spec.ts
+++ b/src/app/op-log/sync/server-migration.service.spec.ts
@@ -441,7 +441,7 @@ describe('ServerMigrationService', () => {
         expect(opLogStoreSpy.append).not.toHaveBeenCalled();
       });
 
-      it('always shows the snack for a user-driven force upload', async () => {
+      it('always shows the snack for a user-driven force upload and does not consume the automatic notice', async () => {
         failValidation();
 
         await service.handleServerMigration(defaultProvider, {
@@ -452,6 +452,27 @@ describe('ServerMigrationService', () => {
           skipServerEmptyCheck: true,
           syncImportReason: 'FORCE_UPLOAD',
         });
+        await service.handleServerMigration(defaultProvider);
+
+        expect(snackServiceSpy.open).toHaveBeenCalledTimes(3);
+      });
+
+      it('reports again when the user confirms a migration to a non-empty server', async () => {
+        failValidation();
+        await service.handleServerMigration(defaultProvider);
+        expect(snackServiceSpy.open).toHaveBeenCalledTimes(1);
+
+        const provider = createMockSyncProvider();
+        (provider.getLastServerSeq as jasmine.Spy).and.returnValue(Promise.resolve(0));
+        (provider.downloadOps as jasmine.Spy).and.returnValue(
+          Promise.resolve({ ops: [], latestSeq: 5, hasMore: false }),
+        );
+        opLogStoreSpy.hasSyncedOps.and.returnValue(Promise.resolve(true));
+        matDialogSpy.open.and.returnValue({
+          afterClosed: () => of(true),
+        } as MatDialogRef<unknown>);
+
+        await service.checkAndHandleMigration(provider);
 
         expect(snackServiceSpy.open).toHaveBeenCalledTimes(2);
       });

--- a/src/app/op-log/sync/server-migration.service.spec.ts
+++ b/src/app/op-log/sync/server-migration.service.spec.ts
@@ -419,6 +419,61 @@ describe('ServerMigrationService', () => {
       );
     });
 
+    describe('validation-failed snack throttling (#9921)', () => {
+      const failValidation = (): void => {
+        validateStateServiceSpy.validateAndRepair.and.resolveTo({
+          isValid: false,
+          wasRepaired: false,
+          error: 'Validation failed',
+        } as any);
+      };
+
+      it('shows the snack once per session for the automatic server-migration path', async () => {
+        failValidation();
+
+        await service.handleServerMigration(defaultProvider);
+        await service.handleServerMigration(defaultProvider);
+        await service.handleServerMigration(defaultProvider, {
+          syncImportReason: 'SERVER_MIGRATION',
+        });
+
+        expect(snackServiceSpy.open).toHaveBeenCalledTimes(1);
+        expect(opLogStoreSpy.append).not.toHaveBeenCalled();
+      });
+
+      it('always shows the snack for a user-driven force upload', async () => {
+        failValidation();
+
+        await service.handleServerMigration(defaultProvider, {
+          skipServerEmptyCheck: true,
+          syncImportReason: 'FORCE_UPLOAD',
+        });
+        await service.handleServerMigration(defaultProvider, {
+          skipServerEmptyCheck: true,
+          syncImportReason: 'FORCE_UPLOAD',
+        });
+
+        expect(snackServiceSpy.open).toHaveBeenCalledTimes(2);
+      });
+
+      it('notifies again once a SYNC_IMPORT was created in between', async () => {
+        failValidation();
+        await service.handleServerMigration(defaultProvider);
+
+        validateStateServiceSpy.validateAndRepair.and.resolveTo({
+          isValid: true,
+          wasRepaired: false,
+        } as any);
+        await service.handleServerMigration(defaultProvider);
+        expect(opLogStoreSpy.append).toHaveBeenCalledTimes(1);
+
+        failValidation();
+        await service.handleServerMigration(defaultProvider);
+
+        expect(snackServiceSpy.open).toHaveBeenCalledTimes(2);
+      });
+    });
+
     it('should use repaired state and dispatch to store if repair occurred', async () => {
       const repairedState = {
         task: {

--- a/src/app/op-log/sync/server-migration.service.ts
+++ b/src/app/op-log/sync/server-migration.service.ts
@@ -84,6 +84,13 @@ export class ServerMigrationService {
   private _matDialog = inject(MatDialog);
   private _userInputWaitState = inject(UserInputWaitStateService);
   private writeFlushService = inject(OperationWriteFlushService);
+  /**
+   * Automatic seeding re-runs on every sync while the local state fails
+   * validation (the client stays blocked rather than stranding its state,
+   * #9921), so the error snack is shown once per session; the not-in-sync
+   * status stays visible. Reset once a SYNC_IMPORT is created again.
+   */
+  private _validationFailureNotified = false;
 
   /**
    * Checks if we're connecting to a new/empty server and handles migration if needed.
@@ -252,10 +259,15 @@ export class ServerMigrationService {
           'ServerMigrationService: Cannot create SYNC_IMPORT - state validation failed.',
           validationResult.error || validationResult.crossModelError,
         );
-        this.snackService.open({
-          type: 'ERROR',
-          msg: T.F.SYNC.S.SERVER_MIGRATION_VALIDATION_FAILED,
-        });
+        // A user-driven force upload always reports; only the automatic path is
+        // throttled (see _validationFailureNotified).
+        if (!isServerMigration || !this._validationFailureNotified) {
+          this.snackService.open({
+            type: 'ERROR',
+            msg: T.F.SYNC.S.SERVER_MIGRATION_VALIDATION_FAILED,
+          });
+        }
+        this._validationFailureNotified = true;
         return;
       }
 
@@ -329,6 +341,7 @@ export class ServerMigrationService {
         'ServerMigrationService: Created SYNC_IMPORT operation for server migration. ' +
           'Will be uploaded immediately via follow-up upload.',
       );
+      this._validationFailureNotified = false;
       return op.id;
     });
   }

--- a/src/app/op-log/sync/server-migration.service.ts
+++ b/src/app/op-log/sync/server-migration.service.ts
@@ -128,6 +128,8 @@ export class ServerMigrationService {
       if (hasSyncedOps) {
         const confirmed = await this._confirmMigrationToNonEmptyServer();
         if (confirmed) {
+          // The user just asked for this explicitly, so a failure must be reported.
+          this._validationFailureNotified = false;
           await this.handleServerMigration(syncProvider, {
             skipServerEmptyCheck: true,
             syncImportReason: 'SERVER_MIGRATION',
@@ -267,7 +269,9 @@ export class ServerMigrationService {
             msg: T.F.SYNC.S.SERVER_MIGRATION_VALIDATION_FAILED,
           });
         }
-        this._validationFailureNotified = true;
+        if (isServerMigration) {
+          this._validationFailureNotified = true;
+        }
         return;
       }
 

--- a/src/app/op-log/sync/sync-local-state.service.spec.ts
+++ b/src/app/op-log/sync/sync-local-state.service.spec.ts
@@ -97,14 +97,6 @@ describe('SyncLocalStateService', () => {
       expect(await service.isNeverSyncedGenesisClient()).toBe(true);
     });
 
-    it('stays true when regular ops were captured after the genesis', async () => {
-      // Post-migration edits ship normally, but the pre-migration state still
-      // lives only inside the genesis payload. Only the first row decides.
-      opLogStoreSpy.getFirstOpEntry.and.resolveTo(migrationGenesis);
-      opLogStoreSpy.getLastSeq.and.resolveTo(2);
-      expect(await service.isNeverSyncedGenesisClient()).toBe(true);
-    });
-
     it('is false once real sync history exists', async () => {
       opLogStoreSpy.hasSyncedOps.and.resolveTo(true);
       expect(await service.isNeverSyncedGenesisClient()).toBe(false);

--- a/src/app/op-log/sync/sync-local-state.service.spec.ts
+++ b/src/app/op-log/sync/sync-local-state.service.spec.ts
@@ -60,7 +60,7 @@ describe('SyncLocalStateService', () => {
       'getLastSeq',
       'hasSyncedOps',
       'getLatestFullStateOpEntry',
-      'getOpsAfterSeq',
+      'getFirstOpEntry',
     ]);
     // Defaults describe a legacy-migrated client that has never synced: the
     // genesis wrote a state cache and one op, nothing else happened since.
@@ -68,7 +68,7 @@ describe('SyncLocalStateService', () => {
     opLogStoreSpy.getLastSeq.and.resolveTo(1);
     opLogStoreSpy.hasSyncedOps.and.resolveTo(false);
     opLogStoreSpy.getLatestFullStateOpEntry.and.resolveTo(undefined);
-    opLogStoreSpy.getOpsAfterSeq.and.resolveTo([migrationGenesis]);
+    opLogStoreSpy.getFirstOpEntry.and.resolveTo(migrationGenesis);
 
     TestBed.configureTestingModule({
       providers: [
@@ -93,43 +93,44 @@ describe('SyncLocalStateService', () => {
     });
 
     it('is true for a RECOVERY genesis as well', async () => {
-      opLogStoreSpy.getOpsAfterSeq.and.resolveTo([recoveryGenesis]);
+      opLogStoreSpy.getFirstOpEntry.and.resolveTo(recoveryGenesis);
       expect(await service.isNeverSyncedGenesisClient()).toBe(true);
     });
 
     it('stays true when regular ops were captured after the genesis', async () => {
       // Post-migration edits ship normally, but the pre-migration state still
-      // lives only inside the genesis payload.
-      opLogStoreSpy.getOpsAfterSeq.and.resolveTo([migrationGenesis, regularOp]);
+      // lives only inside the genesis payload. Only the first row decides.
+      opLogStoreSpy.getFirstOpEntry.and.resolveTo(migrationGenesis);
+      opLogStoreSpy.getLastSeq.and.resolveTo(2);
       expect(await service.isNeverSyncedGenesisClient()).toBe(true);
     });
 
     it('is false once real sync history exists', async () => {
       opLogStoreSpy.hasSyncedOps.and.resolveTo(true);
       expect(await service.isNeverSyncedGenesisClient()).toBe(false);
-      expect(opLogStoreSpy.getOpsAfterSeq).not.toHaveBeenCalled();
+      expect(opLogStoreSpy.getFirstOpEntry).not.toHaveBeenCalled();
     });
 
     it('is false once a local full-state op exists (state already ships as SYNC_IMPORT)', async () => {
       opLogStoreSpy.getLatestFullStateOpEntry.and.resolveTo(syncImport);
       expect(await service.isNeverSyncedGenesisClient()).toBe(false);
-      expect(opLogStoreSpy.getOpsAfterSeq).not.toHaveBeenCalled();
+      expect(opLogStoreSpy.getFirstOpEntry).not.toHaveBeenCalled();
     });
 
     it("is false when the first op is another client's genesis (raw rebuild from server history)", async () => {
-      opLogStoreSpy.getOpsAfterSeq.and.resolveTo([
+      opLogStoreSpy.getFirstOpEntry.and.resolveTo(
         entry('MIGRATION', ActionType.MIGRATION_GENESIS_IMPORT, OpType.Batch, 'remote'),
-      ]);
+      );
       expect(await service.isNeverSyncedGenesisClient()).toBe(false);
     });
 
     it('is false when the first op is a regular op', async () => {
-      opLogStoreSpy.getOpsAfterSeq.and.resolveTo([regularOp]);
+      opLogStoreSpy.getFirstOpEntry.and.resolveTo(regularOp);
       expect(await service.isNeverSyncedGenesisClient()).toBe(false);
     });
 
     it('is false for an empty log', async () => {
-      opLogStoreSpy.getOpsAfterSeq.and.resolveTo([]);
+      opLogStoreSpy.getFirstOpEntry.and.resolveTo(undefined);
       expect(await service.isNeverSyncedGenesisClient()).toBe(false);
     });
   });
@@ -139,7 +140,7 @@ describe('SyncLocalStateService', () => {
       opLogStoreSpy.loadStateCache.and.resolveTo(null);
       opLogStoreSpy.getLastSeq.and.resolveTo(0);
       expect(await service.isFreshOrNeverSyncedGenesisClient([regularOp.op])).toBe(true);
-      expect(opLogStoreSpy.getOpsAfterSeq).not.toHaveBeenCalled();
+      expect(opLogStoreSpy.getFirstOpEntry).not.toHaveBeenCalled();
     });
 
     it('stays true for a wholly fresh client even when a full-state op is incoming', async () => {
@@ -156,11 +157,11 @@ describe('SyncLocalStateService', () => {
       expect(
         await service.isFreshOrNeverSyncedGenesisClient([regularOp.op, syncImport.op]),
       ).toBe(false);
-      expect(opLogStoreSpy.getOpsAfterSeq).not.toHaveBeenCalled();
+      expect(opLogStoreSpy.getFirstOpEntry).not.toHaveBeenCalled();
     });
 
     it('is false for a client with ordinary history', async () => {
-      opLogStoreSpy.getOpsAfterSeq.and.resolveTo([regularOp]);
+      opLogStoreSpy.getFirstOpEntry.and.resolveTo(regularOp);
       expect(await service.isFreshOrNeverSyncedGenesisClient([regularOp.op])).toBe(false);
     });
   });

--- a/src/app/op-log/sync/sync-local-state.service.ts
+++ b/src/app/op-log/sync/sync-local-state.service.ts
@@ -6,18 +6,22 @@ import { OpLog } from '../../core/log';
 import { T } from '../../t.const';
 import { confirmDialog } from '../../util/native-dialogs';
 import { hasMeaningfulStateData } from '../validation/has-meaningful-state-data.util';
-import { isFullStateOpType, Operation, OperationLogEntry } from '../core/operation.types';
+import {
+  isFullStateOpType,
+  isGenesisEntityType,
+  Operation,
+  OperationLogEntry,
+} from '../core/operation.types';
 
 /**
  * Legacy-migration and crash-recovery genesis ops carry this client's entire
- * state as an ordinary Batch op. They upload like any other op but replay as a
- * no-op on every other client, so the state they carry never reaches the server
- * in a form another device can apply. Only this client's own genesis counts: a
- * raw rebuild from server history can start with another device's genesis op.
+ * state as an ordinary Batch op that replays as a no-op on every other client,
+ * so the state they carry never reaches the server in a form another device
+ * can apply. Only this client's own genesis counts: a raw rebuild from server
+ * history (pre-#9921 uploads) can start with another device's genesis op.
  */
 const isOwnGenesisOp = (entry: OperationLogEntry): boolean =>
-  entry.source === 'local' &&
-  (entry.op.entityType === 'MIGRATION' || entry.op.entityType === 'RECOVERY');
+  entry.source === 'local' && isGenesisEntityType(entry.op.entityType);
 
 @Injectable({
   providedIn: 'root',
@@ -56,7 +60,7 @@ export class SyncLocalStateService {
     if (await this.opLogStore.getLatestFullStateOpEntry()) {
       return false;
     }
-    const [firstEntry] = await this.opLogStore.getOpsAfterSeq(0);
+    const firstEntry = await this.opLogStore.getFirstOpEntry();
     return !!firstEntry && isOwnGenesisOp(firstEntry);
   }
 


### PR DESCRIPTION
Follow-ups from the #9863 fix (#9919), kept out of that change to stay
minimal. None is user-visible on its own.

1. Empty-server seeding no longer reports "handled" when nothing was
   created. handleServerMigration() can return undefined (server no longer
   empty on its fresh check, state judged empty, validation failed, no
   client id) and the download branch still returned
   server_migration_handled, so the wrapper uploaded the client's ordinary
   ops, hasSyncedOps() flipped to true and its pre-op-log / genesis state
   was stranded with no further full-state decision. The branch now checks
   the return value and answers a new server_migration_skipped outcome that
   the wrapper treats as "skip upload this cycle" (UNKNOWN_OR_CHANGED); the
   next sync re-downloads and reaches the conflict branch.

2. Genesis ops are no longer uploaded. MIGRATION / RECOVERY Batch ops
   carry the whole local state but replay as a no-op on every other client,
   so they only cost server storage and download time for every later
   joiner. The upload service marks them synced locally and leaves them out
   of the pending set; the download-side decision of the same cycle (which
   still sees the op as pending) is what ships the state as a SYNC_IMPORT.

3. One first-row store primitive and one shared predicate.
   OperationLogStoreService.getFirstOpEntry() is an early-stopped cursor
   read like getLastSeq; isGenesisEntityType() next to isFullStateOpType
   replaces the three hard-coded 'MIGRATION' || 'RECOVERY' literals
   (hasSyncedOps, isNeverSyncedGenesisClient, checkAndMigrate), the latter
   two of which decoded the whole log to look at its first row.

4. E2E coverage of the silent join path. Both clients' SuperSync private
   config (encryption key included) is seeded into the sup-sync credential
   store before the app boots, the way the legacy helper seeds pf, so the
   first client's setup skips the post-setup encryption modal and leaves
   only ordinary ops on the server. The joining legacy client holds nothing
   but its genesis op and must get the local-data conflict dialog. Also
   fixes SuperSyncPage.conflictDialog, which still pointed at the removed
   dialog-conflict-resolution selector.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V7f75cjhrWED3hQhJ7Mhzj