### PR TITLE
fix(focus-mode): scope the Pomodoro work duration to the run #9645

### DIFF
--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.html
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.html
@@ -100,11 +100,6 @@
           <!-- Clock time display -->
           <div
             class="clock-time"
-            [matTooltip]="
-              isShowDurationSlider()
-                ? (T.F.FOCUS_MODE.CLICK_TO_EDIT_DURATION | translate)
-                : ''
-            "
             [title]="T.F.FOCUS_MODE.FOCUS_TIME_TOOLTIP | translate"
           >
             @if (focusModeService.isInOvertime()) {
@@ -161,6 +156,7 @@
               [hideHandle]="isPomodoro()"
               [useFlexibleIncrement]="!isPomodoro()"
               [blurOnEnter]="true"
+              [valueTitle]="T.F.FOCUS_MODE.CLICK_TO_EDIT_DURATION | translate"
               (modelChange)="onDurationChange($event)"
             ></input-duration-slider>
           </div>

--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.spec.ts
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.spec.ts
@@ -68,6 +68,7 @@ describe('FocusModeMainComponent', () => {
   let currentTaskSubject: BehaviorSubject<TaskCopy | null>;
   let mainStateSignal: WritableSignal<FocusMainUIState>;
   let mockMatDialog: jasmine.SpyObj<MatDialog>;
+  let globalConfigServiceSpy: jasmine.SpyObj<GlobalConfigService>;
 
   const mockTask: TaskCopy = {
     id: 'task-1',
@@ -89,11 +90,15 @@ describe('FocusModeMainComponent', () => {
 
   beforeEach(async () => {
     mainStateSignal = signal(FocusMainUIState.Preparation);
-    const globalConfigServiceSpy = jasmine.createSpyObj('GlobalConfigService', [], {
-      tasks: jasmine.createSpy().and.returnValue({
-        notesTemplate: 'Default task notes template',
-      }),
-    });
+    globalConfigServiceSpy = jasmine.createSpyObj(
+      'GlobalConfigService',
+      ['updateSection'],
+      {
+        tasks: jasmine.createSpy().and.returnValue({
+          notesTemplate: 'Default task notes template',
+        }),
+      },
+    );
 
     currentTaskSubject = new BehaviorSubject<TaskCopy | null>(mockTask);
     const taskServiceSpy = jasmine.createSpyObj(
@@ -136,6 +141,7 @@ describe('FocusModeMainComponent', () => {
         isSkipPreparation: false,
       }),
       pomodoroConfig: jasmine.createSpy().and.returnValue(undefined),
+      sessionWorkDuration: jasmine.createSpy().and.returnValue(null),
       isInOvertime: jasmine.createSpy().and.returnValue(false),
       isSessionPaused: jasmine.createSpy().and.returnValue(false),
     });
@@ -666,6 +672,34 @@ describe('FocusModeMainComponent', () => {
     });
   });
 
+  describe('onDurationChange (issue #9645)', () => {
+    it('should remember a Pomodoro duration for the run instead of writing config', () => {
+      component.onDurationChange(2400000);
+
+      expect(component.displayDuration()).toBe(2400000);
+      expect(mockStore.dispatch).toHaveBeenCalledWith(
+        actions.setFocusSessionDuration({ focusSessionDuration: 2400000 }),
+      );
+      expect(mockStore.dispatch).toHaveBeenCalledWith(
+        actions.setSessionWorkDuration({ duration: 2400000 }),
+      );
+      expect(globalConfigServiceSpy.updateSection).not.toHaveBeenCalled();
+    });
+
+    it('should not remember a duration outside Pomodoro mode', () => {
+      (focusModeServiceSpy.mode as jasmine.Spy).and.returnValue(FocusModeMode.Countdown);
+
+      component.onDurationChange(2400000);
+
+      expect(mockStore.dispatch).toHaveBeenCalledWith(
+        actions.setFocusSessionDuration({ focusSessionDuration: 2400000 }),
+      );
+      expect(mockStore.dispatch).not.toHaveBeenCalledWith(
+        actions.setSessionWorkDuration({ duration: 2400000 }),
+      );
+    });
+  });
+
   describe('mode selector visibility', () => {
     it('should show mode selector in preparation state (default)', () => {
       // Default setup has: mainState=Preparation
@@ -812,6 +846,7 @@ describe('FocusModeMainComponent - notes panel (issue #5752)', () => {
         isSkipPreparation: false,
       }),
       pomodoroConfig: signal(undefined),
+      sessionWorkDuration: signal(null),
       isInOvertime: signal(false),
     };
 
@@ -1160,6 +1195,7 @@ describe('FocusModeMainComponent - sync with tracking (issue #6009)', () => {
       mainState: mainStateSignal,
       focusModeConfig: focusModeConfigSignal,
       pomodoroConfig: signal(undefined),
+      sessionWorkDuration: signal(null),
       isInOvertime: signal(false),
     };
 

--- a/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.ts
+++ b/src/app/features/focus-mode/focus-mode-main/focus-mode-main.component.ts
@@ -10,10 +10,10 @@ import {
   signal,
 } from '@angular/core';
 import { Log } from '../../../core/log';
-import { from, Observable, of, Subject, Subscription, timer } from 'rxjs';
+import { from, Observable, of, Subscription, timer } from 'rxjs';
 import { GlobalConfigService } from '../../config/global-config.service';
 import { TaskService } from '../../tasks/task.service';
-import { debounceTime, switchMap, take } from 'rxjs/operators';
+import { switchMap, take } from 'rxjs/operators';
 import { TaskAttachmentService } from '../../tasks/task-attachment/task-attachment.service';
 import { fadeAnimation, fadeSwapAnimation } from '../../../ui/animations/fade.ani';
 import { IssueService } from '../../issue/issue.service';
@@ -30,6 +30,7 @@ import {
   selectFocusTask,
   setFocusModeMode,
   setFocusSessionDuration,
+  setSessionWorkDuration,
   startFocusPreparation,
   startFocusSession,
   unPauseFocusSession,
@@ -230,11 +231,6 @@ export class FocusModeMainComponent {
   displayDuration = signal(25 * 60 * 1000); // Default 25 minutes
   isTaskSelectorOpen = signal(false);
 
-  // Pomodoro's work duration lives in synced global config. Persisting on every
-  // keystroke emits one sync op per character, so coalesce rapid edits and write
-  // once the user pauses (or when the session starts — see startSession()).
-  private readonly _pomodoroDurationToPersist$ = new Subject<number>();
-
   // OS-level window focus. When the user tabs away (or focuses another app),
   // hide the muted control buttons so we don't blink at them.
   readonly isWindowFocused = signal(
@@ -341,11 +337,13 @@ export class FocusModeMainComponent {
         return;
       }
 
-      // Pomodoro's editable duration is its configured work-period — read
-      // straight from pomodoroConfig so the slider reflects the persisted
-      // value, not the (initially zero) session duration.
+      // Pomodoro's editable duration is the one typed for this run, else its
+      // configured work-period — read straight from either so the slider shows
+      // what will run, not the (initially zero) session duration.
       if (mode === FocusModeMode.Pomodoro && this._isPreparation()) {
-        const pomodoroDuration = this.focusModeService.pomodoroConfig()?.duration;
+        const pomodoroDuration =
+          this.focusModeService.sessionWorkDuration() ??
+          this.focusModeService.pomodoroConfig()?.duration;
         this.displayDuration.set(
           pomodoroDuration && pomodoroDuration > 0
             ? pomodoroDuration
@@ -366,10 +364,6 @@ export class FocusModeMainComponent {
         this.displayDuration.set(stored);
       }
     });
-
-    this._pomodoroDurationToPersist$
-      .pipe(debounceTime(400), takeUntilDestroyed())
-      .subscribe((duration) => this._persistPomodoroDuration(duration));
   }
 
   @HostListener('window:focus') onWindowFocus(): void {
@@ -497,12 +491,6 @@ export class FocusModeMainComponent {
       return;
     }
 
-    // Persist any pending (debounced) Pomodoro duration edit before starting so
-    // a value typed within the debounce window isn't dropped.
-    if (this.mode() === FocusModeMode.Pomodoro) {
-      this._persistPomodoroDuration(this.displayDuration());
-    }
-
     const config = this.focusModeConfig();
 
     // Sync between focus session and tracking is always on — require a task
@@ -612,22 +600,12 @@ export class FocusModeMainComponent {
 
   onDurationChange(duration: number): void {
     this.displayDuration.set(duration);
-
-    // Pomodoro's duration is persistent (synced) config, not session store.
-    // Debounce the write (see _pomodoroDurationToPersist$) so typing "25" emits
-    // one sync op rather than one per keystroke.
-    if (this.mode() === FocusModeMode.Pomodoro) {
-      this._pomodoroDurationToPersist$.next(duration);
-      return;
-    }
-
     this._store.dispatch(setFocusSessionDuration({ focusSessionDuration: duration }));
-  }
 
-  private _persistPomodoroDuration(duration: number): void {
-    const current = this.focusModeService.pomodoroConfig();
-    if (current && current.duration !== duration) {
-      this._globalConfigService.updateSection('pomodoro', { ...current, duration }, true);
+    // Pomodoro chains cycles without ever showing this screen again, so the
+    // typed duration is remembered for the run rather than written to config.
+    if (this.mode() === FocusModeMode.Pomodoro) {
+      this._store.dispatch(setSessionWorkDuration({ duration }));
     }
   }
 

--- a/src/app/features/focus-mode/focus-mode-strategies.spec.ts
+++ b/src/app/features/focus-mode/focus-mode-strategies.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { GlobalConfigService } from '../config/global-config.service';
 import {
   PomodoroStrategy,
@@ -8,10 +9,13 @@ import {
 } from './focus-mode-strategies';
 import { FocusModeMode, FocusScreen, FOCUS_MODE_DEFAULTS } from './focus-mode.model';
 import { FocusModeStorageService } from './focus-mode-storage.service';
+import { initialState as focusModeInitialState } from './store/focus-mode.reducer';
+import { selectSessionWorkDuration } from './store/focus-mode.selectors';
 
 describe('FocusModeStrategies', () => {
   let mockGlobalConfigService: jasmine.SpyObj<GlobalConfigService>;
   let focusModeStorage: jasmine.SpyObj<FocusModeStorageService>;
+  let store: MockStore;
 
   beforeEach(() => {
     const globalConfigServiceSpy = jasmine.createSpyObj('GlobalConfigService', [], {
@@ -30,6 +34,7 @@ describe('FocusModeStrategies', () => {
         FlowtimeStrategy,
         CountdownStrategy,
         FocusModeStrategyFactory,
+        provideMockStore({ initialState: { focusMode: focusModeInitialState } }),
         { provide: GlobalConfigService, useValue: globalConfigServiceSpy },
         {
           provide: FocusModeStorageService,
@@ -48,6 +53,13 @@ describe('FocusModeStrategies', () => {
       FocusModeStorageService,
     ) as jasmine.SpyObj<FocusModeStorageService>;
     focusModeStorage.getLastCountdownDuration.and.returnValue(null);
+    store = TestBed.inject(MockStore);
+  });
+
+  // overrideSelector memoizes on the selector itself, so a leaked override
+  // would follow into the next spec.
+  afterEach(() => {
+    store.resetSelectors();
   });
 
   describe('PomodoroStrategy', () => {
@@ -69,6 +81,24 @@ describe('FocusModeStrategies', () => {
         expect(strategy.initialSessionDuration).toBe(
           FOCUS_MODE_DEFAULTS.SESSION_DURATION,
         );
+      });
+
+      it('should prefer the session work duration over the config', () => {
+        store.overrideSelector(selectSessionWorkDuration, 2400000);
+        store.refreshState();
+
+        expect(strategy.initialSessionDuration).toBe(2400000);
+      });
+
+      it('should fall back to the config once the session work duration is cleared', () => {
+        store.overrideSelector(selectSessionWorkDuration, 2400000);
+        store.refreshState();
+        expect(strategy.initialSessionDuration).toBe(2400000);
+
+        store.overrideSelector(selectSessionWorkDuration, null);
+        store.refreshState();
+
+        expect(strategy.initialSessionDuration).toBe(1500000);
       });
     });
 

--- a/src/app/features/focus-mode/focus-mode-strategies.ts
+++ b/src/app/features/focus-mode/focus-mode-strategies.ts
@@ -1,4 +1,5 @@
 import { Injectable, inject } from '@angular/core';
+import { Store } from '@ngrx/store';
 import {
   FocusModeStrategy,
   FocusScreen,
@@ -7,14 +8,22 @@ import {
 } from './focus-mode.model';
 import { GlobalConfigService } from '../config/global-config.service';
 import { FocusModeStorageService } from './focus-mode-storage.service';
+import { selectSessionWorkDuration } from './store/focus-mode.selectors';
 
 const MIN_BREAK_MS = 60 * 1000;
 
 @Injectable({ providedIn: 'root' })
 export class PomodoroStrategy implements FocusModeStrategy {
   private globalConfigService = inject(GlobalConfigService);
+  private sessionWorkDuration = inject(Store).selectSignal(selectSessionWorkDuration);
 
   get initialSessionDuration(): number {
+    // A duration typed on the preparation screen governs the whole run, so the
+    // cycles started after a break keep it instead of falling back to config.
+    const sessionDuration = this.sessionWorkDuration();
+    if (sessionDuration) {
+      return sessionDuration;
+    }
     const config = this.globalConfigService.pomodoroConfig();
     return config?.duration ?? FOCUS_MODE_DEFAULTS.SESSION_DURATION;
   }

--- a/src/app/features/focus-mode/focus-mode.model.spec.ts
+++ b/src/app/features/focus-mode/focus-mode.model.spec.ts
@@ -206,6 +206,7 @@ describe('FocusModeModel', () => {
         pausedTaskId: null,
         _isResumingBreak: false,
         _isOvertimeEnabled: false,
+        _sessionWorkDuration: null,
       };
 
       expect(state.timer).toEqual(timer);

--- a/src/app/features/focus-mode/focus-mode.model.ts
+++ b/src/app/features/focus-mode/focus-mode.model.ts
@@ -53,6 +53,11 @@ export interface FocusModeState {
 
   // Internal flag: when true, tick reducer won't auto-stop work timer at duration
   _isOvertimeEnabled: boolean;
+
+  // Internal: Pomodoro work duration typed on the preparation screen. Overrides
+  // the configured duration for every cycle of this run and is never persisted,
+  // so the configured value stays the default after a restart.
+  _sessionWorkDuration: number | null;
 }
 
 // Mode strategy interface

--- a/src/app/features/focus-mode/focus-mode.service.ts
+++ b/src/app/features/focus-mode/focus-mode.service.ts
@@ -30,6 +30,7 @@ export class FocusModeService {
   timeRemaining = this._store.selectSignal(selectors.selectTimeRemaining);
   progress = this._store.selectSignal(selectors.selectProgress);
   sessionDuration = this._store.selectSignal(selectors.selectTimeDuration);
+  sessionWorkDuration = this._store.selectSignal(selectors.selectSessionWorkDuration);
 
   // Session signals
   isSessionRunning = this._store.selectSignal(selectors.selectIsSessionRunning);

--- a/src/app/features/focus-mode/store/focus-mode.actions.ts
+++ b/src/app/features/focus-mode/store/focus-mode.actions.ts
@@ -74,6 +74,15 @@ export const setFocusSessionDuration = createAction(
   props<{ focusSessionDuration: number }>(),
 );
 
+/**
+ * Pomodoro work duration typed on the preparation screen. Session-scoped: it
+ * survives breaks so later cycles run the same length, but is never persisted.
+ */
+export const setSessionWorkDuration = createAction(
+  '[FocusMode] Set Session Work Duration',
+  props<{ duration: number }>(),
+);
+
 export const completeTask = createAction('[FocusMode] Complete Task');
 
 export const adjustRemainingTime = createAction(

--- a/src/app/features/focus-mode/store/focus-mode.reducer.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.reducer.spec.ts
@@ -10,6 +10,7 @@ import {
   FocusScreen,
   FOCUS_MODE_DEFAULTS,
 } from '../focus-mode.model';
+import { updateGlobalConfigSection } from '../../config/store/global-config.actions';
 
 describe('FocusModeReducer', () => {
   beforeEach(() => {
@@ -665,6 +666,58 @@ describe('FocusModeReducer', () => {
     });
   });
 
+  describe('session work duration (#9645)', () => {
+    const SESSION_DURATION = 40 * 60 * 1000;
+
+    it('should set the session work duration', () => {
+      const result = focusModeReducer(
+        initialState,
+        a.setSessionWorkDuration({ duration: SESSION_DURATION }),
+      );
+
+      expect(result._sessionWorkDuration).toBe(SESSION_DURATION);
+    });
+
+    it('should survive a full Pomodoro cycle so the next session reuses it', () => {
+      const cycle = [
+        a.completeFocusSession({ isManual: false }),
+        a.incrementCycle(),
+        a.startBreak({ duration: 5 * 60 * 1000 }),
+        a.completeBreak({}),
+      ];
+
+      const result = cycle.reduce(
+        focusModeReducer,
+        focusModeReducer(
+          initialState,
+          a.setSessionWorkDuration({ duration: SESSION_DURATION }),
+        ),
+      );
+
+      expect(result._sessionWorkDuration).toBe(SESSION_DURATION);
+    });
+
+    it('should be cleared when the user leaves focus mode', () => {
+      const state = { ...initialState, _sessionWorkDuration: SESSION_DURATION };
+      const result = focusModeReducer(state, a.cancelFocusSession());
+
+      expect(result._sessionWorkDuration).toBeNull();
+    });
+
+    it('should survive a Pomodoro settings save, local or synced from another device', () => {
+      const state = { ...initialState, _sessionWorkDuration: SESSION_DURATION };
+      const result = focusModeReducer(
+        state,
+        updateGlobalConfigSection({
+          sectionKey: 'pomodoro',
+          sectionCfg: { duration: 30 * 60 * 1000 },
+        }),
+      );
+
+      expect(result._sessionWorkDuration).toBe(SESSION_DURATION);
+    });
+  });
+
   describe('cycle management', () => {
     it('should increment cycle', () => {
       const action = a.incrementCycle();
@@ -923,6 +976,34 @@ describe('FocusModeReducer', () => {
       );
 
       expect(result.mode).toBe(FocusModeMode.Pomodoro);
+    });
+
+    it('re-seeds the session work duration from a restored Pomodoro work session', () => {
+      const result = focusModeReducer(
+        { ...initialState, mode: FocusModeMode.Pomodoro },
+        a.restoreFocusSessionFromNative({
+          durationMs: 40 * 60 * 1000,
+          remainingMs: 10 * 60 * 1000,
+          isBreak: false,
+          isPaused: false,
+        }),
+      );
+
+      expect(result._sessionWorkDuration).toBe(40 * 60 * 1000);
+    });
+
+    it('does not seed the session work duration from a restored break', () => {
+      const result = focusModeReducer(
+        { ...initialState, mode: FocusModeMode.Pomodoro },
+        a.restoreFocusSessionFromNative({
+          durationMs: 5 * 60 * 1000,
+          remainingMs: 2 * 60 * 1000,
+          isBreak: true,
+          isPaused: false,
+        }),
+      );
+
+      expect(result._sessionWorkDuration).toBeNull();
     });
 
     it('clamps elapsed to 0 if remaining exceeds duration', () => {

--- a/src/app/features/focus-mode/store/focus-mode.reducer.ts
+++ b/src/app/features/focus-mode/store/focus-mode.reducer.ts
@@ -35,6 +35,7 @@ export const initialState: FocusModeState = {
   pausedTaskId: null,
   _isResumingBreak: false,
   _isOvertimeEnabled: false,
+  _sessionWorkDuration: null,
 };
 
 const createWorkTimer = (duration: number): TimerState => ({
@@ -199,6 +200,8 @@ export const focusModeReducer = createReducer(
     isOverlayShown: false,
     pausedTaskId: null,
     _isOvertimeEnabled: false,
+    // Leaving focus mode ends the run the typed duration belonged to.
+    _sessionWorkDuration: null,
   })),
 
   // Flowtime end-of-session: store elapsed duration and pause the timer. The
@@ -301,6 +304,13 @@ export const focusModeReducer = createReducer(
     };
   }),
 
+  // Pomodoro only: remember the typed duration for the rest of this run. Kept
+  // outside `timer`, which completeBreak resets, so later cycles still see it.
+  on(a.setSessionWorkDuration, (state, { duration }) => ({
+    ...state,
+    _sessionWorkDuration: duration,
+  })),
+
   // Cycle management
   on(a.incrementCycle, (state) => ({
     ...state,
@@ -395,6 +405,12 @@ export const focusModeReducer = createReducer(
         // running timer; we don't pop the full-screen overlay on app reopen.
         currentScreen: isBreak ? FocusScreen.Break : FocusScreen.Main,
         mainState: FocusMainUIState.InProgress,
+        // The restored work session is the only surviving record of a typed
+        // duration, so re-seed it or the next cycle would drop to the config.
+        _sessionWorkDuration:
+          !isBreak && mode === FocusModeMode.Pomodoro
+            ? durationMs
+            : state._sessionWorkDuration,
       };
     },
   ),

--- a/src/app/features/focus-mode/store/focus-mode.selectors.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.selectors.spec.ts
@@ -30,6 +30,7 @@ describe('FocusModeSelectors', () => {
     pausedTaskId: null,
     _isResumingBreak: false,
     _isOvertimeEnabled: false,
+    _sessionWorkDuration: null,
     ...overrides,
   });
 

--- a/src/app/features/focus-mode/store/focus-mode.selectors.ts
+++ b/src/app/features/focus-mode/store/focus-mode.selectors.ts
@@ -107,6 +107,12 @@ export const selectIsResumingBreak = createSelector(
   (state) => state._isResumingBreak,
 );
 
+// Session-scoped Pomodoro work duration (preparation screen override)
+export const selectSessionWorkDuration = createSelector(
+  selectFocusModeState,
+  (state) => state._sessionWorkDuration,
+);
+
 // Overtime selectors
 export const selectIsOvertimeEnabled = createSelector(
   selectFocusModeState,

--- a/src/app/ui/duration/input-duration-slider/input-duration-slider.component.html
+++ b/src/app/ui/duration/input-duration-slider/input-duration-slider.component.html
@@ -28,6 +28,7 @@
       [id]="uid"
       [ngModel]="_model()"
       [placeholder]="T.G.EXAMPLE_VAL | translate"
+      [title]="valueTitle()"
       class="value"
       inputDuration="optional"
       spellcheck="false"

--- a/src/app/ui/duration/input-duration-slider/input-duration-slider.component.ts
+++ b/src/app/ui/duration/input-duration-slider/input-duration-slider.component.ts
@@ -61,6 +61,11 @@ export class InputDurationSliderComponent implements OnInit, OnDestroy {
   // for Pomodoro preparation, where the duration is typed rather than dragged.
   readonly hideHandle = input(false);
 
+  // Native tooltip for the editable value — the only hint that the value can be
+  // typed at all in the handle-less variant. Opt-in so the other consumers,
+  // where the input is an ordinary labelled field, stay untouched.
+  readonly valueTitle = input('');
+
   // On Enter, commit the typed value and drop focus. Opt-in (focus-mode) only:
   // blurring on Enter cancels the browser's implicit form submission, so the
   // default must stay off or the time-estimate dialogs (slider inside a <form>


### PR DESCRIPTION
## Problem

Editing the duration on the focus preparation screen wrote the global synced pomodoro config, so adjusting one session changed the default on every device (#9645).

That write was also load bearing. The auto-start effects read `strategy.initialSessionDuration`, which for Pomodoro is just `pomodoroConfig().duration`, so the global write was the only thing carrying a changed duration past the first break. Removing it alone would trade "changes the default everywhere" for "reverts to 25 after the first break".

## Solution

As specified in #9645. The value lives on `FocusModeState` as `_sessionWorkDuration`, outside `timer` since `completeBreak` resets that. `PomodoroStrategy.initialSessionDuration` prefers it and falls back to `pomodoroConfig().duration`, so all four consumers stay unchanged, both auto-start effects included. Prep screen writes it instead of `_persistPomodoroDuration`, which is gone together with its debounce subject. Not persisted, so restart brings back the config value.

Two calls are yours.

`onDurationChange` now also dispatches `setFocusSessionDuration` for Pomodoro. It returned early before and never touched `timer.duration`, the config write reached it through `syncDurationWithPomodoroConfig$`. Dropping the write alone left the timer stale through preparation, visible on the rocket countdown and in `selectProgress`.

`restoreFocusSessionFromNative` re-seeds the field for a Pomodoro work session. Without it an Android session re-adopted after an app swipe falls back to config at the next cycle, which is worse than today. It does diverge from "gone on restart", so tell me and I drop it.

I had a clear-on-`updateGlobalConfigSection` in there too and removed it: it fired on any save of the pomodoro section, and also on that same action replayed from another device op log, which puts the cross device coupling back, just pointing other way.

Two side effects worth naming. `syncTrackingStartToSession$` inherits the value, so with `autoStartFocusOnPlay` pressing play later in the run starts at the typed duration. And `CLICK_TO_EDIT_DURATION` moved to the slider value, it was bound to `.clock-time` which is `opacity: 0; pointer-events: none` while the slider shows, so it has never been visible in either mode.

Countdown untouched, no synced model gains a field, no new way back to the prep screen.

Your changelog note holds: after this the cog is the only way to move the Pomodoro default.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). Not ticked on purpose: 4.15 describes the Pomodoro duration as "configurable" and never mentions the prep screen as the place to set the default, so nothing there is wrong now. Say the word if you want a line about the per run duration and I add it.
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass. Ran `focus-mode`, `ui/duration`, and the specs that touch `FocusModeState` outside them (`android`, `idle`, `ios`, `tracking-presence`, `tracking-reminder`, `core-ui/main-header`, `core/browser-title`, `core/electron`), plus `tsc -p src/tsconfig.spec.json`. Not the full suite, it does not run on my machine.
- [x] My commit messages follow the Angular format (`type(scope): description`)
