### PR TITLE
fix(sync): protect archive-only legacy data at join time, report seeding outcomes honestly #9932

### DIFF
--- a/docs/sync-and-op-log/operation-log-architecture.md
+++ b/docs/sync-and-op-log/operation-log-architecture.md
@@ -349,6 +349,29 @@ providers keep uploading it: there the ops upload is what writes the state
 snapshot. Servers may still hold genesis ops uploaded by older clients;
 receivers apply them as no-ops as before.
 
+Both join-time decisions are gated on `SyncLocalStateService.hasMeaningfulStoreData`,
+which uses `hasAnyUserData` — `hasMeaningfulStateData` widened with archives, live
+time tracking and repeat configs, since a legacy client's work can be entirely
+archived. Archived tasks and flushed time tracking live only in IndexedDB and the
+synchronous store snapshot substitutes an empty archive, so the gate falls back to
+the archive-inclusive snapshot when the narrow check finds nothing (#9932).
+Everything it counts is strictly non-default, keeping it a subset of the seeding's
+own check (`hasServerMigrationStateData`).
+
+The wider notion is deliberately confined to that gate. `hasMeaningfulStateData`
+itself stays narrow because `hasNothingWorthUploading` consumes it in the refusing
+direction (#9256), where over-reporting "has data" would let a device holding
+nothing overwrite the server — time tracked against onboarding example tasks being
+exactly such a false positive.
+`ServerMigrationService.handleServerMigration` reports `created` /
+`reused_pending` / `skipped` (with a reason). On the server-reset branch only a
+genuine failure to ship existing state — validation failed, or no client id —
+answers `server_migration_skipped`, so the upload waits for the next cycle
+instead of settling the client onto a server without its base state. A state
+judged empty has nothing to ship, and a server that is no longer empty has been
+seeded by someone else; both continue with the ordinary upload, because blocking
+either would strand the cycle with the client's ops still pending.
+
 ## A.4 Compaction
 
 ### Purpose

--- a/e2e/tests/sync/supersync-legacy-migration-sync.spec.ts
+++ b/e2e/tests/sync/supersync-legacy-migration-sync.spec.ts
@@ -7,6 +7,7 @@ import {
   closeClient,
   createSimulatedClient,
   createTestUser,
+  getArchiveYoungTaskIds,
   getLocalOpLogSummary,
   getSuperSyncConfig,
   isFullStateOpType,
@@ -16,6 +17,7 @@ import {
 import {
   createLegacyMigratedClient,
   closeLegacyClient,
+  toArchiveOnlyLegacyData,
 } from '../../utils/legacy-migration-helpers';
 
 // Import fixtures
@@ -605,6 +607,98 @@ test.describe('@supersync @migration SuperSync Legacy Migration Sync', () => {
   });
 
   /**
+   * Test: archive-only legacy client joins a server that holds ordinary ops (#9932)
+   *
+   * Same setup as the genesis-only test above, but Client B's legacy data holds
+   * only an archived task: its NgRx store reads as the default state and the
+   * archive lives only in IndexedDB. Before #9932 the fresh-client gate judged
+   * B as having nothing to protect and applied A's ops silently, stranding the
+   * archive on B. Expected now: the conflict dialog, and "Keep local" ships the
+   * archive as a SYNC_IMPORT that A adopts.
+   */
+  test('archive-only legacy client joining a server with ordinary ops gets the conflict dialog', async ({
+    browser,
+    baseURL,
+    testRunId,
+  }) => {
+    test.slow();
+    const url = baseURL || 'http://localhost:4242';
+
+    const user = await createTestUser(testRunId);
+    const syncConfig = getSuperSyncConfig(user);
+    const seedCredentials = (page: Page): Promise<void> =>
+      seedSuperSyncCredentials(page, {
+        baseUrl: syncConfig.baseUrl,
+        accessToken: syncConfig.accessToken,
+        encryptKey: syncConfig.password!,
+      });
+    const isFullStateOp = (op: { opType: string }): boolean =>
+      isFullStateOpType(op.opType);
+    const legacyData = toArchiveOnlyLegacyData(legacyDataClientB.data);
+    const ARCHIVED_TASK_ID = legacyDataClientB.data.archiveYoung.task.ids[0];
+
+    let clientA: SimulatedE2EClient | null = null;
+    let clientB: {
+      context: Awaited<ReturnType<typeof browser.newContext>>;
+      page: Awaited<ReturnType<typeof browser.newPage>>;
+    } | null = null;
+
+    try {
+      // === Client A: fresh client, key pre-seeded, uploads ordinary ops only ===
+      clientA = await createSimulatedClient(browser, url, 'A', testRunId, {
+        seedBeforeBoot: seedCredentials,
+      });
+      await clientA.workView.waitForTaskList();
+      await clientA.workView.addTask('Task A1 - Fresh');
+      await waitForStatePersistence(clientA.page);
+      await clientA.sync.setupSuperSync({ ...syncConfig, waitForInitialSync: false });
+      await clientA.sync.syncAndWait();
+      const opsA = await getLocalOpLogSummary(clientA.page);
+      expect(opsA.some((op) => op.entityType === 'TASK' && op.isSynced)).toBe(true);
+      expect(opsA.filter(isFullStateOp)).toEqual([]);
+
+      // === Client B: legacy migration, archived task only ===
+      clientB = await createLegacyMigratedClient(browser, url, legacyData, 'B', {
+        seedBeforeBoot: seedCredentials,
+      });
+      const syncPageB = new SuperSyncPage(clientB.page);
+      await new WorkViewPage(clientB.page).waitForTaskList();
+      await expect(clientB.page.locator('task')).toHaveCount(0);
+      expect(await getArchiveYoungTaskIds(clientB.page)).toContain(ARCHIVED_TASK_ID);
+      const opsB = await getLocalOpLogSummary(clientB.page);
+      expect(opsB[0]?.entityType).toBe('MIGRATION');
+      expect(opsB.filter(isFullStateOp)).toEqual([]);
+
+      await syncPageB.setupSuperSync({
+        baseUrl: syncConfig.baseUrl,
+        accessToken: syncConfig.accessToken,
+        waitForInitialSync: false,
+      });
+
+      // The regression pin: an archive-only store prompts like one with active tasks.
+      await expect(syncPageB.conflictDialog).toBeVisible({ timeout: 30000 });
+      await syncPageB.resolveConflictDialog('local');
+      await syncPageB.syncAndWait({ useLocal: true });
+      const opsBAfter = await getLocalOpLogSummary(clientB.page);
+      expect(opsBAfter.some(isFullStateOp)).toBe(true);
+      expect(opsBAfter.find((op) => op.entityType === 'MIGRATION')?.isSynced).toBe(true);
+
+      // === Client A adopts B's full state, archive included ===
+      await clientA.sync.syncAndWait();
+      await expect
+        .poll(() => getArchiveYoungTaskIds(clientA!.page), { timeout: 15000 })
+        .toContain(ARCHIVED_TASK_ID);
+      await clientA.workView.waitForTaskList();
+      await expect(
+        clientA.page.locator('task', { hasText: 'Task A1 - Fresh' }),
+      ).not.toBeVisible();
+    } finally {
+      if (clientA) await closeClient(clientA).catch(() => {});
+      if (clientB) await closeLegacyClient(clientB).catch(() => {});
+    }
+  });
+
+  /**
    * Test: Archive data is preserved after migration + sync
    *
    * Verifies that archived tasks from legacy data survive the migration
@@ -693,32 +787,7 @@ test.describe('@supersync @migration SuperSync Legacy Migration Sync', () => {
       console.log('[Test] Client B: Active tasks verified');
 
       // Verify archive data via IndexedDB (archived tasks aren't visible in UI by default)
-      const archiveData = await pageB.evaluate(async () => {
-        return new Promise((resolve, reject) => {
-          const dbRequest = indexedDB.open('SUP_OPS');
-          dbRequest.onsuccess = (event) => {
-            const db = (event.target as IDBOpenDBRequest).result;
-            const tx = db.transaction('archive_young', 'readonly');
-            const store = tx.objectStore('archive_young');
-            const getReq = store.get('current');
-            getReq.onsuccess = () => {
-              db.close();
-              resolve(getReq.result?.data || null);
-            };
-            getReq.onerror = () => {
-              db.close();
-              reject(getReq.error);
-            };
-          };
-          dbRequest.onerror = () => reject(dbRequest.error);
-        });
-      });
-
-      // Verify archive contains the archived task from Client A
-      expect(archiveData).not.toBeNull();
-      const archiveTaskIds = (archiveData as { task?: { ids?: string[] } })?.task?.ids;
-      expect(archiveTaskIds).toBeDefined();
-      expect(archiveTaskIds).toContain('archived-a');
+      expect(await getArchiveYoungTaskIds(pageB)).toContain('archived-a');
       console.log('[Test] SUCCESS: Archive data preserved after migration + sync');
     } finally {
       if (clientA) await closeLegacyClient(clientA).catch(() => {});

--- a/e2e/utils/legacy-migration-helpers.ts
+++ b/e2e/utils/legacy-migration-helpers.ts
@@ -50,6 +50,46 @@ export const readMigratedState = async <T extends Record<string, unknown>>(
   ) as Promise<T>;
 
 /**
+ * Strip a legacy fixture down to its archive: no active tasks, only the INBOX
+ * project and the TODAY tag, archived tasks re-homed to INBOX. Models a legacy
+ * user whose every task was archived before sync was set up (#9932).
+ */
+export const toArchiveOnlyLegacyData = (
+  data: Record<string, unknown>,
+): Record<string, unknown> => {
+  const entityIds = (slice: unknown): string[] =>
+    ((slice as { ids?: string[] })?.ids ?? []).slice();
+  const pick = (slice: unknown, keep: string[]): unknown => {
+    const entities = (slice as { entities: Record<string, unknown> }).entities;
+    return {
+      ids: keep,
+      entities: Object.fromEntries(keep.map((id) => [id, entities[id]])),
+    };
+  };
+  const archiveYoung = data.archiveYoung as {
+    task: { entities: Record<string, object> };
+  };
+  return {
+    ...data,
+    task: { ...(data.task as object), ids: [], entities: {} },
+    project: pick(data.project, ['INBOX_PROJECT']),
+    tag: pick(data.tag, ['TODAY']),
+    archiveYoung: {
+      ...archiveYoung,
+      task: {
+        ids: entityIds(archiveYoung.task),
+        entities: Object.fromEntries(
+          Object.entries(archiveYoung.task.entities).map(([id, task]) => [
+            id,
+            { ...task, projectId: 'INBOX_PROJECT', tagIds: [] },
+          ]),
+        ),
+      },
+    },
+  };
+};
+
+/**
  * Seed the legacy 'pf' IndexedDB database with data.
  * Must be called BEFORE the Angular app initializes.
  *

--- a/e2e/utils/supersync-helpers.ts
+++ b/e2e/utils/supersync-helpers.ts
@@ -277,6 +277,37 @@ export const isFullStateOpType = (opType: string): boolean =>
   ['SYNC_IMPORT', 'BACKUP_IMPORT', 'REPAIR'].includes(opType);
 
 /**
+ * Archived task ids in this client's young archive (`SUP_OPS`/`archive_young`,
+ * key `current`). Archived tasks are not rendered by default, so the archive is
+ * read straight from IndexedDB. Call it only after the app has booted (see
+ * getLocalOpLogSummary for why).
+ */
+export const getArchiveYoungTaskIds = async (page: Page): Promise<string[]> =>
+  page.evaluate(async () => {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('SUP_OPS');
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    try {
+      if (!db.objectStoreNames.contains('archive_young')) {
+        return [];
+      }
+      const archive = await new Promise<
+        { data?: { task?: { ids?: string[] } } } | undefined
+      >((resolve, reject) => {
+        const tx = db.transaction('archive_young', 'readonly');
+        const request = tx.objectStore('archive_young').get('current');
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+      return archive?.data?.task?.ids ?? [];
+    } finally {
+      db.close();
+    }
+  });
+
+/**
  * Summary of every entry in this client's local op log (`SUP_OPS`/`ops`).
  * Entries are stored in the compact format, where `o` is the opType and `e`
  * the entityType — the same string values as the full format. Call it only

--- a/src/app/op-log/core/types/sync-results.types.ts
+++ b/src/app/op-log/core/types/sync-results.types.ts
@@ -285,17 +285,27 @@ export type DownloadCallback = (options?: {
  */
 export type DownloadOutcome =
   | {
-      /** Server was empty/reset — a SYNC_IMPORT was created. Caller must upload. */
+      /**
+       * Server was empty/reset — a SYNC_IMPORT was created (or an unsynced
+       * SERVER_MIGRATION import was already pending). Caller must upload.
+       */
       kind: 'server_migration_handled';
     }
   | {
       /**
-       * Empty-server seeding of a fresh / never-synced genesis client ran but
-       * created no SYNC_IMPORT (server no longer empty, state judged empty,
-       * validation failed, no client id). Nothing shipped the local state, so
-       * the caller must skip this cycle's upload — accepting the client's
-       * ordinary ops would flip hasSyncedOps() and strand that state for good.
-       * The next cycle re-downloads and reaches the conflict branch. (#9921)
+       * Seeding ran but nothing shipped the local state, so the caller must
+       * skip this cycle's upload — accepting the client's ordinary ops would
+       * settle it onto a server that lacks the base state they reference: for a
+       * fresh / never-synced genesis client hasSyncedOps() would flip and strand
+       * its state for good (#9921); for a synced client on a reset server
+       * lastServerSeq would advance and the migration check would never fire
+       * again (#9932). The next cycle re-downloads and re-evaluates.
+       *
+       * Not every skip reaches here. On the server-reset branch only a genuine
+       * failure to ship existing state does (validation failed, no client id).
+       * A server that is no longer empty means someone seeded it, so a base
+       * state exists and the ordinary upload proceeds; blocking it there would
+       * strand the cycle with the client's ops still pending (#9932).
        */
       kind: 'server_migration_skipped';
     }

--- a/src/app/op-log/persistence/operation-log-store.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.spec.ts
@@ -778,6 +778,20 @@ describe('OperationLogStoreService', () => {
       expect(entry?.op.entityId).toBe('task1');
       expect(entry?.source).toBe('local');
     });
+
+    it('pushes a limit of 1 into the adapter scan so SQLite reads a single row (#9932)', async () => {
+      await service.append(createTestOperation({ entityId: 'task1' }), 'local');
+      const adapter = (service as unknown as { _adapter: OpLogDbAdapter })._adapter;
+      const iterateSpy = spyOn(adapter, 'iterate').and.callThrough();
+
+      await service.getFirstOpEntry();
+
+      expect(iterateSpy).toHaveBeenCalledOnceWith(
+        STORE_NAMES.OPS,
+        jasmine.objectContaining({ mode: 'readonly', limit: 1 }),
+        jasmine.any(Function),
+      );
+    });
   });
 
   describe('getLatestFullStateOpEntry', () => {

--- a/src/app/op-log/persistence/operation-log-store.service.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.ts
@@ -2079,13 +2079,17 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
     return lastSeq;
   }
 
-  /** First (lowest-seq) entry, or undefined when empty. Decodes one row (#9921). */
+  /**
+   * First (lowest-seq) entry, or undefined when empty. Decodes one row (#9921);
+   * `limit: 1` pushes the bound into the adapter so SQLite emits `LIMIT 1`
+   * instead of materializing the table before the visitor stops (#9932).
+   */
   async getFirstOpEntry(): Promise<OperationLogEntry | undefined> {
     await this._ensureInit();
     let firstEntry: OperationLogEntry | undefined;
     await this._adapter.iterate<StoredOperationLogEntry>(
       STORE_NAMES.OPS,
-      { mode: 'readonly' },
+      { mode: 'readonly', limit: 1 },
       (value) => {
         firstEntry = decodeStoredEntry(value);
         return 'stop';

--- a/src/app/op-log/sync/operation-log-sync.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.spec.ts
@@ -64,6 +64,27 @@ import { INBOX_PROJECT } from '../../features/project/project.const';
 import { TODAY_TAG, SYSTEM_TAG_IDS } from '../../features/tag/tag.const';
 import { OperationSyncCapable } from '../sync-providers/provider.interface';
 import { selectSyncConfig } from '../../features/config/store/global-config.reducer';
+
+// Mirrors StateSnapshotService's DEFAULT_ARCHIVE (what getStateSnapshot() reports).
+const EMPTY_ARCHIVE = {
+  task: { ids: [], entities: {} },
+  timeTracking: { project: {}, tag: {} },
+  lastTimeTrackingFlush: 0,
+};
+
+// Legacy-migrated client whose only data is archived (#9932): default NgRx
+// slices, one archived task in archiveYoung (see legacy-migration-client-b.json).
+const ARCHIVE_ONLY_NGRX_STATE = {
+  task: { ids: [] },
+  project: { ids: [INBOX_PROJECT.id] },
+  tag: { ids: [TODAY_TAG.id] },
+  note: { ids: [] },
+};
+const ARCHIVE_ONLY_LEGACY_STATE = {
+  ...ARCHIVE_ONLY_NGRX_STATE,
+  archiveYoung: { ...EMPTY_ARCHIVE, task: { ids: ['archived-b'], entities: {} } },
+  archiveOld: EMPTY_ARCHIVE,
+};
 import { DEFAULT_GLOBAL_CONFIG } from '../../features/config/default-global-config.const';
 import { SyncProviderId } from '../sync-providers/provider.const';
 import { stripLocalOnlySyncSettingsFromAppData } from '../../features/config/local-only-sync-settings.util';
@@ -202,17 +223,30 @@ describe('OperationLogSyncService', () => {
       'handleServerMigration',
     ]);
     serverMigrationServiceSpy.checkAndHandleMigration.and.resolveTo();
-    serverMigrationServiceSpy.handleServerMigration.and.resolveTo();
+    serverMigrationServiceSpy.handleServerMigration.and.resolveTo({
+      kind: 'created',
+      opId: 'sync-import',
+    });
 
     // Default: no meaningful local data (only system defaults)
     stateSnapshotServiceSpy = jasmine.createSpyObj('StateSnapshotService', [
       'getStateSnapshot',
+      'getStateSnapshotAsync',
     ]);
     stateSnapshotServiceSpy.getStateSnapshot.and.returnValue({
       task: { ids: [] },
       project: { ids: [INBOX_PROJECT.id] }, // Only default INBOX project
       tag: { ids: [TODAY_TAG.id] }, // Only default TODAY tag
       note: { ids: [] },
+    } as any);
+    // Archive-inclusive read (#9932): consulted only when NgRx holds no user data.
+    stateSnapshotServiceSpy.getStateSnapshotAsync.and.resolveTo({
+      task: { ids: [] },
+      project: { ids: [INBOX_PROJECT.id] },
+      tag: { ids: [TODAY_TAG.id] },
+      note: { ids: [] },
+      archiveYoung: EMPTY_ARCHIVE,
+      archiveOld: EMPTY_ARCHIVE,
     } as any);
 
     backupServiceSpy = jasmine.createSpyObj('BackupService', [
@@ -1900,6 +1934,97 @@ describe('OperationLogSyncService', () => {
         const result = await service.downloadRemoteOps(mockProvider);
 
         expect(result.kind).toBe('server_migration_handled');
+      });
+
+      describe('server-reset seeding outcome (#9932)', () => {
+        const serverResetDownload = (): void => {
+          downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+            newOps: [],
+            latestServerSeq: 0,
+            needsFullStateUpload: true,
+            success: true,
+            providerMode: 'superSyncOps',
+            failedFileCount: 0,
+          });
+        };
+        const providerWithSeq = (): any => ({
+          isReady: () => Promise.resolve(true),
+          setLastServerSeq: jasmine.createSpy('setLastServerSeq').and.resolveTo(),
+        });
+
+        it('reports handled and persists lastServerSeq when a SYNC_IMPORT was created', async () => {
+          serverResetDownload();
+          const provider = providerWithSeq();
+
+          const result = await service.downloadRemoteOps(provider);
+
+          expect(result.kind).toBe('server_migration_handled');
+          expect(provider.setLastServerSeq).toHaveBeenCalledWith(0);
+        });
+
+        it('reports handled when an unsynced server-migration import is already pending (it still uploads)', async () => {
+          serverResetDownload();
+          serverMigrationServiceSpy.handleServerMigration.and.resolveTo({
+            kind: 'reused_pending',
+          });
+          const provider = providerWithSeq();
+
+          const result = await service.downloadRemoteOps(provider);
+
+          expect(result.kind).toBe('server_migration_handled');
+          expect(provider.setLastServerSeq).toHaveBeenCalledWith(0);
+        });
+
+        for (const reason of ['validation_failed', 'no_client_id'] as const) {
+          it(`reports server_migration_skipped and leaves lastServerSeq alone when seeding was skipped (${reason})`, async () => {
+            serverResetDownload();
+            serverMigrationServiceSpy.handleServerMigration.and.resolveTo({
+              kind: 'skipped',
+              reason,
+            });
+            const provider = providerWithSeq();
+
+            const result = await service.downloadRemoteOps(provider);
+
+            expect(result.kind).toBe('server_migration_skipped');
+            expect(provider.setLastServerSeq).not.toHaveBeenCalled();
+          });
+        }
+
+        // Regression (#9932): a fresh check that finds the server no longer
+        // empty means someone seeded it, so a base state exists and the
+        // ordinary path applies. Blocking the upload there stranded the cycle:
+        // the client reported not-in-sync with its ops still pending, which is
+        // what broke `Single client recovers data after complete server data
+        // loss` in the SuperSync E2E suite.
+        it('lets the ordinary upload proceed when the server is no longer empty', async () => {
+          serverResetDownload();
+          serverMigrationServiceSpy.handleServerMigration.and.resolveTo({
+            kind: 'skipped',
+            reason: 'server_not_empty',
+          });
+          const provider = providerWithSeq();
+
+          const result = await service.downloadRemoteOps(provider);
+
+          expect(result.kind).not.toBe('server_migration_skipped');
+          expect(result.kind).toBe('no_new_ops');
+          expect(provider.setLastServerSeq).toHaveBeenCalledWith(0);
+        });
+
+        it('lets the ordinary upload proceed when there is no local state to seed', async () => {
+          serverResetDownload();
+          serverMigrationServiceSpy.handleServerMigration.and.resolveTo({
+            kind: 'skipped',
+            reason: 'empty_state',
+          });
+          const provider = providerWithSeq();
+
+          const result = await service.downloadRemoteOps(provider);
+
+          expect(result.kind).toBe('no_new_ops');
+          expect(provider.setLastServerSeq).toHaveBeenCalledWith(0);
+        });
       });
 
       describe('lastServerSeq persistence', () => {
@@ -4647,7 +4772,10 @@ describe('OperationLogSyncService', () => {
         rejectedOps: [],
         localWinOpsCreated: 0,
       });
-      serverMigrationServiceSpy.handleServerMigration.and.resolveTo('force-import');
+      serverMigrationServiceSpy.handleServerMigration.and.resolveTo({
+        kind: 'created',
+        opId: 'force-import',
+      });
       opLogStoreSpy.getOpById.and.resolveTo({
         syncedAt: Date.now(),
       } as OperationLogEntry);
@@ -4673,7 +4801,7 @@ describe('OperationLogSyncService', () => {
       const callOrder: string[] = [];
       serverMigrationServiceSpy.handleServerMigration.and.callFake(async () => {
         callOrder.push('handleServerMigration');
-        return 'force-import';
+        return { kind: 'created' as const, opId: 'force-import' };
       });
       uploadServiceSpy.uploadPendingOps.and.callFake(async () => {
         callOrder.push('uploadPendingOps');
@@ -4710,7 +4838,10 @@ describe('OperationLogSyncService', () => {
     });
 
     it('should reject when no FORCE_UPLOAD operation was created', async () => {
-      serverMigrationServiceSpy.handleServerMigration.and.resolveTo();
+      serverMigrationServiceSpy.handleServerMigration.and.resolveTo({
+        kind: 'skipped',
+        reason: 'validation_failed',
+      });
 
       const mockProvider = {
         supportsOperationSync: true,
@@ -5914,6 +6045,39 @@ describe('OperationLogSyncService', () => {
       opLogStoreSpy.getUnsynced.and.resolveTo([]); // No unsynced ops
     });
 
+    it('should throw LocalDataConflictError when a fresh client holds only archived tasks (#9932)', async () => {
+      stateSnapshotServiceSpy.getStateSnapshot.and.returnValue({
+        ...ARCHIVE_ONLY_NGRX_STATE,
+        archiveYoung: EMPTY_ARCHIVE,
+        archiveOld: EMPTY_ARCHIVE,
+      } as any);
+      stateSnapshotServiceSpy.getStateSnapshotAsync.and.resolveTo(
+        ARCHIVE_ONLY_LEGACY_STATE as any,
+      );
+
+      downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+        newOps: [],
+        needsFullStateUpload: false,
+        success: true,
+        providerMode: 'fileSnapshotOps',
+        failedFileCount: 0,
+        snapshotState: { task: { ids: ['remote-task'] } },
+        snapshotVectorClock: { clientB: 5 },
+      });
+
+      const mockProvider = {
+        supportsOperationSync: true,
+      } as any;
+
+      await expectAsync(service.downloadRemoteOps(mockProvider)).toBeRejectedWith(
+        jasmine.any(LocalDataConflictError),
+      );
+      const syncHydrationServiceSpy = TestBed.inject(
+        SyncHydrationService,
+      ) as jasmine.SpyObj<SyncHydrationService>;
+      expect(syncHydrationServiceSpy.hydrateFromRemoteSync).not.toHaveBeenCalled();
+    });
+
     it('should throw LocalDataConflictError when fresh client has tasks in NgRx store', async () => {
       // Store has tasks (meaningful data)
       stateSnapshotServiceSpy.getStateSnapshot.and.returnValue({
@@ -6274,7 +6438,10 @@ describe('OperationLogSyncService', () => {
         failedFileCount: 0,
         latestServerSeq: 0, // Empty server
       });
-      serverMigrationServiceSpy.handleServerMigration.and.resolveTo('sync-import-1');
+      serverMigrationServiceSpy.handleServerMigration.and.resolveTo({
+        kind: 'created',
+        opId: 'sync-import-1',
+      });
 
       const mockProvider = {
         supportsOperationSync: true,
@@ -6307,7 +6474,10 @@ describe('OperationLogSyncService', () => {
         latestServerSeq: 0,
       });
       // Server no longer empty on the fresh check / validation failed / no client id
-      serverMigrationServiceSpy.handleServerMigration.and.resolveTo(undefined);
+      serverMigrationServiceSpy.handleServerMigration.and.resolveTo({
+        kind: 'skipped',
+        reason: 'server_not_empty',
+      });
 
       const mockProvider = {
         supportsOperationSync: true,
@@ -6498,6 +6668,82 @@ describe('OperationLogSyncService', () => {
       await expectAsync(service.downloadRemoteOps(mockProvider())).toBeRejectedWithError(
         LocalDataConflictError,
       );
+      // The store already holds data — no archive read needed.
+      expect(stateSnapshotServiceSpy.getStateSnapshotAsync).not.toHaveBeenCalled();
+    });
+
+    // #9932: a legacy client whose data is all archived. The NgRx slices are the
+    // defaults; the archived task exists only in IndexedDB, which the synchronous
+    // snapshot reports as an empty DEFAULT_ARCHIVE.
+    describe('archive-only legacy data (#9932)', () => {
+      beforeEach(() => {
+        stateSnapshotServiceSpy.getStateSnapshot.and.returnValue({
+          ...ARCHIVE_ONLY_NGRX_STATE,
+          archiveYoung: EMPTY_ARCHIVE,
+          archiveOld: EMPTY_ARCHIVE,
+        } as any);
+        stateSnapshotServiceSpy.getStateSnapshotAsync.and.resolveTo(
+          ARCHIVE_ONLY_LEGACY_STATE as any,
+        );
+      });
+
+      it('throws LocalDataConflictError instead of silently applying ordinary remote ops', async () => {
+        downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+          newOps: [remoteTaskOp],
+          needsFullStateUpload: false,
+          success: true,
+          providerMode: 'superSyncOps',
+          failedFileCount: 0,
+          latestServerSeq: 5,
+        });
+
+        await expectAsync(
+          service.downloadRemoteOps(mockProvider()),
+        ).toBeRejectedWithError(LocalDataConflictError);
+        expect(remoteOpsProcessingServiceSpy.processRemoteOps).not.toHaveBeenCalled();
+      });
+
+      it('seeds an empty server with a SYNC_IMPORT instead of leaving the archive on this device only', async () => {
+        downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+          newOps: [],
+          needsFullStateUpload: false,
+          success: true,
+          providerMode: 'superSyncOps',
+          failedFileCount: 0,
+          latestServerSeq: 0,
+        });
+        const provider = mockProvider();
+
+        const result = await service.downloadRemoteOps(provider);
+
+        expect(serverMigrationServiceSpy.handleServerMigration).toHaveBeenCalledWith(
+          provider,
+          { syncImportReason: 'SERVER_MIGRATION' },
+        );
+        expect(result.kind).toBe('server_migration_handled');
+      });
+
+      it('still reports no_new_ops on an empty server when the archives are empty too', async () => {
+        stateSnapshotServiceSpy.getStateSnapshotAsync.and.resolveTo({
+          ...ARCHIVE_ONLY_NGRX_STATE,
+          archiveYoung: EMPTY_ARCHIVE,
+          archiveOld: EMPTY_ARCHIVE,
+        } as any);
+        downloadServiceSpy.downloadRemoteOps.and.resolveTo({
+          newOps: [],
+          needsFullStateUpload: false,
+          success: true,
+          providerMode: 'superSyncOps',
+          failedFileCount: 0,
+          latestServerSeq: 0,
+        });
+
+        const result = await service.downloadRemoteOps(mockProvider());
+
+        expect(stateSnapshotServiceSpy.getStateSnapshotAsync).toHaveBeenCalled();
+        expect(serverMigrationServiceSpy.handleServerMigration).not.toHaveBeenCalled();
+        expect(result.kind).toBe('no_new_ops');
+      });
     });
 
     it('creates a SYNC_IMPORT via server migration on an empty server', async () => {
@@ -6509,7 +6755,10 @@ describe('OperationLogSyncService', () => {
         failedFileCount: 0,
         latestServerSeq: 0,
       });
-      serverMigrationServiceSpy.handleServerMigration.and.resolveTo('sync-import-1');
+      serverMigrationServiceSpy.handleServerMigration.and.resolveTo({
+        kind: 'created',
+        opId: 'sync-import-1',
+      });
       const provider = mockProvider();
 
       const result = await service.downloadRemoteOps(provider);
@@ -6530,7 +6779,10 @@ describe('OperationLogSyncService', () => {
         failedFileCount: 0,
         latestServerSeq: 0,
       });
-      serverMigrationServiceSpy.handleServerMigration.and.resolveTo(undefined);
+      serverMigrationServiceSpy.handleServerMigration.and.resolveTo({
+        kind: 'skipped',
+        reason: 'validation_failed',
+      });
       const provider = mockProvider();
 
       const result = await service.downloadRemoteOps(provider);

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -676,10 +676,36 @@ export class OperationLogSyncService {
         options?.fenceEpoch,
         'server migration',
       );
-      await this.serverMigrationService.handleServerMigration(syncProvider);
+      const outcome =
+        await this.serverMigrationService.handleServerMigration(syncProvider);
+      // #9932: blocking this cycle's upload is right only when this client HAS
+      // state that failed to ship AND the server still holds no base state for
+      // the ordinary ops that would follow (see `server_migration_skipped` in
+      // DownloadOutcome). Only these two reasons are that case.
+      //
+      // `server_not_empty` is NOT: the fresh check found that someone seeded the
+      // server meanwhile, so a base state exists and the ordinary path applies —
+      // blocking there strands a cycle for nothing, and the client reports
+      // not-in-sync with its ops still pending. `empty_state` has nothing to
+      // ship at all. Both fall through to the ordinary upload, as before #9932.
+      const seedingFailed =
+        outcome.kind === 'skipped' &&
+        (outcome.reason === 'validation_failed' || outcome.reason === 'no_client_id');
+      if (seedingFailed) {
+        OpLog.warn(
+          `OperationLogSyncService: Server-reset seeding created no SYNC_IMPORT (${outcome.reason}).`,
+        );
+        return { kind: 'server_migration_skipped' };
+      }
       // Persist lastServerSeq=0 for the migration case (server was reset)
       if (result.latestServerSeq !== undefined) {
         await syncProvider.setLastServerSeq(result.latestServerSeq);
+      }
+      if (outcome.kind === 'skipped') {
+        OpLog.normal(
+          `OperationLogSyncService: Server was reset but nothing was seeded (${outcome.reason}); continuing with the ordinary upload.`,
+        );
+        return { kind: 'no_new_ops' };
       }
       return { kind: 'server_migration_handled' };
     }
@@ -834,7 +860,7 @@ export class OperationLogSyncService {
           this.syncImportConflictGateService.hasMeaningfulPendingOps(
             unsyncedOps,
             pendingOpClassification,
-          ) || this.syncLocalStateService.hasMeaningfulStoreData(exampleTaskIds);
+          ) || (await this.syncLocalStateService.hasMeaningfulStoreData(exampleTaskIds));
 
         if (hasMeaningfulUserData) {
           // SPAP-9: before surfacing the binary USE_LOCAL/USE_REMOTE dialog, use
@@ -936,7 +962,10 @@ export class OperationLogSyncService {
 
         // CRITICAL FIX: Even if op-log is empty, check if NgRx store has meaningful data.
         // This catches data that existed before the operation-log feature was added.
-        if (isFreshClient && this.syncLocalStateService.hasMeaningfulStoreData()) {
+        if (
+          isFreshClient &&
+          (await this.syncLocalStateService.hasMeaningfulStoreData())
+        ) {
           OpLog.warn(
             'OperationLogSyncService: Fresh client detected with meaningful local data in store. ' +
               'Throwing LocalDataConflictError for conflict resolution dialog.',
@@ -1056,7 +1085,7 @@ export class OperationLogSyncService {
           await this.syncLocalStateService.isFreshOrNeverSyncedGenesisClient(
             result.newOps,
           );
-        if (isFresh && this.syncLocalStateService.hasMeaningfulStoreData()) {
+        if (isFresh && (await this.syncLocalStateService.hasMeaningfulStoreData())) {
           OpLog.warn(
             'OperationLogSyncService: Pre-op-log client with meaningful local data on empty server. ' +
               'Creating SYNC_IMPORT via server migration to seed the server.',
@@ -1065,15 +1094,18 @@ export class OperationLogSyncService {
             options?.fenceEpoch,
             'empty-server migration',
           );
-          const createdOpId = await this.serverMigrationService.handleServerMigration(
+          const outcome = await this.serverMigrationService.handleServerMigration(
             syncProvider,
             { syncImportReason: 'SERVER_MIGRATION' },
           );
           // No SYNC_IMPORT → nothing shipped the state → skip this cycle's upload
           // (see DownloadOutcome) so the next download re-evaluates. (#9921)
-          if (!createdOpId) {
+          // `empty_state` is unreachable here (the gate above is a subset of the
+          // seeding's own check) and would strand the genesis state, so it is
+          // not exempted like in the server-reset branch.
+          if (outcome.kind === 'skipped') {
             OpLog.warn(
-              'OperationLogSyncService: Empty-server seeding created no SYNC_IMPORT.',
+              `OperationLogSyncService: Empty-server seeding created no SYNC_IMPORT (${outcome.reason}).`,
             );
             return { kind: 'server_migration_skipped' };
           }
@@ -1103,7 +1135,7 @@ export class OperationLogSyncService {
     const isFreshClient =
       await this.syncLocalStateService.isFreshOrNeverSyncedGenesisClient(result.newOps);
     if (isFreshClient && result.newOps.length > 0) {
-      if (this.syncLocalStateService.hasMeaningfulStoreData()) {
+      if (await this.syncLocalStateService.hasMeaningfulStoreData()) {
         OpLog.warn(
           `OperationLogSyncService: Fresh client has local data and ${result.newOps.length} remote ops. Showing conflict dialog.`,
         );

--- a/src/app/op-log/sync/operation-log-upload-piggyback-seq.integration.spec.ts
+++ b/src/app/op-log/sync/operation-log-upload-piggyback-seq.integration.spec.ts
@@ -221,12 +221,22 @@ describe('OperationLogSyncService + OperationLogUploadService — piggyback seq 
       'handleServerMigration',
     ]);
     serverMigrationServiceSpy.checkAndHandleMigration.and.resolveTo();
-    serverMigrationServiceSpy.handleServerMigration.and.resolveTo();
+    serverMigrationServiceSpy.handleServerMigration.and.resolveTo({
+      kind: 'created',
+      opId: 'sync-import',
+    });
 
     const stateSnapshotServiceSpy = jasmine.createSpyObj('StateSnapshotService', [
       'getStateSnapshot',
+      'getStateSnapshotAsync',
     ]);
     stateSnapshotServiceSpy.getStateSnapshot.and.returnValue({
+      task: { ids: [] },
+      project: { ids: [INBOX_PROJECT.id] },
+      tag: { ids: [TODAY_TAG.id] },
+      note: { ids: [] },
+    } as any);
+    stateSnapshotServiceSpy.getStateSnapshotAsync.and.resolveTo({
       task: { ids: [] },
       project: { ids: [INBOX_PROJECT.id] },
       tag: { ids: [TODAY_TAG.id] },

--- a/src/app/op-log/sync/server-migration.service.spec.ts
+++ b/src/app/op-log/sync/server-migration.service.spec.ts
@@ -3,7 +3,10 @@ import { TestBed } from '@angular/core/testing';
 import { provideMockStore, MockStore } from '@ngrx/store/testing';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { of } from 'rxjs';
-import { ServerMigrationService } from './server-migration.service';
+import {
+  ServerMigrationService,
+  ServerMigrationOutcome,
+} from './server-migration.service';
 import { OperationLogStoreService } from '../persistence/operation-log-store.service';
 import { VectorClockService } from './vector-clock.service';
 import { ValidateStateService } from '../validation/validate-state.service';
@@ -333,9 +336,10 @@ describe('ServerMigrationService', () => {
         } as any),
       );
 
-      await service.handleServerMigration(defaultProvider);
+      const outcome = await service.handleServerMigration(defaultProvider);
 
       expect(opLogStoreSpy.append).not.toHaveBeenCalled();
+      expect(outcome).toEqual({ kind: 'skipped', reason: 'empty_state' });
     });
 
     it('should skip if state only has system tags', async () => {
@@ -384,10 +388,76 @@ describe('ServerMigrationService', () => {
         } as any),
       );
 
-      const createdOpId = await service.handleServerMigration(defaultProvider);
+      const outcome = await service.handleServerMigration(defaultProvider);
 
       expect(opLogStoreSpy.append).toHaveBeenCalled();
-      expect(createdOpId).toBe(opLogStoreSpy.append.calls.mostRecent().args[0].id);
+      expect(outcome).toEqual({
+        kind: 'created',
+        opId: opLogStoreSpy.append.calls.mostRecent().args[0].id,
+      });
+    });
+
+    describe('outcome (#9932)', () => {
+      it('is reused_pending when an unsynced server-migration import is already queued', async () => {
+        opLogStoreSpy.getOpsAfterSeq.and.resolveTo([createMigrationEntry()]);
+
+        const outcome = await service.handleServerMigration(defaultProvider);
+
+        expect(outcome).toEqual({ kind: 'reused_pending' });
+        expect(opLogStoreSpy.append).not.toHaveBeenCalled();
+      });
+
+      it('never reports reused_pending for a FORCE_UPLOAD even when a migration import is pending', async () => {
+        opLogStoreSpy.getOpsAfterSeq.and.resolveTo([createMigrationEntry()]);
+
+        const outcome = await service.handleServerMigration(defaultProvider, {
+          skipServerEmptyCheck: true,
+          syncImportReason: 'FORCE_UPLOAD',
+        });
+
+        expect(outcome.kind).toBe('created');
+        expect(opLogStoreSpy.append).toHaveBeenCalled();
+      });
+
+      // The invariant the widened gate rests on: hasMeaningfulStateData must stay a
+      // SUBSET of this service's own hasServerMigrationStateData. If it ever went
+      // wider, the gate would trigger seeding that then skips as `empty_state`,
+      // and the client would re-run the whole decision on every sync forever.
+      // Archive-only state is the case #9932 widened the gate to cover, so it is
+      // the one that has to ship here.
+      it('creates a SYNC_IMPORT for archive-only state, so the widened gate can never seed nothing', async () => {
+        stateSnapshotServiceSpy.getStateSnapshotAsync.and.resolveTo({
+          task: { ids: [], entities: {} },
+          project: {
+            ids: [INBOX_PROJECT.id],
+            entities: { [INBOX_PROJECT.id]: INBOX_PROJECT },
+          },
+          tag: { ids: Array.from(SYSTEM_TAG_IDS), entities: {} },
+          note: { ids: [], entities: {} },
+          taskRepeatCfg: { ids: [], entities: {} },
+          timeTracking: { project: {}, tag: {} },
+          archiveYoung: {
+            task: {
+              ids: ['archived-1'],
+              entities: { 'archived-1': { id: 'archived-1' } },
+            },
+            timeTracking: { project: {}, tag: {} },
+            lastTimeTrackingFlush: 0,
+          },
+          archiveOld: {
+            task: { ids: [], entities: {} },
+            timeTracking: { project: {}, tag: {} },
+          },
+        } as unknown as AppStateSnapshot);
+
+        const outcome = await service.handleServerMigration(defaultProvider);
+
+        expect(outcome.kind).toBe('created');
+        expect(opLogStoreSpy.append).toHaveBeenCalled();
+        expect(opLogStoreSpy.append.calls.mostRecent().args[0].opType).toBe(
+          OpType.SyncImport,
+        );
+      });
     });
 
     it('should proceed if non-entity sync state differs from defaults', async () => {
@@ -419,12 +489,13 @@ describe('ServerMigrationService', () => {
         error: 'Validation failed',
       } as any);
 
-      await service.handleServerMigration(defaultProvider);
+      const outcome = await service.handleServerMigration(defaultProvider);
 
       expect(opLogStoreSpy.append).not.toHaveBeenCalled();
       expect(snackServiceSpy.open).toHaveBeenCalledWith(
         jasmine.objectContaining({ type: 'ERROR' }),
       );
+      expect(outcome).toEqual({ kind: 'skipped', reason: 'validation_failed' });
     });
 
     describe('validation-failed snack throttling (#9921)', () => {
@@ -558,9 +629,10 @@ describe('ServerMigrationService', () => {
     it('should abort if no client ID is available', async () => {
       clientIdProviderSpy.loadClientId.and.returnValue(Promise.resolve(null));
 
-      await service.handleServerMigration(defaultProvider);
+      const outcome = await service.handleServerMigration(defaultProvider);
 
       expect(opLogStoreSpy.append).not.toHaveBeenCalled();
+      expect(outcome).toEqual({ kind: 'skipped', reason: 'no_client_id' });
     });
 
     it('should proceed if state has tasks', async () => {
@@ -825,10 +897,11 @@ describe('ServerMigrationService', () => {
         Promise.resolve({ ops: [], latestSeq: 5, hasMore: false }),
       );
 
-      await service.handleServerMigration(defaultProvider);
+      const outcome = await service.handleServerMigration(defaultProvider);
 
       // Should not create SYNC_IMPORT because server is no longer empty
       expect(opLogStoreSpy.append).not.toHaveBeenCalled();
+      expect(outcome).toEqual({ kind: 'skipped', reason: 'server_not_empty' });
     });
 
     it('should proceed if server is still empty during double-check', async () => {
@@ -996,7 +1069,7 @@ describe('ServerMigrationService', () => {
       simpleCounter: MODEL_CONFIGS.simpleCounter.defaultData,
     };
 
-    const forceUpload = (): Promise<string | undefined> =>
+    const forceUpload = (): Promise<ServerMigrationOutcome> =>
       service.handleServerMigration(defaultProvider, {
         skipServerEmptyCheck: true,
         syncImportReason: 'FORCE_UPLOAD',
@@ -1046,10 +1119,9 @@ describe('ServerMigrationService', () => {
       await forceUpload();
 
       // Note the skip is not a good outcome either: handleServerMigration
-      // returns undefined, which forceUploadLocalState turns into
-      // ForceUploadFailedError (sync-import-conflict-coordinator.service.ts:81-85)
-      // and a FORCE_UPLOAD_FAILED snack — another dead end, just a
-      // non-destructive one.
+      // reports skipped/empty_state, which forceUploadLocalState turns into
+      // ForceUploadFailedError (it requires kind 'created') and a
+      // FORCE_UPLOAD_FAILED snack — another dead end, just a non-destructive one.
       expect(opLogStoreSpy.append).not.toHaveBeenCalled();
     });
 

--- a/src/app/op-log/sync/server-migration.service.ts
+++ b/src/app/op-log/sync/server-migration.service.ts
@@ -25,6 +25,21 @@ import { OperationWriteFlushService } from './operation-write-flush.service';
 
 const MEANINGFUL_ENTITY_STATE_KEYS = new Set(['task', 'project', 'tag', 'note']);
 
+/**
+ * What {@link ServerMigrationService.handleServerMigration} did (#9932).
+ * `created` appended a SYNC_IMPORT; `reused_pending` found an unsynced
+ * SERVER_MIGRATION import already queued, which still ships the state;
+ * `skipped` shipped nothing. What a caller may safely do with each is the
+ * caller's policy — see `DownloadOutcome` in core/types/sync-results.types.ts.
+ */
+export type ServerMigrationOutcome =
+  | { kind: 'created'; opId: string }
+  | { kind: 'reused_pending' }
+  | {
+      kind: 'skipped';
+      reason: 'server_not_empty' | 'empty_state' | 'validation_failed' | 'no_client_id';
+    };
+
 const hasServerMigrationStateData = (state: unknown): boolean => {
   if (!state || typeof state !== 'object') {
     return false;
@@ -186,16 +201,16 @@ export class ServerMigrationService {
    * @param options - Optional configuration
    * @param options.skipServerEmptyCheck - If true, creates SYNC_IMPORT even if server has data.
    *   Used for "USE_LOCAL" conflict resolution to force overwrite remote with local state.
-   * @returns The created SYNC_IMPORT operation ID, or undefined when creation was skipped.
+   * @returns What happened — see {@link ServerMigrationOutcome}.
    */
   async handleServerMigration(
     syncProvider: OperationSyncCapable,
     options?: { skipServerEmptyCheck?: boolean; syncImportReason?: SyncImportReason },
-  ): Promise<string | undefined> {
+  ): Promise<ServerMigrationOutcome> {
     const isServerMigration =
       (options?.syncImportReason ?? 'SERVER_MIGRATION') === 'SERVER_MIGRATION';
     if (isServerMigration && (await this._skipOrThrowForOutstandingServerMigration())) {
-      return;
+      return { kind: 'reused_pending' };
     }
 
     // Double-check server is still empty (in case another client just uploaded).
@@ -208,7 +223,7 @@ export class ServerMigrationService {
           'ServerMigrationService: Server no longer empty, aborting SYNC_IMPORT. ' +
             'Another client may have just uploaded.',
         );
-        return;
+        return { kind: 'skipped', reason: 'server_not_empty' };
       }
     }
 
@@ -228,7 +243,7 @@ export class ServerMigrationService {
       // while this tab was probing the server or waiting for confirmation.
       // Re-check inside the cross-tab operation-log barrier before snapshotting.
       if (isServerMigration && (await this._skipOrThrowForOutstandingServerMigration())) {
-        return;
+        return { kind: 'reused_pending' };
       }
 
       // Get current full state from NgRx store (async to include archives from IndexedDB)
@@ -244,7 +259,7 @@ export class ServerMigrationService {
         OpLog.warn(
           'ServerMigrationService: Skipping SYNC_IMPORT - local state is empty.',
         );
-        return;
+        return { kind: 'skipped', reason: 'empty_state' };
       }
 
       // Validate and repair state before creating SYNC_IMPORT
@@ -272,7 +287,7 @@ export class ServerMigrationService {
         if (isServerMigration) {
           this._validationFailureNotified = true;
         }
-        return;
+        return { kind: 'skipped', reason: 'validation_failed' };
       }
 
       // If state was repaired, use the repaired version
@@ -297,7 +312,7 @@ export class ServerMigrationService {
         OpLog.err(
           'ServerMigrationService: Cannot create SYNC_IMPORT - no client ID available.',
         );
-        return;
+        return { kind: 'skipped', reason: 'no_client_id' };
       }
 
       // Build vector clock by merging ALL local operation clocks.
@@ -346,7 +361,7 @@ export class ServerMigrationService {
           'Will be uploaded immediately via follow-up upload.',
       );
       this._validationFailureNotified = false;
-      return op.id;
+      return { kind: 'created', opId: op.id };
     });
   }
 

--- a/src/app/op-log/sync/sync-import-conflict-coordinator.service.ts
+++ b/src/app/op-log/sync/sync-import-conflict-coordinator.service.ts
@@ -70,7 +70,7 @@ export class SyncImportConflictCoordinatorService {
       'SyncImportConflictCoordinatorService: Force uploading local state - creating SYNC_IMPORT to override remote.',
     );
 
-    const forceUploadOpId = await this.serverMigrationService.handleServerMigration(
+    const migrationOutcome = await this.serverMigrationService.handleServerMigration(
       syncProvider,
       {
         skipServerEmptyCheck: true,
@@ -78,11 +78,14 @@ export class SyncImportConflictCoordinatorService {
       },
     );
 
-    if (!forceUploadOpId) {
+    // FORCE_UPLOAD never reuses a pending SERVER_MIGRATION import, so anything
+    // but `created` means no SYNC_IMPORT exists to force-upload.
+    if (migrationOutcome.kind !== 'created') {
       throw new ForceUploadFailedError(
         'Force upload failed because no SYNC_IMPORT was created.',
       );
     }
+    const forceUploadOpId = migrationOutcome.opId;
 
     const uploadResult = await this.uploadService.uploadPendingOps(syncProvider, {
       skipPiggybackProcessing: true,

--- a/src/app/op-log/sync/sync-local-state.service.spec.ts
+++ b/src/app/op-log/sync/sync-local-state.service.spec.ts
@@ -277,4 +277,71 @@ describe('SyncLocalStateService', () => {
       expect(await service.hasNothingWorthUploading()).toBe(true);
     });
   });
+
+  describe('hasMeaningfulStoreData (#9932)', () => {
+    const emptyArchive = {
+      task: { ids: [], entities: {} },
+      timeTracking: { project: {}, tag: {} },
+      lastTimeTrackingFlush: 0,
+    };
+    const emptyNgRx = {
+      task: { ids: [], entities: {} },
+      project: { ids: ['INBOX_PROJECT'], entities: {} },
+      tag: { ids: ['TODAY'], entities: {} },
+      note: { ids: [], entities: {} },
+    };
+
+    beforeEach(() => {
+      // What getStateSnapshot() reports: NgRx plus placeholder archives.
+      stateSnapshotSpy.getStateSnapshot.and.returnValue({
+        ...emptyNgRx,
+        archiveYoung: emptyArchive,
+        archiveOld: emptyArchive,
+      } as any);
+      stateSnapshotSpy.getStateSnapshotAsync.and.resolveTo({
+        ...emptyNgRx,
+        archiveYoung: emptyArchive,
+        archiveOld: emptyArchive,
+      } as any);
+    });
+
+    it('answers from the store snapshot alone when it already holds user data', async () => {
+      stateSnapshotSpy.getStateSnapshot.and.returnValue({
+        ...emptyNgRx,
+        task: { ids: ['t1'], entities: {} },
+      } as any);
+
+      expect(await service.hasMeaningfulStoreData()).toBe(true);
+      expect(stateSnapshotSpy.getStateSnapshotAsync).not.toHaveBeenCalled();
+    });
+
+    it('reads the archives when the store holds nothing and counts an archived task', async () => {
+      stateSnapshotSpy.getStateSnapshotAsync.and.resolveTo({
+        ...emptyNgRx,
+        archiveYoung: {
+          ...emptyArchive,
+          task: { ids: ['archived-1'], entities: {} },
+        },
+        archiveOld: emptyArchive,
+      } as any);
+
+      expect(await service.hasMeaningfulStoreData()).toBe(true);
+      expect(stateSnapshotSpy.getStateSnapshotAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('is false when both the store and the archives are empty', async () => {
+      expect(await service.hasMeaningfulStoreData()).toBe(false);
+      expect(stateSnapshotSpy.getStateSnapshotAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('applies ignoreTaskIds to the store check but still reads the archives (#7985)', async () => {
+      stateSnapshotSpy.getStateSnapshot.and.returnValue({
+        ...emptyNgRx,
+        task: { ids: ['example-1'], entities: {} },
+      } as any);
+
+      expect(await service.hasMeaningfulStoreData(new Set(['example-1']))).toBe(false);
+      expect(stateSnapshotSpy.getStateSnapshotAsync).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/app/op-log/sync/sync-local-state.service.ts
+++ b/src/app/op-log/sync/sync-local-state.service.ts
@@ -5,7 +5,10 @@ import { StateSnapshotService } from '../backup/state-snapshot.service';
 import { OpLog } from '../../core/log';
 import { T } from '../../t.const';
 import { alertDialog, confirmDialog } from '../../util/native-dialogs';
-import { hasMeaningfulStateData } from '../validation/has-meaningful-state-data.util';
+import {
+  hasAnyUserData,
+  hasMeaningfulStateData,
+} from '../validation/has-meaningful-state-data.util';
 import { isExampleTaskCreateOp } from '../validation/is-example-task-op.util';
 import {
   isFullStateOpType,
@@ -100,12 +103,25 @@ export class SyncLocalStateService {
   }
 
   /**
+   * The fresh-client / genesis-client gate: does this client hold user data?
+   * Uses the wider `hasAnyUserData`, because a legacy-migrated client's work can
+   * be entirely archived, tracked time or repeat configs. Archives live only in
+   * IndexedDB and the synchronous snapshot substitutes an empty DEFAULT_ARCHIVE,
+   * so such a client read as empty here and lost its archive (#9932); when the
+   * narrow check finds nothing, the archive-inclusive snapshot is consulted
+   * before answering "no".
+   *
+   * The wider notion stops here on purpose. `hasNothingWorthUploading` below
+   * consumes the narrow `hasMeaningfulStateData` in the refusing direction
+   * (#9256), where over-reporting "has data" would permit a destructive server
+   * overwrite from a device holding nothing.
+   *
    * @param ignoreTaskIds Optional task ids to exclude from the "has a task?" check.
    *   The file-based conflict gate passes the ids of pending onboarding example tasks so
    *   an example-only store is not treated as meaningful (#7985). Omitting it preserves
    *   the original behavior for every other caller.
    */
-  hasMeaningfulStoreData(ignoreTaskIds?: ReadonlySet<string>): boolean {
+  async hasMeaningfulStoreData(ignoreTaskIds?: ReadonlySet<string>): Promise<boolean> {
     const snapshot = this.stateSnapshotService.getStateSnapshot();
 
     if (!snapshot) {
@@ -115,7 +131,12 @@ export class SyncLocalStateService {
       return false;
     }
 
-    return hasMeaningfulStateData(snapshot, ignoreTaskIds);
+    if (hasAnyUserData(snapshot, ignoreTaskIds)) {
+      return true;
+    }
+
+    const withArchives = await this.stateSnapshotService.getStateSnapshotAsync();
+    return hasAnyUserData(withArchives, ignoreTaskIds);
   }
 
   /**

--- a/src/app/op-log/testing/integration/clean-slate-interrupt.integration.spec.ts
+++ b/src/app/op-log/testing/integration/clean-slate-interrupt.integration.spec.ts
@@ -223,7 +223,7 @@ describe('CleanSlate / Backup interrupt (issue #7709 regression)', () => {
       // throw `LocalDataConflictError(0, {})` — the #7709 chain.
       expect(await storeService.getLastSeq()).toBe(seqBefore);
       expect(await storeService.loadStateCache()).toBeNull();
-      expect(syncLocalState.hasMeaningfulStoreData()).toBe(true);
+      expect(await syncLocalState.hasMeaningfulStoreData()).toBe(true);
       // The device is NOT classified as wholly fresh — even though state_cache
       // was missing before the destructive call too, the surviving op-log keeps
       // `lastSeq > 0` so `isWhollyFreshClient()` is false.

--- a/src/app/op-log/testing/integration/service-logic.integration.spec.ts
+++ b/src/app/op-log/testing/integration/service-logic.integration.spec.ts
@@ -345,7 +345,9 @@ describe('Service Logic Integration', () => {
       'handleServerMigration',
     ]);
     serverMigrationSpy.checkAndHandleMigration.and.returnValue(Promise.resolve());
-    serverMigrationSpy.handleServerMigration.and.returnValue(Promise.resolve());
+    serverMigrationSpy.handleServerMigration.and.returnValue(
+      Promise.resolve({ kind: 'created', opId: 'sync-import' }),
+    );
 
     // Mock OperationWriteFlushService
     const writeFlushSpy = jasmine.createSpyObj('OperationWriteFlushService', [

--- a/src/app/op-log/validation/has-meaningful-state-data.util.spec.ts
+++ b/src/app/op-log/validation/has-meaningful-state-data.util.spec.ts
@@ -1,4 +1,5 @@
-import { hasMeaningfulStateData } from './has-meaningful-state-data.util';
+/* eslint-disable @typescript-eslint/naming-convention */
+import { hasAnyUserData, hasMeaningfulStateData } from './has-meaningful-state-data.util';
 import { INBOX_PROJECT } from '../../features/project/project.const';
 
 // The default app ships with only the INBOX project and the built-in system
@@ -10,11 +11,24 @@ const SYSTEM_TAG_IDS_FIXTURE = [
   'KANBAN_IN_PROGRESS',
 ];
 
+const emptyTimeTracking = (): Record<string, unknown> => ({ project: {}, tag: {} });
+
+// Mirrors StateSnapshotService's DEFAULT_ARCHIVE / the legacy `pf` archive shape.
+const emptyArchive = (): Record<string, unknown> => ({
+  task: { ids: [], entities: {} },
+  timeTracking: emptyTimeTracking(),
+  lastTimeTrackingFlush: 0,
+});
+
 const initialState = (): Record<string, unknown> => ({
   task: { ids: [], entities: {} },
   project: { ids: [INBOX_PROJECT.id], entities: {} },
   tag: { ids: [...SYSTEM_TAG_IDS_FIXTURE], entities: {} },
   note: { ids: [], entities: {} },
+  taskRepeatCfg: { ids: [], entities: {} },
+  timeTracking: emptyTimeTracking(),
+  archiveYoung: emptyArchive(),
+  archiveOld: emptyArchive(),
 });
 
 describe('hasMeaningfulStateData', () => {
@@ -62,9 +76,34 @@ describe('hasMeaningfulStateData', () => {
   });
 
   it('ignores malformed (non-entity) collections without throwing', () => {
-    expect(hasMeaningfulStateData({ task: 'broken', project: null, tag: 123 })).toBe(
-      false,
-    );
+    expect(
+      hasMeaningfulStateData({
+        task: 'broken',
+        project: null,
+        tag: 123,
+        taskRepeatCfg: [],
+        timeTracking: { project: 'x', tag: null },
+        archiveYoung: 'broken',
+        archiveOld: { task: null, timeTracking: 7 },
+      }),
+    ).toBe(false);
+  });
+
+  // #9256 guard: hasNothingWorthUploading consumes hasMeaningfulStateData in the
+  // REFUSING direction, where over-reporting "has data" permits a destructive
+  // server overwrite. The wider signals must stay out of this predicate.
+  it('does NOT count archives, time tracking or repeat configs (stays narrow for #9256)', () => {
+    const s = initialState();
+    s.archiveYoung = { ...emptyArchive(), task: { ids: ['a1'], entities: {} } };
+    s.archiveOld = { ...emptyArchive(), task: { ids: ['a2'], entities: {} } };
+    s.timeTracking = {
+      project: { [INBOX_PROJECT.id]: { '2024-11-16': { s: 1 } } },
+      tag: {},
+    };
+    s.taskRepeatCfg = { ids: ['rc1'], entities: {} };
+
+    expect(hasMeaningfulStateData(s)).toBe(false);
+    expect(hasAnyUserData(s)).toBe(true);
   });
 
   describe('with ignoreTaskIds (#7985)', () => {
@@ -96,5 +135,44 @@ describe('hasMeaningfulStateData', () => {
       expect(hasMeaningfulStateData(s, undefined)).toBe(true);
       expect(hasMeaningfulStateData(s, new Set())).toBe(true);
     });
+  });
+});
+
+describe('hasAnyUserData (#9932)', () => {
+  it('returns true for an archived task in archiveYoung or archiveOld', () => {
+    const young = initialState();
+    young.archiveYoung = { ...emptyArchive(), task: { ids: ['a1'], entities: {} } };
+    expect(hasAnyUserData(young)).toBe(true);
+
+    const old = initialState();
+    old.archiveOld = { ...emptyArchive(), task: { ids: ['a1'], entities: {} } };
+    expect(hasAnyUserData(old)).toBe(true);
+  });
+
+  it('returns true for time tracking, live or flushed into an archive', () => {
+    const tracked = {
+      project: { [INBOX_PROJECT.id]: { '2024-11-16': { s: 1 } } },
+      tag: {},
+    };
+
+    const live = initialState();
+    live.timeTracking = tracked;
+    expect(hasAnyUserData(live)).toBe(true);
+
+    const archived = initialState();
+    archived.archiveOld = { ...emptyArchive(), timeTracking: tracked };
+    expect(hasAnyUserData(archived)).toBe(true);
+  });
+
+  it('returns false for time tracking contexts without any tracked day', () => {
+    const s = initialState();
+    s.timeTracking = { project: { [INBOX_PROJECT.id]: {} }, tag: {} };
+    expect(hasAnyUserData(s)).toBe(false);
+  });
+
+  it('returns true for a task repeat config', () => {
+    const s = initialState();
+    s.taskRepeatCfg = { ids: ['rc1'], entities: {} };
+    expect(hasAnyUserData(s)).toBe(true);
   });
 });

--- a/src/app/op-log/validation/has-meaningful-state-data.util.ts
+++ b/src/app/op-log/validation/has-meaningful-state-data.util.ts
@@ -7,6 +7,9 @@ const isEntityState = (obj: unknown): obj is { ids: string[] } =>
   'ids' in obj &&
   Array.isArray((obj as { ids: unknown }).ids);
 
+const isNonEmptyRecord = (obj: unknown): obj is Record<string, unknown> =>
+  typeof obj === 'object' && obj !== null && Object.keys(obj).length > 0;
+
 /**
  * Returns true if the given (partial) app state contains user-created data worth
  * protecting: at least one task, a non-INBOX project, a non-system tag, or a note.
@@ -18,12 +21,13 @@ const isEntityState = (obj: unknown): obj is { ids: string[] } =>
  * - the snapshot/compaction empty-overwrite guard (prevents a transient degraded
  *   NgRx state from being cached over a good snapshot — see issue #7892).
  *
- * Scope is intentionally narrow (these four collections only) and is always consumed
- * in the "safe" direction: a false negative merely SKIPS work (a snapshot save, a
- * compaction, or a fresh-client sync prompt) — it can never cache empty-over-good or
- * delete data. Omitting models like simpleCounter / taskRepeatCfg / timeTracking
- * therefore cannot lose data; it would only forgo the snapshot/compaction optimization
- * for a data-less-but-active store, so it is left out of this safety fix by design.
+ * Scope is intentionally narrow (these four collections only). Most callers consume
+ * it in the "safe" direction, where a false negative merely SKIPS work (a snapshot
+ * save, a compaction) and can never cache empty-over-good. `hasNothingWorthUploading`
+ * consumes it in the REFUSING direction (#9256), where a false POSITIVE is the
+ * dangerous one — it would let a device holding nothing overwrite the server. Keep
+ * this predicate narrow for that reason: widen {@link hasAnyUserData} instead, which
+ * is scoped to the callers that need the wider notion.
  *
  * Accepts an arbitrary object so callers can pass an NgRx snapshot, a loaded
  * state cache, or a remote payload without type juggling.
@@ -65,4 +69,90 @@ export const hasMeaningfulStateData = (
   }
 
   return false;
+};
+
+/** `{ project: { [ctxId]: { [date]: … } }, tag: { … } }` — any context with a tracked day. */
+const hasTimeTrackingEntries = (timeTracking: unknown): boolean => {
+  if (typeof timeTracking !== 'object' || timeTracking === null) {
+    return false;
+  }
+  const { project, tag } = timeTracking as { project?: unknown; tag?: unknown };
+  return [project, tag].some(
+    (byContext) =>
+      typeof byContext === 'object' &&
+      byContext !== null &&
+      Object.values(byContext).some(isNonEmptyRecord),
+  );
+};
+
+/** `archiveYoung` / `archiveOld`: archived tasks or flushed time tracking. */
+const hasArchiveData = (archive: unknown): boolean => {
+  if (typeof archive !== 'object' || archive === null) {
+    return false;
+  }
+  const a = archive as { task?: unknown; timeTracking?: unknown };
+  return (
+    (isEntityState(a.task) && a.task.ids.length > 0) ||
+    hasTimeTrackingEntries(a.timeTracking)
+  );
+};
+
+/**
+ * {@link hasMeaningfulStateData} plus the collections a legacy-migrated client can
+ * hold when it has no active task, project, tag or note at all: archived tasks and
+ * their flushed time tracking, live time tracking, and task repeat configs (#9932).
+ *
+ * Only the join-time gate (`SyncLocalStateService.hasMeaningfulStoreData`) uses this.
+ * An archive-only client failed the narrow check, so on an empty server nothing
+ * seeded its state and a peer's later SYNC_IMPORT was applied over it silently; on
+ * file-based providers the remote snapshot was hydrated without a dialog. Either way
+ * the archive and worklog on that device were gone.
+ *
+ * That gate has two flavours: the no-arg fresh-client protections, and the #7985
+ * file-based conflict gate which passes the pending example-task ids. The widened
+ * dimensions are not narrowable by `ignoreTaskIds` (they carry no task id), but on
+ * that second path any tracked time has already emitted a TIME_TRACKING op, which
+ * the pending-op gate counts as meaningful before this is consulted.
+ *
+ * Deliberately kept OUT of `hasMeaningfulStateData` so it cannot leak into that
+ * predicate's other consumers — most importantly `hasNothingWorthUploading` (#9256),
+ * where saying "has data" too eagerly permits a destructive server overwrite. Time
+ * tracked against onboarding example tasks is exactly such a false positive, and
+ * `ignoreTaskIds` cannot discount it.
+ *
+ * Archives are only visible on an archive-inclusive snapshot; the synchronous store
+ * snapshot substitutes an empty DEFAULT_ARCHIVE.
+ *
+ * Everything counted is strictly non-default, which keeps this a subset of
+ * `hasServerMigrationStateData` (server-migration.service.ts) — its MODEL_CONFIGS
+ * sweep covers all four of these keys — so a client this gate protects always has
+ * something for the seeding to ship.
+ *
+ * Not counted: `simpleCounter` and the remaining non-entity slices. The default state
+ * SHIPS three simple counters (DEFAULT_SIMPLE_COUNTERS), so a presence check would
+ * call a brand-new install "meaningful" and revive the spurious conflict dialog
+ * #7976/#7980 removed. Counting them needs a strictly-non-default test (e.g. a
+ * counter with a non-empty countOnDay), not a presence test.
+ */
+export const hasAnyUserData = (
+  state: unknown,
+  ignoreTaskIds?: ReadonlySet<string>,
+): boolean => {
+  if (hasMeaningfulStateData(state, ignoreTaskIds)) {
+    return true;
+  }
+  if (!state || typeof state !== 'object') {
+    return false;
+  }
+  const s = state as Record<string, unknown>;
+
+  if (isEntityState(s.taskRepeatCfg) && s.taskRepeatCfg.ids.length > 0) {
+    return true;
+  }
+
+  return (
+    hasTimeTrackingEntries(s.timeTracking) ||
+    hasArchiveData(s.archiveYoung) ||
+    hasArchiveData(s.archiveOld)
+  );
 };


### PR DESCRIPTION
## Problem

Follow-ups from #9921 (PR #9930, now merged), filed as #9932. Rebased onto current master, so it is a single commit.

**1. A legacy-migrated client whose work is entirely archived was treated at join time as having nothing to protect — a real, pre-existing data-loss path.**

`hasMeaningfulStateData` counts tasks, non-INBOX projects, non-system tags and notes. An archive-only client fails that check, and `SyncLocalStateService.hasMeaningfulStoreData()` read the synchronous store snapshot, which substitutes an empty `DEFAULT_ARCHIVE`. Consequences on the join-time paths from #9863/#9921:

- Empty server: nothing seeded the client's state, so it stayed on that device only.
- Once its upload had gone through, a peer's later `SYNC_IMPORT` reached the incoming-import gate with zero pending ops and was applied silently. The archive and worklog on that device were gone.
- File-based providers: same cohort, `hasLocalChanges` false and not wholly fresh, so the remote snapshot was hydrated without a dialog.

The util's own comment claimed a false negative "can never delete data"; through this path it could.

**2. Server-reset seeding still reported `server_migration_handled` unconditionally.** In the `needsFullStateUpload` branch, `handleServerMigration()` can return without creating anything, yet the branch persisted `lastServerSeq` and reported handled. #9921 fixed only the empty-server branch.

**3. `getFirstOpEntry` read the whole table on SQLite.** `sqlIterate` runs `SELECT … ORDER BY …` with no `LIMIT` and materializes every row before honoring `'stop'`.

## Solution

**1.** Adds `hasAnyUserData` next to `hasMeaningfulStateData`: the narrow predicate widened with archived tasks and their flushed time tracking, live time tracking, and task repeat configs. `hasMeaningfulStoreData` uses it and is now async, because only the archive-inclusive snapshot can answer for an archive-only client.

The wider notion is **deliberately confined to that one gate** rather than folded into `hasMeaningfulStateData`. #9256 (#9931) has just made `hasNothingWorthUploading` a consumer of the narrow predicate in the **refusing** direction, where saying "has data" too eagerly permits a destructive server overwrite from a device holding nothing — and time tracked against onboarding example tasks is exactly such a false positive, one `ignoreTaskIds` cannot discount. A util spec pins that `hasMeaningfulStateData` stays narrow, so a future widening trips a test rather than quietly reopening that hole.

Consequently the other six consumers — the #7892 snapshot/compaction guard, the local-backup skip and ring, the op-log hydrator's replay-fallback gate, `hasServerMigrationStateData`, and `hasNothingWorthUploading` — see **no behaviour change at all**.

Everything `hasAnyUserData` counts is strictly non-default, so the gate stays a subset of the seeding's own check (`hasServerMigrationStateData`, whose `MODEL_CONFIGS` sweep covers all four keys). A client this gate protects always has something for the seeding to ship.

**2.** `handleServerMigration` returns a `ServerMigrationOutcome` (`created` / `reused_pending` / `skipped` + reason) instead of `string | undefined`, resolving the ambiguity the issue describes: `undefined` previously conflated "nothing was created" with "an already-pending import will still upload". In the server-reset branch, `created` and `reused_pending` persist `lastServerSeq` and report handled; a skip other than `empty_state` reports `server_migration_skipped` so the upload waits for the next cycle; `empty_state` persists `lastServerSeq` and lets the ordinary upload proceed. The empty-server branch keeps the #9921 behaviour, and `FORCE_UPLOAD` requires `created`.

**3.** `getFirstOpEntry` passes `limit: 1`, so SQLite emits `LIMIT 1`. `getLastSeq` already did this (#8313), contrary to the issue text.

### Reproductions

Per the repo rule that a sync fix must carry a test that fails without it, each item was verified to fail against pre-fix production code in a throwaway worktree:

| Item | Pinning tests | Pre-fix |
| --- | --- | --- |
| 1, predicate | `has-meaningful-state-data.util.spec.ts` (archive, time tracking, repeat cfg) | 3 fail |
| 1, async fallback | `sync-local-state.service.spec.ts` | 3 fail |
| 1, real path | `operation-log-sync.service.spec.ts` (conflict on non-empty server, seeding on empty server, no silent file-based hydration) | fail |
| 2 | `server-migration.service.spec.ts` outcomes + the `server_migration_skipped` / `no_new_ops` routing tests | fail |
| 3 | `operation-log-store.service.spec.ts` limit push-down | fail |

Plus one test that is not a reproduction but a boundary pin: `hasMeaningfulStateData` must NOT count archives, time tracking or repeat configs, which is what keeps #9256's guard intact.

The sync-service tests inject the real `SyncLocalStateService` and the real util, so they exercise the fix rather than a stub; only `StateSnapshotService` is mocked, at fixtures that reproduce the real `DEFAULT_ARCHIVE` exactly.

A SuperSync E2E (`archive-only legacy client joining a server with ordinary ops gets the conflict dialog`) mirrors the #9921 genesis-only test and asserts the dialog plus the archive reaching the peer through the `SYNC_IMPORT`. It derives its data from the existing `legacy-migration-client-b.json` fixture via `toArchiveOnlyLegacyData`, so no new fixture file is added. It runs in this PR's sync E2E gate.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — `docs/sync-and-op-log/operation-log-architecture.md` §A.3; no user-facing behaviour change to document.
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

### Risk notes

Everything here is in the sync layer, so the risks are worth stating explicitly.

**Interaction with #9256 (#9931), which landed while this was open.** That change made `hasNothingWorthUploading` the first consumer of `hasMeaningfulStateData` in the refusing direction. Widening that shared predicate — which is what this PR originally did — would have let a device whose only signal is time tracked on example tasks pass the "has data" check and perform a destructive server overwrite. The split into `hasAnyUserData` exists specifically to avoid that, and the boundary is pinned by a test.

**Blast radius of the reset-branch skip.** A previously-synced client on a reset server whose state fails `validateAndRepair` now stays blocked instead of uploading incremental ops onto a server with no base state. #9921 chose this trade for fresh/genesis clients; this extends it to any synced client on a reset server.

The user-facing messaging is unchanged from master: the `SERVER_MIGRATION_VALIDATION_FAILED` snack and its once-per-session throttle already exist, and the text names the remedy — "Please try importing a backup" — which is a real path, since importing a backup replaces the state with valid data, validation then passes and seeding proceeds. Sync status also stays `UNKNOWN_OR_CHANGED` rather than reporting success, so the not-in-sync signal persists past the snack. What changes is only that the client no longer performs the harmful upload while in that state: previously it shipped ordinary ops to a server holding no base state and advanced `lastServerSeq`, after which the migration check never fired again and the state was stranded for good. Reaching this state at all means the store is corrupt beyond what `validateAndRepair` can fix, so the block is a symptom rather than the disease.

`server_not_empty` is self-resolving (the next download sees a non-empty server and takes the normal path). `no_client_id` has no user-visible signal, but sync cannot work without a client id anyway.

**`hasMeaningfulStoreData` can now reject.** The archive read can throw on an IndexedDB failure, where the old synchronous check could not. That is fail-closed: the sync cycle aborts with an error and nothing is applied or uploaded. The previous behaviour on an unreadable archive would have been to answer "no meaningful data" and adopt the peer's state — the very loss this PR fixes.

**Known gap, pre-existing and deliberately not fixed here:** `ServerMigrationService.checkAndHandleMigration` discards the new outcome at both of its internal call sites, and it is wired as the upload `preUploadCallback`, whose result the upload service does not inspect. So on the user-confirmed provider-switch path onto a non-empty server, a skipped seeding still lets ordinary ops upload — the same bug class as item 2, in a third call site. It predates this change, is outside #9932's scope, and I could not construct a confirmed reachable failure for it, so per the repo's "do not fix one blind" rule it is left for a follow-up rather than fixed speculatively. The new `ServerMigrationOutcome` type makes it a small change when someone reproduces it.

**Not counted, on purpose:** `simpleCounter` (named in the issue) and the other non-entity slices. The default state ships three counters, so a presence check would call a fresh install "meaningful" and revive the spurious conflict dialog #7976/#7980 removed. Counting them needs a strictly-non-default test rather than `ids.length`; the util documents this so the next reader does not reintroduce that bug.

**Service size:** `operation-log-sync.service.ts` grows by 23 lines and `operation-log-store.service.ts` by 4. Both are on the grandfathered `max-lines` warn list (0 lint errors, no new entries added), but the rule asks that touched offenders shrink rather than grow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01939vch294buzXTE45g1UcU