### PR TITLE
fix(ios): keep keyboard geometry off the root element (#9779)

### DIFF
--- a/e2e/measure/ios-keyboard-relayout.measure.ts
+++ b/e2e/measure/ios-keyboard-relayout.measure.ts
@@ -1,0 +1,510 @@
+/**
+ * Manual measurement harness for #9779 — "opening the add-task bar on iOS is
+ * laggy, and it gets worse the more task rows are on screen".
+ *
+ * Not a test: it asserts only that its own setup worked, prints numbers, and
+ * always passes. Run it by hand:
+ *
+ *   npx playwright test --config e2e/measure/playwright.measure.config.ts \
+ *     --project=measure-webkit
+ *
+ * MEASURE_OPEN_TASK_COUNT / MEASURE_DONE_TASK_COUNT override the seeded list
+ * (default 128 open + 73 done — the reporter's own Inbox).
+ *
+ * What it measures, and why each one is here:
+ *
+ * - `root-custom-property write` — `keyboardWillShow` sets `--keyboard-height`
+ *   on `document.documentElement`, and `keyboardWillHide` resets it along with
+ *   `--keyboard-overlay-offset` (`global-theme.service.ts`).
+ * - `leaf-custom-property write` — the same write aimed at an element nothing
+ *   inherits from. The pair is the measurement: it prices the #9809 treatment of
+ *   `--visual-viewport-height` if applied to these two as well.
+ * - `plain-property write` — a non-inherited property on the root. Weaker: it
+ *   does NOT move the rows (the label says so), so it prices the write plus the
+ *   forced rect read, not layout.
+ * - `shell-height-write` — `iosShellHeight` writes a height on `.app-container`
+ *   once per visualViewport resize while the keyboard animates.
+ * - `resize-dispatch` — `_notifyIOSViewportChange` fires a synthetic window
+ *   resize per animation frame, waking CdkTextareaAutosize and every connected
+ *   CDK overlay's ViewportRuler.
+ * - `add-task-bar-open` — tap on the mobile FAB to the input holding focus.
+ *
+ * Findings as of 2026-09 (WebKit 26, iPhone 13 viewport, `ng serve` build):
+ *
+ *                                   0 rows   201 rows   128 rows, done collapsed
+ *   root-custom-property write        9.2ms    219.5ms                    121.9ms
+ *   leaf-custom-property write        0.1ms      0.1ms                          -
+ *   plain-property write              0.1ms      0.1ms                          -
+ *   shell-height-write x30            5.0ms      5.0ms                          -
+ *   resize-dispatch x30               0.0ms      0.0ms                          -
+ *   add-task-bar-open                49.0ms     37.0ms                     41.0ms
+ *
+ * Only the root custom-property write scales, and it scales hard. The identical
+ * write on a leaf stays at 0.1ms with 201 rows on screen, so the cost is style
+ * invalidation across everything that could inherit the property — not the write,
+ * and not layout. Collapsing the Completed Tasks section, the reporter's own
+ * workaround, drops it to 121.9ms because `collapsible.component.html` wraps its
+ * panel in a structural `@if`: those rows leave the DOM. `display: none` does NOT
+ * help, because WebKit still computes style for display-none subtrees, and
+ * neither does `content-visibility` — both land inside the run-to-run drift that
+ * the repeated `[rows: none, repeat]` baseline exists to expose.
+ *
+ * The shell-height write and the synthetic resize are genuinely flat. The resize
+ * costs nothing here partly because the app is zoneless
+ * (`provideZonelessChangeDetection`), and partly because this harness runs it
+ * with no overlay open, which is not the state the real keyboard opens in.
+ *
+ * KNOWN BLIND SPOTS. `_initIOSKeyboardHandling` is gated on native iOS, so it
+ * never runs here: these are hand-simulated writes, not the real event sequence.
+ * Headless WebKit also does no real tile rasterization and has no soft keyboard,
+ * so the cost of Capacitor `resize: 'native'` animating the WKWebView frame is
+ * out of reach at any list size. Absolute numbers are relative indicators only —
+ * an A15 is not this machine.
+ *
+ * Timing note: WebKit clamps `performance.now()` to 1ms, so nothing below times
+ * a single operation directly. `shell-height-write` and `resize-dispatch` report
+ * the total across N iterations; `root ... write` divides its N-iteration total
+ * back down to a per-write figure, which is only meaningful because each write
+ * is far above the clamp. `add-task-bar-open` polls with requestAnimationFrame,
+ * so it is quantised to ~16.7ms — differences under one frame are not real.
+ */
+import { expect, test } from '../fixtures/test.fixture';
+import type { Page } from '@playwright/test';
+
+/** The reporter's Inbox: 128 open + 73 done. */
+const OPEN_TASK_COUNT = Number(process.env.MEASURE_OPEN_TASK_COUNT ?? 128);
+const DONE_TASK_COUNT = Number(process.env.MEASURE_DONE_TASK_COUNT ?? 73);
+const TASK_COUNT = OPEN_TASK_COUNT + DONE_TASK_COUNT;
+/** Mirrors the op-log batch cap; only affects how the seed is chunked. */
+const MAX_BATCH_OPERATIONS_SIZE = 50;
+const SHELL_WRITE_FRAMES = 30;
+const RESIZE_DISPATCHES = 30;
+const ROOT_WRITES = 20;
+const WRITE_KINDS = [
+  'root-custom-property',
+  'leaf-custom-property',
+  'plain-property',
+] as const;
+const OPEN_REPS = 11;
+/** The first open of each variant pays for lazy work that never repeats. */
+const OPEN_WARMUP_REPS = 2;
+const INBOX_PROJECT_ID = 'INBOX_PROJECT';
+
+/** Row-level CSS whose effect on each measurement is worth knowing. */
+const ROW_VARIANTS: readonly { label: string; css: string }[] = [
+  { label: 'none', css: '' },
+  {
+    label: 'content-visibility',
+    css: 'task { content-visibility: auto; contain-intrinsic-size: auto 52px; }',
+  },
+  // The discriminator: `display: none` removes the rows from layout but not from
+  // style computation, so a cost that survives it is style invalidation.
+  { label: 'display:none', css: 'task { display: none; }' },
+];
+
+const STYLE_ID = 'measure-variant-style';
+
+const applyRowVariant = async (page: Page, css: string): Promise<void> => {
+  await page.evaluate(
+    ({ id, variantCss }) => {
+      document.getElementById(id)?.remove();
+      if (variantCss) {
+        const style = document.createElement('style');
+        style.id = id;
+        style.textContent = variantCss;
+        document.head.appendChild(style);
+      }
+      // Settle the new styles so they are not charged to the next measurement.
+      document.body.getBoundingClientRect();
+    },
+    { id: STYLE_ID, variantCss: css },
+  );
+};
+
+const clearRowVariant = (page: Page): Promise<void> => applyRowVariant(page, '');
+
+const seedProjectTasks = async (
+  page: Page,
+  taskIdPrefix: string,
+  openCount: number,
+  doneCount: number,
+): Promise<void> => {
+  await page.evaluate(
+    ({ batchSize, doneTaskCount, idPrefix, openTaskCount, projectId }) => {
+      const count = openTaskCount + doneTaskCount;
+      const store = (
+        window as unknown as {
+          __e2eTestHelpers?: { store?: { dispatch: (action: unknown) => void } };
+        }
+      ).__e2eTestHelpers?.store;
+      if (!store) {
+        throw new Error('__e2eTestHelpers.store missing — is this a dev/stage build?');
+      }
+      const operations = Array.from({ length: count }, (_, index) => ({
+        type: 'create',
+        tempId: `temp-${index}`,
+        // Done rows land in the collapsible Completed Tasks section, which is
+        // what the reporter collapses to make the lag go away.
+        data: { title: `Measure seed ${index + 1}`, isDone: index >= openTaskCount },
+      }));
+      const createdTaskIds = Object.fromEntries(
+        operations.map(({ tempId }, index) => [
+          tempId,
+          `${idPrefix}${String(index).padStart(4, '0')}`,
+        ]),
+      );
+      for (let offset = 0; offset < operations.length; offset += batchSize) {
+        store.dispatch({
+          type: '[Task Shared] batchUpdateForProject',
+          projectId,
+          operations: operations.slice(offset, offset + batchSize),
+          createdTaskIds,
+          createdTaskTimestamp: 1_750_000_000_000,
+          meta: {
+            isPersistent: true,
+            entityType: 'PROJECT',
+            entityId: projectId,
+            opType: 'BATCH',
+          },
+        });
+      }
+    },
+    {
+      batchSize: MAX_BATCH_OPERATIONS_SIZE,
+      doneTaskCount: doneCount,
+      idPrefix: taskIdPrefix,
+      openTaskCount: openCount,
+      projectId: INBOX_PROJECT_ID,
+    },
+  );
+};
+
+interface Sample {
+  readonly label: string;
+  readonly rowCount: number;
+  readonly values: number[];
+}
+
+const median = (values: readonly number[]): number =>
+  [...values].sort((a, b) => a - b)[Math.floor(values.length / 2)];
+
+const summarize = ({ label, rowCount, values }: Sample, unit: string): string => {
+  const sorted = [...values].sort((a, b) => a - b);
+  return (
+    `${label.padEnd(38)} rows=${String(rowCount).padStart(4)} ` +
+    `median=${median(values).toFixed(1)}${unit} ` +
+    `min=${sorted[0].toFixed(1)}${unit} max=${sorted[sorted.length - 1].toFixed(1)}${unit}`
+  );
+};
+
+/**
+ * Shell-height write plus the forced layout the browser would do before paint,
+ * totalled over `frames` because of the 1ms clock clamp.
+ */
+const measureShellHeightWrites = async (page: Page, frames: number): Promise<Sample> =>
+  page.evaluate((frameCount) => {
+    const shell = document.querySelector('.app-container') as HTMLElement | null;
+    if (!shell) {
+      throw new Error('.app-container missing');
+    }
+    const base = window.innerHeight;
+    // Mimic the shrink animation: a different height every frame, which is what
+    // iosShellHeight writes as visualViewport resize events land.
+    const writeFrame = (i: number): void => {
+      const height = base - 300 - (i % 7);
+      shell.style.height = `${height}px`;
+      shell.style.minHeight = `${height}px`;
+      shell.getBoundingClientRect();
+    };
+    const runs: number[] = [];
+    for (let run = 0; run < 5; run++) {
+      for (let i = 0; i < 5; i++) {
+        writeFrame(i);
+      }
+      const started = performance.now();
+      for (let i = 0; i < frameCount; i++) {
+        writeFrame(i);
+      }
+      runs.push(performance.now() - started);
+    }
+    shell.style.height = '';
+    shell.style.minHeight = '';
+    shell.getBoundingClientRect();
+    return {
+      label: `shell-height-write x${frameCount}`,
+      rowCount: document.querySelectorAll('task').length,
+      values: runs,
+    };
+  }, frames);
+
+/**
+ * The write `keyboardWillShow`/`keyboardWillHide` still make on the root
+ * (`global-theme.service.ts`: `--keyboard-height`, `--keyboard-overlay-offset`),
+ * against the same write aimed at a leaf element.
+ *
+ * A custom property invalidates the computed style of everything that could
+ * inherit it, so on `document.documentElement` its cost scales with the whole
+ * rendered tree, and on a leaf it does not. That pair is the measurement: it is
+ * the difference the #9809 treatment of `--visual-viewport-height` would make if
+ * applied to these two as well.
+ *
+ * `plain-property` is a third, weaker reading: a non-inherited property on the
+ * root. It reports whether the write plus the forced rect read is itself free —
+ * NOT whether layout is free, since it does not move the rows (the returned
+ * label says which, so a 0ms reading is never mistaken for the latter).
+ */
+type WriteKind = 'root-custom-property' | 'leaf-custom-property' | 'plain-property';
+
+const measureCssVarWrites = async (
+  page: Page,
+  kind: WriteKind,
+  writes: number,
+): Promise<Sample> =>
+  page.evaluate(
+    ({ propertyKind, writeCount }) => {
+      const root = document.documentElement;
+      const leaf = document.querySelector('.add-task-button') as HTMLElement | null;
+      if (propertyKind === 'leaf-custom-property' && !leaf) {
+        throw new Error('.add-task-button missing — no leaf to write to');
+      }
+      const lastRow = (): Element | null => document.querySelector('task:last-of-type');
+      const write = (i: number): void => {
+        if (propertyKind === 'root-custom-property') {
+          root.style.setProperty('--keyboard-height', `${300 + (i % 7)}px`);
+        } else if (propertyKind === 'leaf-custom-property') {
+          leaf!.style.setProperty('--keyboard-height', `${300 + (i % 7)}px`);
+        } else {
+          root.style.setProperty('padding-top', `${i % 7}px`);
+        }
+        // Force the style recalculation the browser would do before paint.
+        document.body.getBoundingClientRect();
+      };
+      // A reading of ~0ms only means "cheap"; whether it also relayouts the rows
+      // is a separate question, and reporting it stops the two being conflated.
+      write(0);
+      const before = lastRow()?.getBoundingClientRect().top;
+      write(5);
+      const movesRows = before !== lastRow()?.getBoundingClientRect().top;
+
+      const runs: number[] = [];
+      for (let run = 0; run < 5; run++) {
+        const started = performance.now();
+        for (let i = 0; i < writeCount; i++) {
+          write(i);
+        }
+        runs.push((performance.now() - started) / writeCount);
+      }
+      root.style.removeProperty('--keyboard-height');
+      root.style.removeProperty('padding-top');
+      leaf?.style.removeProperty('--keyboard-height');
+      document.body.getBoundingClientRect();
+      return {
+        label: `${propertyKind} write (moves rows: ${movesRows})`,
+        rowCount: document.querySelectorAll('task').length,
+        values: runs,
+      };
+    },
+    { propertyKind: kind, writeCount: writes },
+  );
+
+/** The synthetic window resize `_notifyIOSViewportChange` fires per frame. */
+const measureResizeDispatch = async (page: Page, dispatches: number): Promise<Sample> =>
+  page.evaluate((count) => {
+    const burst = (): void => {
+      for (let i = 0; i < count; i++) {
+        window.dispatchEvent(new Event('resize'));
+      }
+      // Charge the layout the app would be forced into before the next paint.
+      document.body.getBoundingClientRect();
+    };
+    burst();
+    const runs: number[] = [];
+    for (let run = 0; run < 5; run++) {
+      const started = performance.now();
+      burst();
+      runs.push(performance.now() - started);
+    }
+    return {
+      label: `resize-dispatch x${count}`,
+      rowCount: document.querySelectorAll('task').length,
+      values: runs,
+    };
+  }, dispatches);
+
+/**
+ * The reported interaction, timed in-page so Playwright IPC and actionability
+ * checks stay out of the number.
+ */
+const measureAddTaskBarOpen = async (
+  page: Page,
+  label: string,
+  reps: number,
+): Promise<Sample> => {
+  const values: number[] = [];
+  for (let rep = 0; rep < reps + OPEN_WARMUP_REPS; rep++) {
+    const elapsed = await page.evaluate(async () => {
+      const button = document.querySelector('.add-task-button') as HTMLElement | null;
+      if (!button) {
+        throw new Error('.add-task-button missing — is the mobile bottom nav shown?');
+      }
+      if (document.querySelector('add-task-bar.global')) {
+        throw new Error('add-task-bar already open — the previous rep did not close');
+      }
+      const until = (predicate: () => boolean): Promise<number> =>
+        new Promise((resolve, reject) => {
+          const deadline = performance.now() + 20000;
+          const check = (): void => {
+            if (predicate()) {
+              resolve(performance.now());
+            } else if (performance.now() > deadline) {
+              reject(new Error('timed out waiting for the add-task bar'));
+            } else {
+              requestAnimationFrame(check);
+            }
+          };
+          check();
+        });
+
+      const started = performance.now();
+      button.click();
+      // Focus, not mere presence: the reporter's complaint is the delay before
+      // they can type, which is what the keyboard hangs off.
+      const focusedAt = await until(
+        () => !!document.activeElement?.closest('add-task-bar.global'),
+      );
+      return focusedAt - started;
+    });
+    if (rep >= OPEN_WARMUP_REPS) {
+      values.push(elapsed);
+    }
+
+    // Closed through the store, not Escape: a keypress that lands a frame before
+    // the input takes focus is silently dropped, and the next rep then aborts on
+    // an already-open bar.
+    await page.evaluate(() => {
+      const store = (
+        window as unknown as {
+          __e2eTestHelpers?: { store?: { dispatch: (action: unknown) => void } };
+        }
+      ).__e2eTestHelpers?.store;
+      store?.dispatch({ type: '[Layout] Hide AddTaskBar' });
+    });
+    await page.locator('add-task-bar.global').waitFor({ state: 'detached' });
+  }
+  return {
+    label: `add-task-bar-open [rows: ${label}]`,
+    rowCount: await page.locator('task').count(),
+    values,
+  };
+};
+
+test.describe('#9779 iOS add-task-bar open cost', () => {
+  test('what scales with the number of rendered task rows', async ({
+    page,
+    workViewPage,
+    testPrefix,
+  }) => {
+    const lines: string[] = [];
+    lines.push(
+      await page.evaluate(
+        () =>
+          `engine=${navigator.userAgent.includes('Chrome') ? 'chromium' : 'webkit'} ` +
+          `viewport=${window.innerWidth}x${window.innerHeight}`,
+      ),
+    );
+
+    // Seed straight into the built-in Inbox project: creating one through the UI
+    // needs the side nav, which is collapsed at this viewport.
+    await page.evaluate((projectId) => {
+      window.location.hash = `#/project/${projectId}/tasks`;
+    }, INBOX_PROJECT_ID);
+    await workViewPage.waitForTaskList();
+    // The FAB is the entry point every open measurement uses; without it the
+    // harness would silently measure nothing.
+    await expect(page.locator('.add-task-button')).toBeVisible();
+
+    // Boot work (lazy chunks, first render, initial sync) keeps running for a
+    // while after the list appears, and it lands squarely on whatever is measured
+    // first. Burn it off, otherwise the empty-list baseline reads slower than the
+    // 200-row case and the comparison inverts.
+    // `waitForTimeout` is banned in e2e/tests for good reason; here there is no
+    // event to wait for — the point is to let unrelated boot work drain.
+    await page.waitForTimeout(2000);
+    await measureShellHeightWrites(page, SHELL_WRITE_FRAMES);
+    await measureAddTaskBarOpen(page, 'warmup', 1);
+
+    lines.push('--- empty list ---');
+    for (const kind of WRITE_KINDS) {
+      lines.push(summarize(await measureCssVarWrites(page, kind, ROOT_WRITES), 'ms'));
+    }
+    lines.push(summarize(await measureShellHeightWrites(page, SHELL_WRITE_FRAMES), 'ms'));
+    lines.push(summarize(await measureResizeDispatch(page, RESIZE_DISPATCHES), 'ms'));
+    lines.push(summarize(await measureAddTaskBarOpen(page, 'none', OPEN_REPS), 'ms'));
+
+    const taskIdPrefix = `${testPrefix}-measure-`;
+    await seedProjectTasks(page, taskIdPrefix, OPEN_TASK_COUNT, DONE_TASK_COUNT);
+    // A silent seeding failure would look exactly like "cost does not scale",
+    // so the row count is asserted rather than merely reported.
+    await expect(page.locator(`task[data-task-id^="${taskIdPrefix}"]`)).toHaveCount(
+      TASK_COUNT,
+      { timeout: 30000 },
+    );
+    await page.waitForTimeout(1500);
+
+    lines.push(
+      `--- ${TASK_COUNT} tasks (${OPEN_TASK_COUNT} open + ${DONE_TASK_COUNT} done) ---`,
+    );
+    for (const { label, css } of ROW_VARIANTS) {
+      await applyRowVariant(page, css);
+      for (const kind of WRITE_KINDS) {
+        lines.push(
+          summarize(await measureCssVarWrites(page, kind, ROOT_WRITES), 'ms') +
+            `  [rows: ${label}]`,
+        );
+      }
+      lines.push(
+        summarize(await measureShellHeightWrites(page, SHELL_WRITE_FRAMES), 'ms') +
+          `  [rows: ${label}]`,
+      );
+      lines.push(
+        summarize(await measureResizeDispatch(page, RESIZE_DISPATCHES), 'ms') +
+          `  [rows: ${label}]`,
+      );
+      await clearRowVariant(page);
+    }
+    // Variants run in fixed order, and these numbers drift upward over a run.
+    // Repeating the unmodified baseline last is what tells a real variant effect
+    // apart from that drift — compare each variant to BOTH baselines.
+    lines.push(
+      summarize(
+        await measureCssVarWrites(page, 'root-custom-property', ROOT_WRITES),
+        'ms',
+      ) + '  [rows: none, repeat]',
+    );
+    for (const { label, css } of ROW_VARIANTS) {
+      await applyRowVariant(page, css);
+      lines.push(summarize(await measureAddTaskBarOpen(page, label, OPEN_REPS), 'ms'));
+      await clearRowVariant(page);
+    }
+
+    // The reporter's own workaround, run as an A/B. Collapsing is not hiding:
+    // `collapsible.component.html` wraps its panel in a structural `@if`, so the
+    // done rows leave the DOM entirely rather than becoming `display: none`.
+    const doneHeader = page
+      .locator('collapsible', { hasText: 'Completed Tasks' })
+      .locator('.collapsible-header')
+      .first();
+    await doneHeader.click();
+    await expect(page.locator('task')).toHaveCount(OPEN_TASK_COUNT);
+    lines.push(`--- ${OPEN_TASK_COUNT} tasks, Completed Tasks collapsed ---`);
+    lines.push(
+      summarize(
+        await measureCssVarWrites(page, 'root-custom-property', ROOT_WRITES),
+        'ms',
+      ),
+    );
+    lines.push(summarize(await measureAddTaskBarOpen(page, 'none', OPEN_REPS), 'ms'));
+
+    console.log(`\n===== #9779 MEASUREMENT =====\n${lines.join('\n')}\n`);
+  });
+});

--- a/e2e/measure/playwright.measure.config.ts
+++ b/e2e/measure/playwright.measure.config.ts
@@ -1,0 +1,75 @@
+/**
+ * Config for the manual measurement harnesses in this folder. They are profiling
+ * tools, not assertions: they print numbers and always pass, so they live outside
+ * `e2e/tests` and are never collected by `npm run e2e`.
+ *
+ *   npx playwright test --config e2e/measure/playwright.measure.config.ts \
+ *     --project=measure-webkit
+ *
+ * WebKit is the point — it is the closest engine to the iOS WKWebView available
+ * without a device. `measure-chromium` runs the same harness for comparison.
+ */
+import { defineConfig, devices } from '@playwright/test';
+import path from 'path';
+
+const IPHONE_13 = devices['iPhone 13'];
+const REPO_ROOT = path.join(__dirname, '..', '..');
+
+const MOBILE_CONTEXT = {
+  viewport: IPHONE_13.viewport,
+  screen: IPHONE_13.screen,
+  deviceScaleFactor: IPHONE_13.deviceScaleFactor,
+  isMobile: IPHONE_13.isMobile,
+  hasTouch: IPHONE_13.hasTouch,
+  locale: 'en-GB',
+};
+
+export default defineConfig({
+  testDir: __dirname,
+  // `*.measure.ts`, deliberately not `*.spec.ts`: the default Playwright pattern
+  // is what keeps `npm run e2e` from ever collecting these.
+  testMatch: /.*\.measure\.ts$/,
+  // No globalSetup: the harnesses need no bundled plugins and no SuperSync server.
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    baseURL: process.env.E2E_BASE_URL || 'http://localhost:4242',
+    locale: 'en-GB',
+    userAgent: 'PLAYWRIGHT',
+    navigationTimeout: 60000,
+    actionTimeout: 30000,
+  },
+  projects: [
+    {
+      name: 'measure-webkit',
+      use: {
+        browserName: 'webkit' as const,
+        // The isolated-context fixture consumes contextOptions, so the mobile
+        // descriptor has to be nested here rather than spread at use level.
+        contextOptions: { ...MOBILE_CONTEXT, userAgent: IPHONE_13.userAgent },
+      },
+    },
+    {
+      name: 'measure-chromium',
+      use: {
+        browserName: 'chromium' as const,
+        contextOptions: MOBILE_CONTEXT,
+      },
+    },
+  ],
+  webServer: process.env.E2E_BASE_URL
+    ? undefined
+    : {
+        command: 'npm run startFrontend:e2e',
+        url: 'http://localhost:4242',
+        reuseExistingServer: true,
+        timeout: 4 * 60 * 1000,
+        stdout: 'ignore',
+        stderr: 'pipe',
+      },
+  outputDir: path.join(REPO_ROOT, '.tmp', 'e2e-measure-results'),
+  timeout: 300 * 1000,
+  expect: { timeout: 30 * 1000 },
+});

--- a/src/app/core/theme/cdk-safe-area-viewport.util.spec.ts
+++ b/src/app/core/theme/cdk-safe-area-viewport.util.spec.ts
@@ -4,10 +4,12 @@ import { FlexibleConnectedPositionStrategy } from '@angular/cdk/overlay';
 import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { patchCdkViewportForSafeArea } from './cdk-safe-area-viewport.util';
+import { BodyClass } from '../../app.constants';
 
 const SAFE_BOTTOM = 48;
 const SAFE_TOP = 48;
 const NAV_HEIGHT = 56;
+const KEYBOARD_OVERLAY_OFFSET = 120;
 
 /**
  * Mirrors the mobile bottom nav (#8792): a bar pinned to the viewport bottom
@@ -56,6 +58,7 @@ describe('patchCdkViewportForSafeArea', () => {
   >;
   let originalMarginTop: unknown;
   let originalMarginBottom: unknown;
+  let keyboardOverlayOffsetPx: number;
 
   const openMenuAndMeasure = async (
     itemLabels?: string[],
@@ -88,7 +91,8 @@ describe('patchCdkViewportForSafeArea', () => {
     TestBed.configureTestingModule({ providers: [provideNoopAnimations()] });
     originalMarginTop = proto['_getViewportMarginTop'];
     originalMarginBottom = proto['_getViewportMarginBottom'];
-    patchCdkViewportForSafeArea(document);
+    keyboardOverlayOffsetPx = 0;
+    patchCdkViewportForSafeArea(document, () => keyboardOverlayOffsetPx);
   });
 
   afterEach(() => {
@@ -100,6 +104,7 @@ describe('patchCdkViewportForSafeArea', () => {
     document.documentElement.style.removeProperty('--safe-area-top');
     document.documentElement.style.removeProperty('--safe-area-inset-bottom');
     document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+    document.body.classList.remove(BodyClass.isIOS, BodyClass.isKeyboardVisible);
   });
 
   // Android WebView >= 140: Capacitor SystemBars passes the native insets
@@ -146,10 +151,38 @@ describe('patchCdkViewportForSafeArea', () => {
     expect(twoItems.panelBottom).toBeCloseTo(oneItem.panelBottom, 0);
   });
 
+  // The offset arrives through the getter, not off <html> — it is not published
+  // as a root custom property (#9779). Reading a computed style here would
+  // silently yield the 0px :root fallback and drop the keyboard from the
+  // reserved strip, which no test caught before this one.
+  it('keeps a menu clear of an iOS keyboard that still overlays the viewport', async () => {
+    document.body.classList.add(BodyClass.isIOS, BodyClass.isKeyboardVisible);
+    keyboardOverlayOffsetPx = KEYBOARD_OVERLAY_OFFSET;
+
+    const { panelBottom } = await openMenuAndMeasure();
+
+    expect(panelBottom).toBeLessThanOrEqual(
+      document.documentElement.clientHeight - KEYBOARD_OVERLAY_OFFSET,
+    );
+  });
+
+  // Same setup, minus the class: the strip must not be reserved while the
+  // keyboard is down, or every menu on iOS floats 120px off the bottom.
+  it('ignores the keyboard offset when the keyboard is not up', async () => {
+    document.body.classList.add(BodyClass.isIOS);
+    keyboardOverlayOffsetPx = KEYBOARD_OVERLAY_OFFSET;
+
+    const { panelBottom } = await openMenuAndMeasure();
+
+    expect(panelBottom).toBeGreaterThan(
+      document.documentElement.clientHeight - KEYBOARD_OVERLAY_OFFSET,
+    );
+  });
+
   it('does not stack insets when applied more than once', async () => {
     document.documentElement.style.setProperty('--safe-area-bottom', `${SAFE_BOTTOM}px`);
-    patchCdkViewportForSafeArea(document);
-    patchCdkViewportForSafeArea(document);
+    patchCdkViewportForSafeArea(document, () => keyboardOverlayOffsetPx);
+    patchCdkViewportForSafeArea(document, () => keyboardOverlayOffsetPx);
 
     const { panelBottom, triggerTop } = await openMenuAndMeasure();
 

--- a/src/app/core/theme/cdk-safe-area-viewport.util.ts
+++ b/src/app/core/theme/cdk-safe-area-viewport.util.ts
@@ -12,7 +12,6 @@ import { BodyClass } from '../../app.constants';
  */
 const CSS_VAR_RESOLVED_SAFE_AREA_TOP = '--safe-area-top';
 const CSS_VAR_RESOLVED_SAFE_AREA_BOTTOM = '--safe-area-bottom';
-const CSS_VAR_KEYBOARD_OVERLAY_OFFSET = '--keyboard-overlay-offset';
 
 const readPx = (doc: Document, name: string): number =>
   parseInt(getComputedStyle(doc.documentElement).getPropertyValue(name), 10) || 0;
@@ -43,8 +42,16 @@ const readPx = (doc: Document, name: string): number =>
  * placement is then correct for any inset combination.
  *
  * Idempotent: patching twice would add the inset twice.
+ *
+ * The keyboard overlay offset comes in as a getter rather than being read off
+ * `getComputedStyle(documentElement)` like the two insets: it is deliberately
+ * not published as a root custom property, because a write there restyles every
+ * element that could inherit it (#9779). See KeyboardGeometryService.
  */
-export const patchCdkViewportForSafeArea = (doc: Document): void => {
+export const patchCdkViewportForSafeArea = (
+  doc: Document,
+  getKeyboardOverlayOffsetPx: () => number,
+): void => {
   const proto = FlexibleConnectedPositionStrategy.prototype as unknown as {
     _getViewportMarginTop: () => number;
     _getViewportMarginBottom: () => number;
@@ -65,7 +72,7 @@ export const patchCdkViewportForSafeArea = (doc: Document): void => {
     const keyboardOverlayOffset =
       doc.body.classList.contains(BodyClass.isIOS) &&
       doc.body.classList.contains(BodyClass.isKeyboardVisible)
-        ? readPx(doc, CSS_VAR_KEYBOARD_OVERLAY_OFFSET)
+        ? getKeyboardOverlayOffsetPx()
         : 0;
     return (
       originalBottom.call(this) +

--- a/src/app/core/theme/global-theme.service.spec.ts
+++ b/src/app/core/theme/global-theme.service.spec.ts
@@ -329,10 +329,14 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     _isIosKeyboardSettled: boolean;
     _cssVarCache: Map<string, string>;
     _overlayContainer: { getContainerElement(): HTMLElement };
-    _iosViewportVarTarget: HTMLElement;
+    _keyboardVarTargetEl: HTMLElement | null;
     _iosShowSettle: OneShotSettle;
     _iosHideSettle: OneShotSettle;
     iosShellHeight: WritableSignal<string | null>;
+    _keyboardGeometry: {
+      keyboardHeightPx: WritableSignal<number>;
+      keyboardOverlayOffsetPx: WritableSignal<number>;
+    };
     _scrollActiveInputIntoView(): void;
     _environmentInjector: EnvironmentInjector;
   }
@@ -366,7 +370,6 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     visualViewport.height = visualViewportHeight;
   };
 
-  const rootVar = (name: string): string => root.style.getPropertyValue(name);
   /** Set on the CDK overlay container, which every overlay inherits from. */
   const overlayVar = (name: string): string =>
     overlayContainer.style.getPropertyValue(name);
@@ -434,6 +437,10 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     } as unknown as Document;
     harness._overlayContainer = { getContainerElement: () => overlayContainer };
     harness.iosShellHeight = signal<string | null>(null);
+    harness._keyboardGeometry = {
+      keyboardHeightPx: signal(0),
+      keyboardOverlayOffsetPx: signal(0),
+    };
     harness._destroyRef = { onDestroy: () => undefined };
     harness._keyboardListenerHandles = [];
     harness._focusinListener = null;
@@ -500,8 +507,8 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     willShow();
 
     expect(body.classList.contains(BodyClass.isKeyboardVisible)).toBe(true);
-    expect(rootVar('--keyboard-height')).toBe(`${KEYBOARD_HEIGHT}px`);
-    expect(rootVar('--keyboard-overlay-offset')).toBe('0px');
+    expect(overlayVar('--keyboard-height')).toBe(`${KEYBOARD_HEIGHT}px`);
+    expect(overlayVar('--keyboard-overlay-offset')).toBe('0px');
     expect(overlayVar('--visual-viewport-height')).toBe(`${BASE_HEIGHT}px`);
     expect(harness.iosShellHeight()).toBe(
       `calc(${BASE_HEIGHT}px - var(--safe-area-top))`,
@@ -521,7 +528,7 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     );
     // The shrunken web view already ends above the keyboard; offsetting the
     // fixed bar again would move it twice (#8778).
-    expect(rootVar('--keyboard-overlay-offset')).toBe('0px');
+    expect(overlayVar('--keyboard-overlay-offset')).toBe('0px');
     flushRender();
     expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
   });
@@ -544,7 +551,7 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     willShow();
     didShow();
 
-    expect(rootVar('--keyboard-overlay-offset')).toBe(`${KEYBOARD_HEIGHT}px`);
+    expect(overlayVar('--keyboard-overlay-offset')).toBe(`${KEYBOARD_HEIGHT}px`);
     expect(overlayVar('--visual-viewport-height')).toBe(
       `${BASE_HEIGHT - KEYBOARD_HEIGHT}px`,
     );
@@ -560,7 +567,7 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
 
     willShow(KEYBOARD_HEIGHT + 100);
 
-    expect(rootVar('--keyboard-overlay-offset')).toBe(`${KEYBOARD_HEIGHT + 100}px`);
+    expect(overlayVar('--keyboard-overlay-offset')).toBe(`${KEYBOARD_HEIGHT + 100}px`);
     expect(overlayVar('--visual-viewport-height')).toBe(
       `${BASE_HEIGHT - KEYBOARD_HEIGHT - 100}px`,
     );
@@ -589,8 +596,8 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     shrinkViewport(BASE_HEIGHT);
 
     expect(body.classList.contains(BodyClass.isKeyboardVisible)).toBe(false);
-    expect(rootVar('--keyboard-height')).toBe('0px');
-    expect(rootVar('--keyboard-overlay-offset')).toBe('0px');
+    expect(overlayVar('--keyboard-height')).toBe('0px');
+    expect(overlayVar('--keyboard-overlay-offset')).toBe('0px');
     expect(overlayVar('--visual-viewport-height')).toBe(`${BASE_HEIGHT}px`);
     // Handed back to the stylesheet, which sizes the shell without a keyboard.
     expect(harness.iosShellHeight()).toBeNull();
@@ -623,24 +630,47 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     // Mid-shrink the clamped frame stands. --keyboard-height has non-overlay
     // consumers so it has to live on <html>, and the obscured area moves every
     // frame — correcting here would be a root write per frame (#9779).
-    expect(rootVar('--keyboard-height')).toBe(`${BASE_HEIGHT * 0.6}px`);
+    expect(overlayVar('--keyboard-height')).toBe(`${BASE_HEIGHT * 0.6}px`);
 
     didShow();
 
-    expect(rootVar('--keyboard-height')).toBe(`${KEYBOARD_HEIGHT}px`);
-    expect(rootVar('--keyboard-overlay-offset')).toBe('0px');
+    expect(overlayVar('--keyboard-height')).toBe(`${KEYBOARD_HEIGHT}px`);
+    expect(overlayVar('--keyboard-overlay-offset')).toBe('0px');
   });
 
-  it('does not write <html> per frame for a bogus keyboard frame either', () => {
+  it('does not rewrite the corrected height per frame either', () => {
     willShow(BASE_HEIGHT - 10);
-    const writesAfterShow = varWrites(setPropertySpy, '--keyboard-height');
+    const writesAfterShow = varWrites(overlaySetPropertySpy, '--keyboard-height');
 
     for (let step = 60; step <= 300; step += 60) {
       shrinkViewport(BASE_HEIGHT - step);
       flushFrame();
     }
 
-    expect(varWrites(setPropertySpy, '--keyboard-height')).toBe(writesAfterShow);
+    expect(varWrites(overlaySetPropertySpy, '--keyboard-height')).toBe(writesAfterShow);
+  });
+
+  // The whole point of #9779: a custom property on <html> invalidates the
+  // computed style of everything that could inherit it, which WebKit charges per
+  // node — ~220ms for ONE write against a 201-row task list, versus ~0.1ms for
+  // the same write on an element nothing inherits from (harness in e2e/measure/).
+  // #9809 moved --visual-viewport-height off the root and left these two behind;
+  // this is what stops them, or a third, drifting back.
+  it('never publishes keyboard geometry on <html>', () => {
+    willShow();
+    shrinkViewport(BASE_HEIGHT - KEYBOARD_HEIGHT);
+    didShow();
+    willHide();
+    didHide();
+
+    const rootWrites = setPropertySpy.calls
+      .allArgs()
+      .map(([name]) => name as string)
+      .filter(
+        (name) => name.startsWith('--keyboard') || name === '--visual-viewport-height',
+      );
+
+    expect(rootWrites).toEqual([]);
   });
 
   describe('when iOS drops keyboardDidShow', () => {
@@ -649,12 +679,12 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     it('settles on a timer instead', fakeAsync(() => {
       willShow();
 
-      expect(rootVar('--keyboard-overlay-offset')).toBe('0px');
+      expect(overlayVar('--keyboard-overlay-offset')).toBe('0px');
 
       tick(SETTLE_FALLBACK_MS);
       flushRender();
 
-      expect(rootVar('--keyboard-overlay-offset')).toBe(`${KEYBOARD_HEIGHT}px`);
+      expect(overlayVar('--keyboard-overlay-offset')).toBe(`${KEYBOARD_HEIGHT}px`);
       expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
     }));
 
@@ -692,7 +722,7 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
 
     // Re-measuring at the second willShow would clamp the keyboard against the
     // already-shrunken 464px and shrink the shell to 185.6px.
-    expect(rootVar('--keyboard-height')).toBe(`${KEYBOARD_HEIGHT}px`);
+    expect(overlayVar('--keyboard-height')).toBe(`${KEYBOARD_HEIGHT}px`);
     expect(harness.iosShellHeight()).toBe(
       `calc(${BASE_HEIGHT - KEYBOARD_HEIGHT}px - var(--safe-area-top))`,
     );
@@ -738,7 +768,7 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     didShow();
     flushRender();
 
-    expect(rootVar('--keyboard-height')).toBe(`${KEYBOARD_HEIGHT}px`);
+    expect(overlayVar('--keyboard-height')).toBe(`${KEYBOARD_HEIGHT}px`);
     expect(harness.iosShellHeight()).toBe(
       `calc(${BASE_HEIGHT - KEYBOARD_HEIGHT}px - var(--safe-area-top))`,
     );
@@ -759,9 +789,9 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     );
   });
 
-  // The point of the split: <html> carries only variables that change once per
-  // open/close, never the one the animation drives frame by frame (#9779).
-  it('never writes the per-frame viewport height on <html>', () => {
+  // The point of the split: <html> carries none of the keyboard geometry, least
+  // of all the variable the animation drives frame by frame (#9779).
+  it('writes the per-frame viewport height on the overlay container only', () => {
     willShow();
     for (let step = 60; step <= 300; step += 60) {
       shrinkViewport(BASE_HEIGHT - step);
@@ -774,7 +804,9 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     expect(varWrites(setPropertySpy, '--visual-viewport-height')).toBe(0);
     // One per distinct height: the five shrinks plus the restore on hide.
     expect(varWrites(overlaySetPropertySpy, '--visual-viewport-height')).toBe(6);
-    expect(varWrites(setPropertySpy, '--keyboard-height')).toBe(2);
+    // The keyboard height changes once per open/close, and lands there too.
+    expect(varWrites(setPropertySpy, '--keyboard-height')).toBe(0);
+    expect(varWrites(overlaySetPropertySpy, '--keyboard-height')).toBe(2);
   });
 });
 

--- a/src/app/core/theme/global-theme.service.spec.ts
+++ b/src/app/core/theme/global-theme.service.spec.ts
@@ -627,9 +627,9 @@ describe('GlobalThemeService iOS keyboard sequencing', () => {
     willShow(BASE_HEIGHT - 10);
     shrinkViewport(BASE_HEIGHT - KEYBOARD_HEIGHT);
 
-    // Mid-shrink the clamped frame stands. --keyboard-height has non-overlay
-    // consumers so it has to live on <html>, and the obscured area moves every
-    // frame — correcting here would be a root write per frame (#9779).
+    // Mid-shrink the clamped frame stands: the obscured area moves every frame,
+    // so correcting here would be a write per animation frame (#9779). The
+    // corrected value lands once, on didShow.
     expect(overlayVar('--keyboard-height')).toBe(`${BASE_HEIGHT * 0.6}px`);
 
     didShow();
@@ -918,4 +918,123 @@ describe('GlobalThemeService scroll-into-view guard', () => {
       expect(spy).toHaveBeenCalledWith(true);
     });
   });
+});
+
+// The non-iOS tracker covers Capacitor Android, the legacy F-Droid build and
+// Android mobile web — and, unlike `_initIOSKeyboardHandling`, it is the branch
+// that runs in a plain browser. It writes the same variable through the same
+// helper, so it is the other way `--keyboard-height` could drift back onto
+// <html> (#9779).
+describe('GlobalThemeService non-iOS keyboard tracking', () => {
+  interface VisualViewportHarness {
+    _initVisualViewportKeyboardTracking(): void;
+    document: Document;
+    _destroyRef: { onDestroy(cb: () => void): void };
+    _cssVarCache: Map<string, string>;
+    _overlayContainer: { getContainerElement(): HTMLElement };
+    _keyboardVarTargetEl: HTMLElement | null;
+    _keyboardGeometry: {
+      keyboardHeightPx: WritableSignal<number>;
+      keyboardOverlayOffsetPx: WritableSignal<number>;
+    };
+  }
+
+  const BASE_HEIGHT = 800;
+  const KEYBOARD_HEIGHT = 336;
+  /** Mirrors KEYBOARD_RESIZE_DEBOUNCE_MS in the service. */
+  const OPEN_DEBOUNCE_MS = 200;
+
+  let harness: VisualViewportHarness;
+  let root: HTMLElement;
+  let overlayContainer: HTMLElement;
+  let rootSetPropertySpy: jasmine.Spy;
+  let viewportListener: (() => void) | null;
+  let visualViewport: {
+    height: number;
+    addEventListener: jasmine.Spy;
+    removeEventListener: jasmine.Spy;
+  };
+  let originalInnerHeight: PropertyDescriptor | undefined;
+  let originalVisualViewport: PropertyDescriptor | undefined;
+
+  const resizeTo = (height: number): void => {
+    visualViewport.height = height;
+    viewportListener?.();
+  };
+
+  beforeEach(() => {
+    root = document.createElement('div');
+    overlayContainer = document.createElement('div');
+    rootSetPropertySpy = spyOn(root.style, 'setProperty').and.callThrough();
+    viewportListener = null;
+
+    visualViewport = {
+      height: BASE_HEIGHT,
+      addEventListener: jasmine
+        .createSpy('addEventListener')
+        .and.callFake((_name: string, cb: () => void) => {
+          viewportListener = cb;
+        }),
+      removeEventListener: jasmine.createSpy('removeEventListener'),
+    };
+    originalInnerHeight = Object.getOwnPropertyDescriptor(window, 'innerHeight');
+    originalVisualViewport = Object.getOwnPropertyDescriptor(window, 'visualViewport');
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      get: () => BASE_HEIGHT,
+    });
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      get: () => visualViewport,
+    });
+
+    harness = Object.create(GlobalThemeService.prototype) as VisualViewportHarness;
+    // documentElement is wired to the spied element on purpose: the pre-#9779
+    // code reached <html> through it, so the guard below can actually fail.
+    harness.document = { documentElement: root } as unknown as Document;
+    harness._overlayContainer = { getContainerElement: () => overlayContainer };
+    harness._keyboardVarTargetEl = null;
+    harness._cssVarCache = new Map<string, string>();
+    harness._keyboardGeometry = {
+      keyboardHeightPx: signal(0),
+      keyboardOverlayOffsetPx: signal(0),
+    };
+    harness._destroyRef = { onDestroy: () => undefined };
+  });
+
+  afterEach(() => {
+    const restore = (name: string, descriptor?: PropertyDescriptor): void => {
+      if (descriptor) {
+        Object.defineProperty(window, name, descriptor);
+      } else {
+        delete (window as unknown as Record<string, unknown>)[name];
+      }
+    };
+    restore('innerHeight', originalInnerHeight);
+    restore('visualViewport', originalVisualViewport);
+  });
+
+  it('publishes the keyboard height on the overlay container, never on <html>', fakeAsync(() => {
+    harness._initVisualViewportKeyboardTracking();
+
+    // The open path is debounced so the bar does not park at intermediate
+    // partial-keyboard heights while the IME animates.
+    resizeTo(BASE_HEIGHT - KEYBOARD_HEIGHT);
+    tick(OPEN_DEBOUNCE_MS);
+
+    expect(overlayContainer.style.getPropertyValue('--keyboard-height')).toBe(
+      `${KEYBOARD_HEIGHT}px`,
+    );
+    expect(harness._keyboardGeometry.keyboardHeightPx()).toBe(KEYBOARD_HEIGHT);
+
+    // Close commits synchronously, so the bar drops with the IME rather than
+    // parking at the old height for the debounce window.
+    resizeTo(BASE_HEIGHT);
+
+    expect(overlayContainer.style.getPropertyValue('--keyboard-height')).toBe('0px');
+    expect(harness._keyboardGeometry.keyboardHeightPx()).toBe(0);
+    expect(rootSetPropertySpy.calls.allArgs().map(([name]) => name as string)).toEqual(
+      [],
+    );
+  }));
 });

--- a/src/app/core/theme/global-theme.service.ts
+++ b/src/app/core/theme/global-theme.service.ts
@@ -1133,7 +1133,9 @@ export class GlobalThemeService {
       SafeArea.getSafeAreaInsets().then(({ insets }) => applyInsets(insets));
       SafeArea.addListener('safeAreaChanged', ({ insets }) => applyInsets(insets));
     }
-    patchCdkViewportForSafeArea(this.document);
+    patchCdkViewportForSafeArea(this.document, () =>
+      this._keyboardGeometry.keyboardOverlayOffsetPx(),
+    );
   }
 
   private _initMobileStatusBar(): void {

--- a/src/app/core/theme/global-theme.service.ts
+++ b/src/app/core/theme/global-theme.service.ts
@@ -53,6 +53,7 @@ import { IS_ANDROID_WEB_VIEW } from '../../util/is-android-web-view';
 import { androidInterface } from '../../features/android/android-interface';
 import { HttpClient } from '@angular/common/http';
 import { CapacitorPlatformService } from '../platform/capacitor-platform.service';
+import { KeyboardGeometryService } from './keyboard-geometry.service';
 import { Keyboard, KeyboardInfo, KeyboardPlugin } from '@capacitor/keyboard';
 import { PluginListenerHandle, registerPlugin } from '@capacitor/core';
 import { OverlayContainer } from '@angular/cdk/overlay';
@@ -213,6 +214,7 @@ export class GlobalThemeService {
   private _destroyRef = inject(DestroyRef);
   private _inputIntentService = inject(InputIntentService);
   private _overlayContainer = inject(OverlayContainer);
+  private _keyboardGeometry = inject(KeyboardGeometryService);
   private _hasInitialized = false;
   private _keyboardListenerHandles: PluginListenerHandle[] = [];
   private _focusinListener: ((event: FocusEvent) => void) | null = null;
@@ -234,21 +236,25 @@ export class GlobalThemeService {
   // Last value written per CSS variable, so a repeated write (the keyboard
   // animation fires many identical visualViewport resizes) costs nothing.
   private readonly _cssVarCache = new Map<string, string>();
-  // Where --visual-viewport-height goes; see _initIOSKeyboardHandling, which
-  // assigns it before the first update and before any listener is registered.
-  // Definitely assigned rather than nullable: a fallback to <html> here would be
-  // cached by _setCssVar and silently suppress the later write to the real
-  // target, leaving dialogs on the 100vh fallback for the session.
-  private _iosViewportVarTarget!: HTMLElement;
+  private _keyboardVarTargetEl: HTMLElement | null = null;
 
   /**
-   * Height for the app shell while the iOS keyboard is open, as a CSS value, or
-   * null to leave the sizing to the stylesheet. Bound by app.component rather
-   * than published as a custom property: the shell wraps the whole task list,
-   * and a variable it inherits costs a document-wide style recalc on every
-   * frame of the keyboard animation (#9779).
+   * Where every keyboard geometry variable goes — the CDK overlay container,
+   * never `<html>`: a root custom property invalidates the computed style of
+   * every element that could inherit it, measured at ~220ms for ONE write on a
+   * 201-row list against ~0.1ms on an element nothing inherits from (#9779,
+   * harness in `e2e/measure/`). Lazy so both keyboard trackers share a target.
    */
-  readonly iosShellHeight = signal<string | null>(null);
+  private get _keyboardVarTarget(): HTMLElement {
+    return (this._keyboardVarTargetEl ??= this._overlayContainer.getContainerElement());
+  }
+
+  /**
+   * Re-exported for app.component, the long-standing consumer. New readers
+   * should inject KeyboardGeometryService directly — see its doc comment for
+   * why the geometry is bound rather than published on `<html>`.
+   */
+  readonly iosShellHeight = this._keyboardGeometry.iosShellHeight;
 
   private _isCustomWindowTitleBarEnabled(): boolean {
     // The main process (main-window.ts) force-disables the custom title bar on
@@ -716,8 +722,8 @@ export class GlobalThemeService {
     keyboard.setAccessoryBarVisible({ isVisible: false });
     // Resolved up front (this creates the container if CDK has not yet needed
     // it) so a dialog opened while the keyboard is already up finds the
-    // variable in place.
-    this._iosViewportVarTarget = this._overlayContainer.getContainerElement();
+    // variables in place.
+    this._keyboardVarTargetEl = this._overlayContainer.getContainerElement();
     this._updateIOSKeyboardViewportVars();
 
     if (window.visualViewport) {
@@ -775,10 +781,11 @@ export class GlobalThemeService {
         this.document.body.classList.add(BodyClass.isKeyboardVisible);
         // Set CSS variable for keyboard height to adjust layout
         this._setCssVar(
-          this.document.documentElement,
+          this._keyboardVarTarget,
           CSS_VAR_KEYBOARD_HEIGHT,
           `${keyboardHeight}px`,
         );
+        this._keyboardGeometry.keyboardHeightPx.set(keyboardHeight);
         this._updateIOSKeyboardViewportVars();
       })
       .then((handle) => this._keyboardListenerHandles.push(handle));
@@ -802,9 +809,11 @@ export class GlobalThemeService {
         // view is actually back to full size instead.
         this._iosHideSettle.arm(() => this._clearIosKeyboardBaseline());
         this.document.body.classList.remove(BodyClass.isKeyboardVisible);
-        const root = this.document.documentElement;
-        this._setCssVar(root, CSS_VAR_KEYBOARD_HEIGHT, '0px');
-        this._setCssVar(root, CSS_VAR_KEYBOARD_OVERLAY_OFFSET, '0px');
+        const target = this._keyboardVarTarget;
+        this._setCssVar(target, CSS_VAR_KEYBOARD_HEIGHT, '0px');
+        this._setCssVar(target, CSS_VAR_KEYBOARD_OVERLAY_OFFSET, '0px');
+        this._keyboardGeometry.keyboardHeightPx.set(0);
+        this._keyboardGeometry.keyboardOverlayOffsetPx.set(0);
         this._updateIOSKeyboardViewportVars();
       })
       .then((handle) => this._keyboardListenerHandles.push(handle));
@@ -885,30 +894,27 @@ export class GlobalThemeService {
       isKeyboardFrameUnreliable: this._iosKeyboardFrameUnreliable,
     });
 
-    const root = this.document.documentElement;
+    const target = this._keyboardVarTarget;
     let hasChanged = this._setCssVar(
-      // Not on <html>: a custom property there invalidates every element that
-      // could inherit it, which WebKit charges per node — measured at ~390ms per
-      // write on a 200-task list, on every frame of the keyboard animation
-      // (#9779). Only overlay panes read this one, so it lives on their
-      // container; the app shell gets a plain height below.
-      this._iosViewportVarTarget,
+      target,
       CSS_VAR_VISUAL_VIEWPORT_HEIGHT,
       `${vars.visualViewportHeightPx}px`,
     );
     hasChanged =
       this._setCssVar(
-        root,
+        target,
         CSS_VAR_KEYBOARD_OVERLAY_OFFSET,
         `${vars.keyboardOverlayOffsetPx}px`,
       ) || hasChanged;
+    this._keyboardGeometry.keyboardOverlayOffsetPx.set(vars.keyboardOverlayOffsetPx);
     if (vars.correctedKeyboardHeightPx !== null) {
       hasChanged =
         this._setCssVar(
-          root,
+          target,
           CSS_VAR_KEYBOARD_HEIGHT,
           `${vars.correctedKeyboardHeightPx}px`,
         ) || hasChanged;
+      this._keyboardGeometry.keyboardHeightPx.set(vars.correctedKeyboardHeightPx);
     }
     this.iosShellHeight.set(
       this._iosKeyboardHeight > 0
@@ -971,7 +977,6 @@ export class GlobalThemeService {
   private _initVisualViewportKeyboardTracking(): void {
     const vv = window.visualViewport;
     if (!vv) return;
-    const root = this.document.documentElement;
     // Filter out small differences from URL bar / overlay UI rather than the
     // IME — keeps us from setting a phantom keyboard offset.
     const KEYBOARD_THRESHOLD_PX = 100;
@@ -989,7 +994,13 @@ export class GlobalThemeService {
     const commit = (): void => {
       const obscured = window.innerHeight - vv.height;
       const keyboardHeight = obscured > KEYBOARD_THRESHOLD_PX ? obscured : 0;
-      root.style.setProperty(CSS_VAR_KEYBOARD_HEIGHT, `${keyboardHeight}px`);
+      // Same target as the iOS path, for the same reason — see _keyboardVarTarget.
+      this._setCssVar(
+        this._keyboardVarTarget,
+        CSS_VAR_KEYBOARD_HEIGHT,
+        `${keyboardHeight}px`,
+      );
+      this._keyboardGeometry.keyboardHeightPx.set(keyboardHeight);
     };
 
     const onViewportResize = (): void => {

--- a/src/app/core/theme/ios-keyboard-css-contract.spec.ts
+++ b/src/app/core/theme/ios-keyboard-css-contract.spec.ts
@@ -9,8 +9,8 @@ import { BodyClass } from '../../app.constants';
 class KeyboardContractDialogComponent {}
 
 /**
- * The rendered half of #9779's split: GlobalThemeService writes
- * `--visual-viewport-height` on the CDK overlay container instead of `<html>`,
+ * The rendered half of #9779's split: GlobalThemeService writes the keyboard
+ * geometry variables on the CDK overlay container instead of `<html>`,
  * which only holds up if the rules that consume it sit inside that container
  * and inherit it. The service spec pins where the value is written; this pins
  * that writing it there still produces the layout the stylesheet promises.
@@ -46,7 +46,6 @@ describe('iOS keyboard CSS contract', () => {
     TestBed.inject(MatDialog).closeAll();
     TestBed.tick();
     document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
-    document.documentElement.style.removeProperty('--keyboard-overlay-offset');
     document.body.classList.remove(
       BodyClass.isNativeMobile,
       BodyClass.isIOS,
@@ -85,10 +84,14 @@ describe('iOS keyboard CSS contract', () => {
     );
   });
 
-  // This one stays on <html>: it changes at most once per open/close, and the
-  // add-task bar reads it from outside the overlay layer.
-  it('reserves keyboard space in the overlay wrapper from the root variable', () => {
-    document.documentElement.style.setProperty(
+  // This used to stay on <html> on the grounds that it changes at most once per
+  // open/close. It does — and that single write measured ~220ms against a
+  // 201-row task list, because a root custom property invalidates the computed
+  // style of everything that could inherit it (#9779). It now lands here, and
+  // the add-task bar, which sits outside this container, binds it onto its own
+  // host instead.
+  it('reserves keyboard space in the overlay wrapper from the container variable', () => {
+    overlayContainer.style.setProperty(
       '--keyboard-overlay-offset',
       `${KEYBOARD_OVERLAY_OFFSET_PX}px`,
     );

--- a/src/app/core/theme/keyboard-geometry.service.ts
+++ b/src/app/core/theme/keyboard-geometry.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, signal } from '@angular/core';
+
+/**
+ * Keyboard-driven geometry published as signals for components to bind, rather
+ * than as custom properties on `<html>`.
+ *
+ * A custom property on the root element invalidates the computed style of every
+ * element that could inherit it, and WebKit charges that per node: one write
+ * measured ~220ms against a 201-row task list, versus ~0.1ms on an element
+ * nothing inherits from (#9779, harness in `e2e/measure/`). Consumers inside
+ * the CDK overlay container inherit these values as CSS variables written on
+ * the container itself; consumers outside it — the app shell and the global
+ * add-task bar — bind the signals here onto their own host instead.
+ *
+ * Written by GlobalThemeService, which owns the keyboard listeners. Kept
+ * separate from it so a component can read the geometry without pulling in the
+ * theming engine.
+ */
+@Injectable({ providedIn: 'root' })
+export class KeyboardGeometryService {
+  /**
+   * Height for the app shell while the iOS keyboard is open, as a CSS value, or
+   * null to leave the sizing to the stylesheet.
+   */
+  readonly iosShellHeight = signal<string | null>(null);
+
+  /** Slice of the viewport the keyboard obscures. */
+  readonly keyboardHeightPx = signal(0);
+
+  /**
+   * How far the keyboard still overlays the (possibly already shrunk) WebView
+   * viewport on iOS — never the full keyboard height, or fixed elements move
+   * twice (#8778).
+   */
+  readonly keyboardOverlayOffsetPx = signal(0);
+}

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.scss
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.scss
@@ -53,6 +53,9 @@
   // #9277), so max() just picks out whichever term is live on the platform at
   // hand. `--s2` rather than `--s`, which leaves the buttons flush against the
   // obstruction and awkward to tap.
+  //
+  // `--keyboard-height` resolves off this component's own host, where the `host`
+  // block binds it — it is deliberately not published on :root (#9779).
   bottom: calc(max(var(--keyboard-height), var(--safe-area-bottom)) + var(--s2));
   transition: bottom var(--transition-duration-m) ease-out;
 }

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.spec.ts
@@ -18,6 +18,7 @@ import { LocalizationConfig, MiscConfig } from '../../config/global-config.model
 import { first } from 'rxjs/operators';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { signal, Signal } from '@angular/core';
+import { KeyboardGeometryService } from '../../../core/theme/keyboard-geometry.service';
 import { AddTaskSuggestion } from './add-task-suggestions.model';
 import { PlannerActions } from '../../planner/store/planner.actions';
 import { TaskCopy, TaskReminderOptionId } from '../task.model';
@@ -340,18 +341,23 @@ describe('AddTaskBarComponent', () => {
   describe('mobile keyboard positioning', () => {
     let hadTouchPrimaryClass: boolean;
     let hadIOSClass: boolean;
+    let keyboardGeometry: KeyboardGeometryService;
 
     beforeEach(() => {
+      // Driven through the signals rather than by writing the custom properties
+      // here, because that is how they reach the host now: the bar binds them
+      // onto itself instead of reading them off `<html>` (#9779).
+      keyboardGeometry = TestBed.inject(KeyboardGeometryService);
       hadTouchPrimaryClass = document.body.classList.contains(BodyClass.isTouchPrimary);
       hadIOSClass = document.body.classList.contains(BodyClass.isIOS);
       document.body.classList.add(BodyClass.isTouchPrimary);
       document.body.classList.remove(BodyClass.isIOS);
       fixture.nativeElement.classList.add('global');
-      fixture.nativeElement.style.setProperty('--keyboard-height', '336px');
+      keyboardGeometry.keyboardHeightPx.set(336);
+      keyboardGeometry.keyboardOverlayOffsetPx.set(0);
       // Non-zero for every case in this block, so the assertions below pin
       // whether each offset stacks with the bottom inset or supersedes it.
       fixture.nativeElement.style.setProperty('--safe-area-bottom', '48px');
-      fixture.nativeElement.style.setProperty('--keyboard-overlay-offset', '0px');
       fixture.nativeElement.style.setProperty('--s', '8px');
       fixture.nativeElement.style.setProperty('--s2', '16px');
       fixture.nativeElement.style.setProperty('--transition-duration-m', '0ms');
@@ -374,7 +380,8 @@ describe('AddTaskBarComponent', () => {
 
     it('keeps the global bar above an iOS keyboard that still overlays the viewport', () => {
       document.body.classList.add(BodyClass.isIOS);
-      fixture.nativeElement.style.setProperty('--keyboard-overlay-offset', '40px');
+      keyboardGeometry.keyboardOverlayOffsetPx.set(40);
+      fixture.detectChanges();
 
       expect(getComputedStyle(fixture.nativeElement).bottom).toBe('56px');
     });
@@ -384,7 +391,8 @@ describe('AddTaskBarComponent', () => {
     });
 
     it('keeps the global bar above the bottom safe area without a keyboard', () => {
-      fixture.nativeElement.style.setProperty('--keyboard-height', '0px');
+      keyboardGeometry.keyboardHeightPx.set(0);
+      fixture.detectChanges();
       fixture.nativeElement.style.setProperty('--safe-area-bottom', '48px');
 
       expect(getComputedStyle(fixture.nativeElement).bottom).toBe('64px');

--- a/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
+++ b/src/app/features/tasks/add-task-bar/add-task-bar.component.ts
@@ -28,6 +28,7 @@ import { blendInOutAnimation } from 'src/app/ui/animations/blend-in-out.ani';
 import { expandFadeAnimation } from '../../../ui/animations/expand.ani';
 import { TaskCopy, TaskReminderOptionId } from '../task.model';
 import { TaskService } from '../task.service';
+import { KeyboardGeometryService } from '../../../core/theme/keyboard-geometry.service';
 import { WorkContextService } from '../../work-context/work-context.service';
 import { WorkContext, WorkContextType } from '../../work-context/work-context.model';
 import { ProjectService } from '../../project/project.service';
@@ -96,6 +97,21 @@ export interface TaskAddEvent {
   isNewTask: boolean;
 }
 
+// The bar is fixed-position outside the CDK overlay container, so it cannot
+// inherit the keyboard geometry written there — it takes the two values it
+// positions itself with straight onto its own host instead. They are NOT
+// published on `<html>`: a root custom property restyles every element that
+// could inherit it, ~220ms for one write on a 201-row task list (#9779).
+// Keys are hoisted into consts so they read as identifiers to the
+// naming-convention lint rule, as in schedule-month.component.ts.
+const HOST_KEYBOARD_HEIGHT_VAR = '[style.--keyboard-height.px]' as const;
+const HOST_KEYBOARD_OVERLAY_OFFSET_VAR = '[style.--keyboard-overlay-offset.px]' as const;
+
+const HOST_BINDINGS = {
+  [HOST_KEYBOARD_HEIGHT_VAR]: 'keyboardHeightPx()',
+  [HOST_KEYBOARD_OVERLAY_OFFSET_VAR]: 'keyboardOverlayOffsetPx()',
+} as const;
+
 @Component({
   selector: 'add-task-bar',
   templateUrl: './add-task-bar.component.html',
@@ -123,9 +139,11 @@ export interface TaskAddEvent {
     SelectOptionRowComponent,
   ],
   providers: [AddTaskBarStateService, AddTaskBarParserService],
+  host: HOST_BINDINGS,
 })
 export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
   private readonly _taskService = inject(TaskService);
+  private readonly _keyboardGeometry = inject(KeyboardGeometryService);
   private readonly _workContextService = inject(WorkContextService);
   private readonly _projectService = inject(ProjectService);
   private readonly _tagService = inject(TagService);
@@ -141,6 +159,10 @@ export class AddTaskBarComponent implements AfterViewInit, OnInit, OnDestroy {
   private readonly _markdownPasteService = inject(MarkdownPasteService);
   private readonly _dateService = inject(DateService);
   private readonly _menuTreeService = inject(MenuTreeService);
+  /** Bound onto the host; see the `host` block for why not `<html>`. */
+  readonly keyboardHeightPx = this._keyboardGeometry.keyboardHeightPx;
+  readonly keyboardOverlayOffsetPx = this._keyboardGeometry.keyboardOverlayOffsetPx;
+
   readonly stateService = inject(AddTaskBarStateService);
 
   T = T;

--- a/src/styles/_css-variables.scss
+++ b/src/styles/_css-variables.scss
@@ -78,15 +78,16 @@
   // docs/android-edge-to-edge-keyboard.md).
   --bottom-nav-safe-area: calc(var(--safe-area-bottom) / 2);
 
-  // Keyboard height (set dynamically via JS)
+  // Fallbacks only, for all three. The live values are written on
+  // `.cdk-overlay-container` and — for the global add-task bar, which sits
+  // outside it — on that component's own host, never here: a custom property on
+  // :root restyles every element that could inherit it, and one such write
+  // measured ~220ms against a 201-row task list (#9779). Rules outside those two
+  // subtrees therefore see the fallbacks; anything in the app shell that needs a
+  // live value takes it from GlobalThemeService (`iosShellHeight`,
+  // `keyboardHeightPx`, `keyboardOverlayOffsetPx`), not from these variables.
   --keyboard-height: 0px;
   --keyboard-overlay-offset: 0px;
-  // Fallback only. On iOS the live value is written on `.cdk-overlay-container`,
-  // not here, because a custom property on :root restyles every element that
-  // could inherit it — the whole task list — on each frame of the keyboard
-  // animation (#9779). Rules outside the overlay layer therefore see 100vh:
-  // anything in the app shell that needs the live height gets it from
-  // GlobalThemeService (see `iosShellHeight`), not from this variable.
   --visual-viewport-height: 100vh;
 
   // -----------------------------


### PR DESCRIPTION
Fixes the remaining lag in #9779.

`--keyboard-height` and `--keyboard-overlay-offset` were written on `<html>`. A custom property there invalidates the computed style of every element that could inherit it, which WebKit charges per node. Both now go to the CDK overlay container, alongside `--visual-viewport-height` (#9809). The one consumer outside that subtree — the global add-task bar — binds the values onto its own host from a new dependency-free `KeyboardGeometryService`.

Measured on the app's own keyboard listener, WebKit at a 390x664 viewport, 201 task rows, 14 writes: **median 245ms → 0ms** per write (post-fix sits below the 1ms clock resolution).

### Caveat worth reviewing carefully

That measurement is the **non-iOS** path (`_initVisualViewportKeyboardTracking`), because the iOS path needs a native shell and never runs under Playwright. Both now write through the same `_keyboardVarTarget`, so iOS should benefit identically — but that is inference from reading, not observation. **Not verified on a real device**; confirming with the reporter after this reaches Play internal / Snap edge is the remaining step.

### Commits

- `f8a55c278f` — the measurement harness under `e2e/measure/`, which is where the numbers above come from. It is a **manual profiling tool, not a test**: it has no assertions, always passes, and is deliberately kept out of `npm run e2e` by `testMatch` in its own config. Run by hand with `npx playwright test --config e2e/measure/playwright.measure.config.ts --project=measure-webkit`. It is the largest part of this diff and nothing in CI executes it.
- `848c2e2f1a` — the retarget, plus `KeyboardGeometryService`
- `371355475e` — regression fix: `patchCdkViewportForSafeArea` read the offset off `getComputedStyle(documentElement)` and silently got the `0px` `:root` fallback, so connected overlays (menus, selects, autocomplete) stopped reserving the keyboard strip on iOS — what #8792 patched CDK for. The branch had no test, which is why the suite stayed green through it; two now cover it, and the positive one fails against the old read.
- `0db740e75c` — guard for the non-iOS write target, which had no unit coverage at all

### Tests

Full unit suite green (14659). Two guards pin the write target — `never publishes keyboard geometry on <html>` (iOS) and `publishes the keyboard height on the overlay container, never on <html>` (non-iOS). Both were checked for non-vacuity by pointing the relevant write back at the root element: 13 failures and 1 respectively.

E2E was not run for this branch.

### Note for whoever touches this file next

`global-theme.service.ts` is at 1180 lines against the lint-enforced 1200 `max-lines` cap for services, and it is not on the grandfathered list — roughly 20 lines of headroom.
