### PR TITLE
🚨 fix(side-nav): run nav item action only once #9872

### DIFF
--- a/src/app/core-ui/magic-side-nav/magic-nav-config.service.ts
+++ b/src/app/core-ui/magic-side-nav/magic-nav-config.service.ts
@@ -356,6 +356,7 @@ export class MagicNavConfigService {
         window.open(item.href, '_blank');
         break;
       case 'action':
+      case 'plugin':
         item.action?.();
         break;
       default:

--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.spec.ts
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.spec.ts
@@ -14,12 +14,19 @@ import { LayoutService } from '../layout/layout.service';
 import { TaskService } from '../../features/tasks/task.service';
 import { DataInitStateService } from '../../core/data-init/data-init-state.service';
 import { ScheduleExternalDragService } from '../../features/schedule/schedule-week/schedule-external-drag.service';
-import { NavConfig } from './magic-side-nav.model';
+import { NavActionItem, NavConfig, NavPluginItem } from './magic-side-nav.model';
 
-describe('MagicSideNavComponent mobile behavior', () => {
+describe('MagicSideNavComponent', () => {
   let fixture: ComponentFixture<MagicSideNavComponent>;
   let isXs: ReturnType<typeof signal<boolean>>;
   let browserMatches: boolean;
+  let navConfigServiceMock: {
+    navConfig: ReturnType<typeof signal<NavConfig>>;
+    areInitialTreesReady: ReturnType<typeof signal<boolean>>;
+    isProjectsExpanded: ReturnType<typeof signal<boolean>>;
+    isTagsExpanded: ReturnType<typeof signal<boolean>>;
+    onNavItemClick: jasmine.Spy;
+  };
 
   const navConfig: NavConfig = {
     items: [],
@@ -36,6 +43,13 @@ describe('MagicSideNavComponent mobile behavior', () => {
   beforeEach(async () => {
     isXs = signal(false);
     browserMatches = false;
+    navConfigServiceMock = {
+      navConfig: signal(navConfig),
+      areInitialTreesReady: signal(false),
+      isProjectsExpanded: signal(false),
+      isTagsExpanded: signal(false),
+      onNavItemClick: jasmine.createSpy('onNavItemClick'),
+    };
     spyOn(window, 'matchMedia').and.callFake(
       () =>
         ({
@@ -50,12 +64,7 @@ describe('MagicSideNavComponent mobile behavior', () => {
       providers: [
         {
           provide: MagicNavConfigService,
-          useValue: {
-            navConfig: signal(navConfig),
-            areInitialTreesReady: signal(false),
-            isProjectsExpanded: signal(false),
-            isTagsExpanded: signal(false),
-          },
+          useValue: navConfigServiceMock,
         },
         {
           provide: LayoutService,
@@ -201,5 +210,42 @@ describe('MagicSideNavComponent mobile behavior', () => {
     );
 
     expect(fixture.componentInstance.showMobileMenuOverlay()).toBe(false);
+  });
+
+  describe('onItemClick', () => {
+    it('dispatches action items to the service without executing them directly', () => {
+      fixture = TestBed.createComponent(MagicSideNavComponent);
+      const action = jasmine.createSpy('action');
+      const item: NavActionItem = {
+        id: 'test-action',
+        label: 'Test action',
+        icon: 'bug_report',
+        type: 'action',
+        action,
+      };
+
+      fixture.componentInstance.onItemClick(item);
+
+      expect(action).not.toHaveBeenCalled();
+      expect(navConfigServiceMock.onNavItemClick).toHaveBeenCalledOnceWith(item);
+    });
+
+    it('still executes plugin actions directly and notifies the service', () => {
+      fixture = TestBed.createComponent(MagicSideNavComponent);
+      const action = jasmine.createSpy('pluginAction');
+      const item: NavPluginItem = {
+        id: 'test-plugin',
+        label: 'Test plugin',
+        icon: 'extension',
+        type: 'plugin',
+        pluginId: 'test-plugin',
+        action,
+      };
+
+      fixture.componentInstance.onItemClick(item);
+
+      expect(action).toHaveBeenCalledTimes(1);
+      expect(navConfigServiceMock.onNavItemClick).toHaveBeenCalledOnceWith(item);
+    });
   });
 });

--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.spec.ts
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.spec.ts
@@ -230,7 +230,7 @@ describe('MagicSideNavComponent', () => {
       expect(navConfigServiceMock.onNavItemClick).toHaveBeenCalledOnceWith(item);
     });
 
-    it('still executes plugin actions directly and notifies the service', () => {
+    it('dispatches plugin items to the service without executing them directly', () => {
       fixture = TestBed.createComponent(MagicSideNavComponent);
       const action = jasmine.createSpy('pluginAction');
       const item: NavPluginItem = {
@@ -244,7 +244,7 @@ describe('MagicSideNavComponent', () => {
 
       fixture.componentInstance.onItemClick(item);
 
-      expect(action).toHaveBeenCalledTimes(1);
+      expect(action).not.toHaveBeenCalled();
       expect(navConfigServiceMock.onNavItemClick).toHaveBeenCalledOnceWith(item);
     });
   });

--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
@@ -390,10 +390,6 @@ export class MagicSideNavComponent implements OnDestroy, AfterViewInit {
       return;
     }
 
-    if (item.type === 'action') {
-      item.action?.();
-    }
-
     if (item.type === 'plugin') {
       item.action?.();
     }

--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
@@ -390,11 +390,7 @@ export class MagicSideNavComponent implements OnDestroy, AfterViewInit {
       return;
     }
 
-    if (item.type === 'plugin') {
-      item.action?.();
-    }
-
-    // Handle via service for actions/hrefs
+    // Single dispatcher for everything but tree items
     this._sideNavConfigService.onNavItemClick(item);
 
     if (this.isMobile()) {


### PR DESCRIPTION
Fixes #9872

## Problem

Clicking Help -> Report a Problem in the side nav opened two identical GitHub tabs. Nav items of type `action` were handled twice: `MagicSideNavComponent.onItemClick` executed `item.action?.()` directly and then also delegated to `MagicNavConfigService.onNavItemClick`, which executes the action again.

## Solution

Remove the direct action call for `action` items and keep `MagicNavConfigService.onNavItemClick` as the single dispatcher. Plugin items still execute their action directly, since the service does not handle them.

Verified manually in the dev build: Report a Problem now opens exactly one tab. Also checked the related `href` items (Get help online, Send feedback): they open a single tab on current master, so no change was needed there.

## Testing

- Added regression coverage verifying that `action` items are delegated without direct execution and `plugin` actions still execute directly exactly once.
- `npx ng test --watch=false --browsers=ChromeHeadless --include=src/app/core-ui/magic-side-nav/magic-side-nav.component.spec.ts` (`8/8 SUCCESS`)
- `npm run checkFile` passed for both changed TypeScript files.

## Type of Change

- [x] Bug fix

## Checklist

- [ ] I have included relevant changes to the documentation/wiki (not applicable: behavior-only bug fix)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format


---

**Maintainer note (added during review):** the fix reaches past the reported issue — `tour-create-task` and `tour-keyboard` (`magic-nav-config.service.ts:317`, `:324`) are `type: 'action'` too, so they were invoking `_startTour` twice per click on master as well.

Commit 6eaade2 was pushed by a maintainer and moves plugin dispatch into `MagicNavConfigService.onNavItemClick`, so every non-`tree` nav item now goes through a single dispatcher. See the review comments for details.
