### PR TITLE
chore(focus-mode): remove unreachable screen-routing code

### DIFF
--- a/src/app/features/focus-mode/focus-mode-overlay/focus-mode-overlay.component.spec.ts
+++ b/src/app/features/focus-mode/focus-mode-overlay/focus-mode-overlay.component.spec.ts
@@ -20,6 +20,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { CdkTrapFocus } from '@angular/cdk/a11y';
 import { By } from '@angular/platform-browser';
 import { BannerComponent } from '../../../core/banner/banner/banner.component';
+import { FocusModeMainComponent } from '../focus-mode-main/focus-mode-main.component';
 
 @Component({
   selector: 'banner',
@@ -27,6 +28,13 @@ import { BannerComponent } from '../../../core/banner/banner/banner.component';
   standalone: true,
 })
 class MockBannerComponent {}
+
+@Component({
+  selector: 'focus-mode-main',
+  template: '',
+  standalone: true,
+})
+class MockFocusModeMainComponent {}
 
 describe('FocusModeOverlayComponent', () => {
   let component: FocusModeOverlayComponent;
@@ -77,8 +85,8 @@ describe('FocusModeOverlayComponent', () => {
         { provide: MatDialog, useValue: mockMatDialog },
       ],
     }).overrideComponent(FocusModeOverlayComponent, {
-      remove: { imports: [BannerComponent] },
-      add: { imports: [MockBannerComponent] },
+      remove: { imports: [BannerComponent, FocusModeMainComponent] },
+      add: { imports: [MockBannerComponent, MockFocusModeMainComponent] },
     });
 
     environmentInjector = TestBed.inject(EnvironmentInjector);
@@ -113,7 +121,7 @@ describe('FocusModeOverlayComponent', () => {
     document.body.appendChild(originButton);
     document.body.classList.add('isMousePrimary');
     originButton.focus();
-    mockFocusModeService.currentScreen.set(FocusScreen.Preparation);
+    mockFocusModeService.currentScreen.set(FocusScreen.Main);
 
     const fixture = TestBed.createComponent(FocusModeOverlayComponent);
     fixture.detectChanges();

--- a/src/app/features/focus-mode/focus-mode-strategies.spec.ts
+++ b/src/app/features/focus-mode/focus-mode-strategies.spec.ts
@@ -6,7 +6,7 @@ import {
   CountdownStrategy,
   FocusModeStrategyFactory,
 } from './focus-mode-strategies';
-import { FocusModeMode, FocusScreen, FOCUS_MODE_DEFAULTS } from './focus-mode.model';
+import { FocusModeMode, FOCUS_MODE_DEFAULTS } from './focus-mode.model';
 import { FocusModeStorageService } from './focus-mode-storage.service';
 
 describe('FocusModeStrategies', () => {
@@ -117,26 +117,6 @@ describe('FocusModeStrategies', () => {
         expect(longBreak).toEqual({
           duration: FOCUS_MODE_DEFAULTS.LONG_BREAK_DURATION,
           isLong: true,
-        });
-      });
-    });
-
-    describe('getNextScreenAfterTaskSelection', () => {
-      it('should go to preparation when not skipping', () => {
-        const result = strategy.getNextScreenAfterTaskSelection(false);
-
-        expect(result).toEqual({
-          screen: FocusScreen.Preparation,
-          duration: 1500000,
-        });
-      });
-
-      it('should go to main screen when skipping preparation', () => {
-        const result = strategy.getNextScreenAfterTaskSelection(true);
-
-        expect(result).toEqual({
-          screen: FocusScreen.Main,
-          duration: 1500000,
         });
       });
     });
@@ -293,26 +273,6 @@ describe('FocusModeStrategies', () => {
         expect(strategy.getBreakDuration(90000)).toBeNull();
       });
     });
-
-    describe('getNextScreenAfterTaskSelection', () => {
-      it('should go to preparation when not skipping', () => {
-        const result = strategy.getNextScreenAfterTaskSelection(false);
-
-        expect(result).toEqual({
-          screen: FocusScreen.Preparation,
-          duration: 0,
-        });
-      });
-
-      it('should go to main screen when skipping preparation', () => {
-        const result = strategy.getNextScreenAfterTaskSelection(true);
-
-        expect(result).toEqual({
-          screen: FocusScreen.Main,
-          duration: 0,
-        });
-      });
-    });
   });
 
   describe('CountdownStrategy', () => {
@@ -357,20 +317,6 @@ describe('FocusModeStrategies', () => {
         const result1 = strategy.getBreakDuration();
 
         expect(result1).toBeNull();
-      });
-    });
-
-    describe('getNextScreenAfterTaskSelection', () => {
-      it('should always go to duration selection', () => {
-        const result1 = strategy.getNextScreenAfterTaskSelection(false);
-        const result2 = strategy.getNextScreenAfterTaskSelection(true);
-
-        expect(result1).toEqual({
-          screen: FocusScreen.DurationSelection,
-        });
-        expect(result2).toEqual({
-          screen: FocusScreen.DurationSelection,
-        });
       });
     });
   });

--- a/src/app/features/focus-mode/focus-mode-strategies.ts
+++ b/src/app/features/focus-mode/focus-mode-strategies.ts
@@ -1,7 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import {
   FocusModeStrategy,
-  FocusScreen,
   FocusModeMode,
   FOCUS_MODE_DEFAULTS,
 } from './focus-mode.model';
@@ -31,18 +30,6 @@ export class PomodoroStrategy implements FocusModeStrategy {
       : (config?.breakDuration ?? FOCUS_MODE_DEFAULTS.SHORT_BREAK_DURATION);
 
     return { duration, isLong };
-  }
-
-  getNextScreenAfterTaskSelection(skipPreparation: boolean): {
-    screen: FocusScreen;
-    duration?: number;
-  } {
-    const duration = this.initialSessionDuration; // Reuse the getter
-
-    return {
-      screen: skipPreparation ? FocusScreen.Main : FocusScreen.Preparation,
-      duration,
-    };
   }
 
   readonly shouldStartBreakAfterSession = true; // Always have breaks in Pomodoro
@@ -105,16 +92,6 @@ export class FlowtimeStrategy implements FocusModeStrategy {
 
     return { duration: breakDuration, isLong: false };
   }
-
-  getNextScreenAfterTaskSelection(skipPreparation: boolean): {
-    screen: FocusScreen;
-    duration?: number;
-  } {
-    return {
-      screen: skipPreparation ? FocusScreen.Main : FocusScreen.Preparation,
-      duration: 0, // Flowtime doesn't have a fixed duration
-    };
-  }
 }
 
 @Injectable({ providedIn: 'root' })
@@ -131,16 +108,6 @@ export class CountdownStrategy implements FocusModeStrategy {
 
   getBreakDuration(): null {
     return null; // No automatic breaks in Countdown mode
-  }
-
-  getNextScreenAfterTaskSelection(skipPreparation: boolean): {
-    screen: FocusScreen;
-    duration?: number;
-  } {
-    // Countdown mode always uses duration selection
-    return {
-      screen: FocusScreen.DurationSelection,
-    };
   }
 }
 

--- a/src/app/features/focus-mode/focus-mode.model.spec.ts
+++ b/src/app/features/focus-mode/focus-mode.model.spec.ts
@@ -148,9 +148,6 @@ describe('FocusModeModel', () => {
 
   describe('FocusScreen enum', () => {
     it('should have all required screens', () => {
-      expect(FocusScreen.TaskSelection).toBe('TaskSelection');
-      expect(FocusScreen.DurationSelection).toBe('DurationSelection');
-      expect(FocusScreen.Preparation).toBe('Preparation');
       expect(FocusScreen.Main).toBe('Main');
       expect(FocusScreen.SessionDone).toBe('SessionDone');
       expect(FocusScreen.Break).toBe('Break');
@@ -197,7 +194,7 @@ describe('FocusModeModel', () => {
 
       const state: FocusModeState = {
         timer,
-        currentScreen: FocusScreen.TaskSelection,
+        currentScreen: FocusScreen.Main,
         mainState: FocusMainUIState.Preparation,
         isOverlayShown: false,
         mode: FocusModeMode.Pomodoro,
@@ -209,7 +206,7 @@ describe('FocusModeModel', () => {
       };
 
       expect(state.timer).toEqual(timer);
-      expect(state.currentScreen).toBe(FocusScreen.TaskSelection);
+      expect(state.currentScreen).toBe(FocusScreen.Main);
       expect(state.mainState).toBe(FocusMainUIState.Preparation);
       expect(state.isOverlayShown).toBe(false);
       expect(state.mode).toBe(FocusModeMode.Pomodoro);

--- a/src/app/features/focus-mode/focus-mode.model.ts
+++ b/src/app/features/focus-mode/focus-mode.model.ts
@@ -16,9 +16,6 @@ export enum FocusMainUIState {
 
 // UI screens enum
 export enum FocusScreen {
-  TaskSelection = 'TaskSelection',
-  DurationSelection = 'DurationSelection',
-  Preparation = 'Preparation',
   Main = 'Main',
   SessionDone = 'SessionDone',
   Break = 'Break',
@@ -61,10 +58,6 @@ export interface FocusModeStrategy {
   readonly shouldStartBreakAfterSession: boolean;
   readonly shouldAutoStartNextSession: boolean;
   getBreakDuration(cycle: number): { duration: number; isLong: boolean } | null;
-  getNextScreenAfterTaskSelection(skipPreparation: boolean): {
-    screen: FocusScreen;
-    duration?: number;
-  };
 }
 
 // Helper functions and type guards for timer


### PR DESCRIPTION
## Problem

Closes #9818.

`FocusModeStrategy.getNextScreenAfterTaskSelection` and the `TaskSelection`, `DurationSelection` and `Preparation` members of `FocusScreen` have had no reachable caller since 31b702c28b deleted the standalone duration-selection and preparation components. The reducer decides screen transitions now and only ever writes `Main`, `SessionDone` and `Break`, so the value the strategies computed was discarded.

## Solution

Removed exactly what the issue lists.

- `getNextScreenAfterTaskSelection` from the `FocusModeStrategy` interface and from `PomodoroStrategy`, `FlowtimeStrategy` and `CountdownStrategy`.
- The three unreachable `FocusScreen` members.
- The assertions in `focus-mode-strategies.spec.ts` and `focus-mode.model.spec.ts` that tested the removed method, deleted rather than rewritten.

`focus-mode.model.spec.ts` also used `FocusScreen.TaskSelection` to build a `FocusModeState` for an unrelated interface assertion. That one is retargeted at `FocusScreen.Main` rather than deleted, since the assertion itself is still worth having.

`FocusModeConfig.isSkipPreparation`, its default, and the non-English `L_SKIP_PREPARATION_SCREEN` entries are untouched.

### One file the issue did not list

`focus-mode-overlay.component.spec.ts` set `currentScreen` to `FocusScreen.Preparation` before rendering. That was load-bearing in a way that is easy to miss. The overlay template is `@if (activePage())` wrapping a `@switch`, so `Preparation` rendered the dialog chrome while matching no branch, which kept every page component out of the fixture. The spec mocks only `BannerComponent`, so the a11y assertions were passing partly because no page component was ever constructed.

Retargeting it to `Main` alone fails.

```
ɵNotFound: NG0201: No provider found for `ScannedActionsSubject`.
Path: IssueService -> JiraCommonInterfacesService -> JiraApiService
      -> SnackService -> InjectionToken LOCAL_ACTIONS -> Actions
```

So it selects `Main` with `FocusModeMainComponent` mocked out, following the pattern the spec already uses for `BannerComponent`. The assertions are unchanged. Happy to drop the mock and leave one `FocusScreen` member alive instead if you would rather not grow that spec, but this seemed the smaller of the two.

## Type of Change

- [x] Refactoring

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). (nothing user-facing to document)
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable) (deletion only, no new behaviour to cover)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Verifying

No behaviour change is intended and none is expected, so the evidence is that nothing moved.

- Full suite 14695 passing, 0 failing, and 14681 on the `America/Los_Angeles` run.
- `npm run lint` clean, 0 errors. The 83 warnings are pre-existing and none are in the changed files.
- Focus mode specs 559 passing, down from 564. That is exactly the 5 deleted assertions and nothing else.
- Focus mode e2e 33/33 (`e2e/tests/focus-mode/`, `focus-mode-feature.spec.ts`, `focus-mode-break.spec.ts`), which covers starting a session in Pomodoro and Countdown, the break flow and session completion.

Also checked before removing the members, since a stored value would have made this unsafe. Focus mode writes only `FOCUS_MODE_MODE` and `LAST_COUNTDOWN_DURATION` to localStorage, and `grep -rn "focus-mode" src/app/pfapi/` is empty, so `currentScreen` is neither persisted nor synced and no removed member can arrive from disk.
