### PR TITLE
docs(wiki): document the GPU-acceleration escape hatch for Linux launch failures

### DIFF
--- a/docs/wiki/2.01-Downloads and Install.md
+++ b/docs/wiki/2.01-Downloads and Install.md
@@ -98,6 +98,24 @@ This changes the Chromium rendering backend; it does not enable any additional
 idle-detection feature and may give up Wayland-native behavior such as
 fractional scaling or native input-method support.
 
+If the window still never appears, disable GPU acceleration entirely:
+
+```bash
+SP_DISABLE_GPU=1 superproductivity
+```
+
+`SP_ENABLE_GPU=1` forces acceleration back on and takes precedence over
+`SP_DISABLE_GPU`. On Snap and Flatpak the app also does this on its own: when a
+launch never finishes starting up, the next launch runs without GPU
+acceleration and logs the reason. To clear that state by hand, delete
+`.gpu-launch-incomplete` from the user data directory (see [[3.06-User-Data]]).
+
+Note that `Failed to get system egl display`, `MESA-LOADER: failed to open …`
+and `Exiting GPU process due to errors during initialization` on the console
+are not by themselves a failure. Chromium falls back to software rendering and
+the app runs normally, so these messages are only worth reporting if the window
+does not appear.
+
 ### Universal MacOS DMG
 
 A DMG containing both the x86_64 and arm64 files is also [available](https://github.com/super-productivity/super-productivity/releases/latest/download/superProductivity-universal.dmg).


### PR DESCRIPTION
The `SP_DISABLE_GPU` / `SP_ENABLE_GPU` env vars and the Snap/Flatpak
crash-recovery guard added in `electron/gpu-startup-guard.ts` were only
discoverable from source or from buried issue comments. Extend the existing
Wayland note in the downloads page so a user hitting a blank window can
self-serve.

Also record that the ANGLE/MESA console errors are not by themselves a
failure — since 18.2.8 they still appear on installs where the app starts
fine via software rendering, so the window not appearing is the actual
symptom to report. This is the discriminator that made triaging #5252,
#7265 and #7270 harder than it needed to be.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TdhHQvL8LWvkkgvNKWetGp