### PR TITLE
test(perf): add the #9779 root custom-property measurement harness

### DIFF
--- a/docs/android-edge-to-edge-keyboard.md
+++ b/docs/android-edge-to-edge-keyboard.md
@@ -47,6 +47,50 @@ So the bar floats above the keyboard if **either** the window/WebView shrinks
 window **does** shrink (the system resizes for the IME), so `--keyboard-height`
 stays `0` and the bar sits correctly at `bottom: var(--s2)`.
 
+## What a `--keyboard-height` write on `<html>` costs (#9779, measured 2026-09)
+
+**Before porting any iOS keyboard fix to the Android path, read this section.**
+The Android/web tracker above writes `--keyboard-height` on `document.documentElement`.
+That write is not free — a custom property on the root is re-resolved per element
+by the style engine, so its cost scales with the number of rendered task rows.
+This is what #9779 was ("opening the add-task bar on iOS is laggy, and it gets
+worse the more task rows are on screen").
+
+Median ms per write, 201 task rows, iPhone 13 viewport, `ng serve` build,
+WebKit 26.5 / Chromium 149:
+
+| write                                 | WebKit | Blink |
+| ------------------------------------- | ------ | ----- |
+| root **custom** property              | ~180   | 12.8  |
+| root **inherited standard** (`color`) | 0.1    | 0.3   |
+| custom property on a leaf element     | 0.1    | 0.1   |
+| root custom, rows `display: none`     | 8      | 1.6   |
+| empty list                            | ~9     | 0.7   |
+
+Three things follow, and the third is the decision:
+
+1. **It is custom properties specifically, not inherited properties.** A `color`
+   write on `<html>` invalidates exactly the same set of elements and stays at the
+   floor. "Don't write inherited things on the root" is the wrong lesson.
+2. **Only the root custom-property write scales with row count.** The shell-height
+   write and everything else measured flat from 0 to 201 rows.
+3. **Blink charges the same mechanism roughly an order of magnitude less.** iOS was
+   fixed in [#9926](https://github.com/super-productivity/super-productivity/pull/9926)
+   by moving the vars onto the CDK overlay container (`IosKeyboardService`). That
+   fix was **deliberately not ported to the Android path**: 12.8ms per write, at a
+   write frequency of about one per keyboard open rather than one per animation
+   frame, does not justify the added indirection. Revisit if the Android tracker
+   ever starts writing per frame, or if row counts grow far beyond 200.
+
+Caveats before quoting these: run-to-run spread on the WebKit figure is ~16%
+(samples: 180.4, 193.4, 194.0, 166.9, 174.3), so treat anything under ~1.2x as
+unresolved — `content-visibility`, for one, is a real ~3.7x cut in Blink but does
+nothing legible in WebKit. Headless engines on a desktop are not an A15; read the
+ratios, not the milliseconds.
+
+Re-measure with `e2e/measure/ios-keyboard-relayout.measure.ts` (hand-run, not part
+of `npm run e2e` — see its header for how and for the methodology caveats).
+
 ## #8508 — reversed / invisible characters (the actual root cause)
 
 **Symptom.** On Android, the add-task bar (and search) showed reversed or
@@ -439,10 +483,10 @@ sits below 140. The `android-tests` job boots a second emulator at API 34
 (`android/run-android-ime-check.sh`) after the API 35 suite
 (`android/run-android-checks.sh`), so every PR exercises both owners:
 
-| Emulator                  | Owner per gate         | Measured (2026-09, 640 px root)                                                                       |
-| ------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------- |
-| API 34, WebView 113.0     | native shim (on)       | `paramsHeight` MATCH_PARENT → **405** = `rect.bottom`; WebView bottom 640 → 405; `innerHeight` 640 → 405 |
-| API 35 (bundled WebView)  | SystemBars (shim off)  | layout params untouched; WebView bottom at `rect.bottom`; `innerHeight` shrinks                       |
+| Emulator                 | Owner per gate        | Measured (2026-09, 640 px root)                                                                          |
+| ------------------------ | --------------------- | -------------------------------------------------------------------------------------------------------- |
+| API 34, WebView 113.0    | native shim (on)      | `paramsHeight` MATCH_PARENT → **405** = `rect.bottom`; WebView bottom 640 → 405; `innerHeight` 640 → 405 |
+| API 35 (bundled WebView) | SystemBars (shim off) | layout params untouched; WebView bottom at `rect.bottom`; `innerHeight` shrinks                          |
 
 The test derives the gate's inputs the way the activity does
 (`NativeInsetShimGate.activeProviderMajor(WebViewCompatibilityChecker.evaluate())`)

--- a/e2e/measure/ios-keyboard-relayout.measure.ts
+++ b/e2e/measure/ios-keyboard-relayout.measure.ts
@@ -80,6 +80,17 @@
  * back down to a per-write figure, which is only meaningful because each write
  * is far above the clamp. `add-task-bar-open` polls with requestAnimationFrame,
  * so it is quantised to ~16.7ms — differences under one frame are not real.
+ *
+ * These per-write figures do NOT extrapolate to a run of writes. The write
+ * measurements force a layout read after every write, which is what isolates one
+ * write's cost — but it also defeats the coalescing a real caller gets for free.
+ * Measured against 201 rows in WebKit: one write with a forced read 388ms, four
+ * writes each followed by a forced read 1647ms (~4x, as expected), four writes
+ * with a single forced read at the end 249ms. So consecutive writes with no
+ * layout read between them cost about ONE recalc, not N. Before citing these
+ * numbers against code that writes several properties in a row — the four
+ * `--safe-area-inset-*` writes in `_initSafeAreaInsets`, say — check whether it
+ * reads layout in between. Usually it does not.
  */
 import { expect, test } from '../fixtures/test.fixture';
 import type { Page } from '@playwright/test';

--- a/e2e/measure/ios-keyboard-relayout.measure.ts
+++ b/e2e/measure/ios-keyboard-relayout.measure.ts
@@ -52,9 +52,9 @@
  *   plain-property                 0.3     0.3       0.4          0.2
  *   shell-height-write x30         0.5     0.6       0.6          0.5
  *
- * HOW MUCH OF THIS IS NOISE. Two clean WebKit runs gave four samples of the
- * same unmodified 201-row root write (opening and `[rows: none, repeat]`):
- * 180.4, 193.4, 194.0, 166.9 — a spread of ~16%, which is why the WebKit column
+ * HOW MUCH OF THIS IS NOISE. Clean WebKit runs gave these samples of the same
+ * unmodified 201-row root write (opening and `[rows: none, repeat]`): 180.4,
+ * 193.4, 194.0, 166.9, 174.3 — a spread of ~16%, which is why the WebKit column
  * above is rounded. Treat anything under ~1.2x there as unresolved. Blink held
  * 12.8 opening against 12.6 repeat, but that is one pair, so its variant cells
  * are single samples too. Measure with nothing else running: one contaminated
@@ -85,10 +85,10 @@
  *    (`collapsible.component.html` wraps its panel in a structural `@if`) and
  *    lands between the two, as it should at 128 rows instead of 201.
  * 5. `content-visibility` is a ~3.7x cut in Blink (one run, so treat the factor
- *    as approximate) and does nothing legible in WebKit: 171.8 and 169.8 across
- *    two runs, against unmodified samples spanning 166.9-194.0. That is not "no
- *    effect" — it is below what this setup can resolve, and a small real win is
- *    not excluded.
+ *    as approximate) and does nothing legible in WebKit: 171.8, 169.8 and 177.1
+ *    across three runs, against unmodified samples spanning 166.9-194.0 — and in
+ *    the third run it came in ABOVE its own baseline (177.1 vs 174.3). Below what
+ *    this setup resolves, so a small real win is not excluded either way.
  *
  * KNOWN BLIND SPOTS. These are hand-simulated writes, not the real event
  * sequence: `IosKeyboardService` is gated on native iOS and never runs here.
@@ -122,6 +122,11 @@
  */
 import { expect, test } from '../fixtures/test.fixture';
 import type { Page } from '@playwright/test';
+// Imported rather than hardcoded so a rename in the app breaks a grep here.
+// Nothing typechecks `e2e/`, so this is a discoverability guard, not a build
+// one — but the two symbols this header used to name went stale silently, and
+// this is the cheapest thing that would have made that visible.
+import { CSS_VAR_KEYBOARD_HEIGHT } from '../../src/app/core/theme/keyboard-css-vars.const';
 
 /**
  * `??` does not catch an empty string and `Number('x')` is NaN; both used to
@@ -376,7 +381,7 @@ const measureCssVarWrites = async (
   writes: number,
 ): Promise<Sample> =>
   page.evaluate(
-    ({ propertyKind, writeCount }) => {
+    ({ keyboardHeightVar, propertyKind, writeCount }) => {
       const root = document.documentElement;
       const leaf = document.querySelector('.add-task-button') as HTMLElement | null;
       if (propertyKind === 'leaf-custom-property' && !leaf) {
@@ -388,9 +393,9 @@ const measureCssVarWrites = async (
       };
       const write = (i: number): void => {
         if (propertyKind === 'root-custom-property') {
-          root.style.setProperty('--keyboard-height', `${300 + (i % 7)}px`);
+          root.style.setProperty(keyboardHeightVar, `${300 + (i % 7)}px`);
         } else if (propertyKind === 'leaf-custom-property') {
-          leaf!.style.setProperty('--keyboard-height', `${300 + (i % 7)}px`);
+          leaf!.style.setProperty(keyboardHeightVar, `${300 + (i % 7)}px`);
         } else if (propertyKind === 'root-inherited-standard') {
           // Same inheritance scope as the root custom property, different
           // property kind. This is the pair that isolates "custom property",
@@ -417,10 +422,10 @@ const measureCssVarWrites = async (
         }
         runs.push((performance.now() - started) / writeCount);
       }
-      root.style.removeProperty('--keyboard-height');
+      root.style.removeProperty(keyboardHeightVar);
       root.style.removeProperty('color');
       root.style.removeProperty('padding-top');
-      leaf?.style.removeProperty('--keyboard-height');
+      leaf?.style.removeProperty(keyboardHeightVar);
       document.body.getBoundingClientRect();
       return {
         label: `${propertyKind} write (moves rows: ${movesRows})`,
@@ -428,7 +433,11 @@ const measureCssVarWrites = async (
         values: runs,
       };
     },
-    { propertyKind: kind, writeCount: writes },
+    {
+      keyboardHeightVar: CSS_VAR_KEYBOARD_HEIGHT,
+      propertyKind: kind,
+      writeCount: writes,
+    },
   );
 
 test.describe('#9779 root custom-property write cost', () => {

--- a/e2e/measure/ios-keyboard-relayout.measure.ts
+++ b/e2e/measure/ios-keyboard-relayout.measure.ts
@@ -84,13 +84,18 @@
  * These per-write figures do NOT extrapolate to a run of writes. The write
  * measurements force a layout read after every write, which is what isolates one
  * write's cost — but it also defeats the coalescing a real caller gets for free.
- * Measured against 201 rows in WebKit: one write with a forced read 388ms, four
- * writes each followed by a forced read 1647ms (~4x, as expected), four writes
- * with a single forced read at the end 249ms. So consecutive writes with no
- * layout read between them cost about ONE recalc, not N. Before citing these
- * numbers against code that writes several properties in a row — the four
- * `--safe-area-inset-*` writes in `_initSafeAreaInsets`, say — check whether it
- * reads layout in between. Usually it does not.
+ * Measured against 201 rows in WebKit, relative to one write with a forced read:
+ * four writes each followed by a forced read cost ~4x; four writes with a single
+ * forced read at the end cost ~1x. So consecutive writes with no layout read
+ * between them are about ONE recalc, not N. Ratios, not absolutes — each case
+ * ran once in a fixed order, so the millisecond figures carry ordering noise
+ * (creating a custom property is not the same work as updating one) and are
+ * deliberately not quoted here; a 4x spread survives that, a 20% one would not.
+ * The batched case also wrote dummy properties nothing consumes, so vars that
+ * feed a `calc()` in the SCSS may cost more. Before citing these numbers against
+ * code that writes several properties in a row — the four `--safe-area-inset-*`
+ * writes in `_initSafeAreaInsets`, say — check whether it reads layout in
+ * between. Usually it does not.
  */
 import { expect, test } from '../fixtures/test.fixture';
 import type { Page } from '@playwright/test';

--- a/e2e/measure/ios-keyboard-relayout.measure.ts
+++ b/e2e/measure/ios-keyboard-relayout.measure.ts
@@ -33,8 +33,10 @@
  * - `shell-height-write` — the `height` + `min-height` that `IosKeyboardService`
  *   drives onto `.app-container` while the keyboard animates.
  *
- * Findings, measured 2026-09 (WebKit 26 / Chromium 151, iPhone 13 viewport
- * 390x664, `ng serve` build, median ms per write over 5 runs of 20):
+ * Findings, measured 2026-09 (WebKit 26.5 / Chromium 149, iPhone 13 viewport
+ * 390x664, `ng serve` build, median ms per write over 5 runs of 20). The engine
+ * build is printed by the harness, so check it against your own run rather than
+ * trusting this line:
  *
  *   WebKit                       0 rows   201    201 c-v   201 d:none   128 collapsed
  *   root-custom-property           8.0   180.4     171.8          8.2         117.2
@@ -50,28 +52,43 @@
  *   plain-property                 0.3     0.3       0.4          0.2
  *   shell-height-write x30         0.5     0.6       0.6          0.5
  *
- * Drift check (the `[rows: none, repeat]` line, measured last): WebKit 193.4 vs
- * an opening 180.4, Blink 12.6 vs 12.8. So in WebKit anything inside ±10% is
- * noise; Blink is stable enough to read directly.
+ * HOW MUCH OF THIS IS NOISE. Two clean WebKit runs gave four samples of the
+ * same unmodified 201-row root write (opening and `[rows: none, repeat]`):
+ * 180.4, 193.4, 194.0, 166.9 — a spread of ~16%. So read the WebKit column as
+ * "about 180", never to the decimal, and treat anything under ~1.2x as
+ * unresolved. Blink is far steadier (12.8 opening vs 12.6 repeat) and can be
+ * read directly. Both engines were measured with nothing else running; a
+ * concurrent second run inflates every figure by ~30% and is easy to do by
+ * accident.
  *
  * WHAT THE NUMBERS SAY.
  *
  * 1. It is custom properties specifically, not inherited properties. A `color`
- *    write on `<html>` invalidates exactly the same set of elements and costs
- *    0.1ms against the custom property's 180.4ms — a ratio of ~1800x in WebKit,
- *    ~40x in Blink. "Don't write inherited things on the root" would be the wrong
- *    lesson; "WebKit resolves custom properties per element on every root write"
- *    is the right one, and it is what the #9926 fix is built on.
+ *    write on `<html>` invalidates exactly the same set of elements and stays at
+ *    the 0.1ms floor while the custom property costs ~180ms — three orders of
+ *    magnitude in WebKit, ~40x in Blink. "Don't write inherited things on the
+ *    root" would be the wrong lesson; "WebKit resolves custom properties per
+ *    element on every root write" is the right one, and it is what the #9926 fix
+ *    is built on. This is the single most useful line in the file: without the
+ *    `root-inherited-standard` control the root-vs-leaf gap reads as the wrong
+ *    conclusion, and it read that way here until 2026-09.
  * 2. Only the root custom-property write scales with row count. Everything else
  *    in both tables is flat from 0 to 201 rows.
- * 3. Blink charges the same mechanism ~14x less (180.4 vs 12.8 at 201 rows).
- *    That is why the iOS fix was not ported to the Android path.
- * 4. Rows that are not rendered are not charged. `display: none` takes WebKit's
- *    180.4ms down to 8.2ms — the empty-list floor (8.0ms) — so the cost tracks
- *    rendered rows, not DOM nodes. Collapsing Completed Tasks, the reporter's own
- *    workaround, gets 117.2ms by removing rows from the DOM outright
- *    (`collapsible.component.html` wraps its panel in a structural `@if`).
- *    `content-visibility` cuts Blink 3.7x but lands inside WebKit's drift band.
+ * 3. Blink charges the same mechanism roughly an order of magnitude less (~180ms
+ *    vs 12.8ms at 201 rows). That is why the iOS fix was not ported to the
+ *    Android path — see `docs/android-edge-to-edge-keyboard.md` for that call.
+ * 4. Rows that are not rendered are barely charged. `display: none` takes
+ *    WebKit's ~180ms to 8.2 and 7.6ms across the two runs — the empty-list floor
+ *    (8.0-10.3ms) — so in WebKit the cost tracks rendered rows, not DOM nodes.
+ *    Blink also drops hard but not to its floor (1.6ms against 0.7ms), so state
+ *    this one per engine. Collapsing Completed Tasks, the reporter's own
+ *    workaround, removes the rows from the DOM outright
+ *    (`collapsible.component.html` wraps its panel in a structural `@if`) and
+ *    lands between the two, as it should at 128 rows instead of 201.
+ * 5. `content-visibility` is a real ~3.7x cut in Blink and does nothing legible
+ *    in WebKit: 171.8 and 169.8 across two runs, against unmodified samples
+ *    spanning 166.9-194.0. That is not "no effect" — it is below what this setup
+ *    can resolve, and a small real win is not excluded.
  *
  * KNOWN BLIND SPOTS. These are hand-simulated writes, not the real event
  * sequence: `IosKeyboardService` is gated on native iOS and never runs here.
@@ -427,11 +444,13 @@ test.describe('#9779 root custom-property write cost', () => {
       // eslint-disable-next-line no-console
       console.log(`[measure] ${line}`);
     };
-    // browserName, not a user-agent sniff: the shared fixture overrides the UA
-    // with "PLAYWRIGHT", so sniffing for "Chrome" reported webkit under both
-    // projects and silently mislabelled every Chromium run.
+    // browserName + browser.version(), never a user-agent sniff: the shared
+    // fixture overwrites the UA with "PLAYWRIGHT", which already made one
+    // generation of this harness report webkit under both projects. The build is
+    // printed rather than hand-written into the header above — a version nobody
+    // re-checked is the kind of claim this file exists to stop making.
     record(
-      `engine=${browserName} ` +
+      `engine=${browserName} build=${page.context().browser()?.version() ?? 'unknown'} ` +
         (await page.evaluate(
           () => `viewport=${window.innerWidth}x${window.innerHeight}`,
         )),

--- a/e2e/measure/ios-keyboard-relayout.measure.ts
+++ b/e2e/measure/ios-keyboard-relayout.measure.ts
@@ -39,11 +39,11 @@
  * trusting this line:
  *
  *   WebKit                       0 rows   201    201 c-v   201 d:none   128 collapsed
- *   root-custom-property           8.0   180.4     171.8          8.2         117.2
- *   root-inherited-standard        0.1     0.1       0.1          0.1
- *   leaf-custom-property           0.1     0.1       0.1          0.1
- *   plain-property                 0.0     0.0       0.1          0.0
- *   shell-height-write x30         5.0     5.0       5.0          5.0
+ *   root-custom-property             ~9   ~180      ~170            8          ~125
+ *   root-inherited-standard         0.1    0.1       0.1          0.1
+ *   leaf-custom-property            0.1    0.1       0.1          0.1
+ *   plain-property                  0.0    0.0       0.1          0.0
+ *   shell-height-write x30            5      5         5            5
  *
  *   Blink                        0 rows   201    201 c-v   201 d:none   128 collapsed
  *   root-custom-property           0.7    12.8       3.5          1.6           8.7
@@ -54,12 +54,12 @@
  *
  * HOW MUCH OF THIS IS NOISE. Two clean WebKit runs gave four samples of the
  * same unmodified 201-row root write (opening and `[rows: none, repeat]`):
- * 180.4, 193.4, 194.0, 166.9 — a spread of ~16%. So read the WebKit column as
- * "about 180", never to the decimal, and treat anything under ~1.2x as
- * unresolved. Blink is far steadier (12.8 opening vs 12.6 repeat) and can be
- * read directly. Both engines were measured with nothing else running; a
- * concurrent second run inflates every figure by ~30% and is easy to do by
- * accident.
+ * 180.4, 193.4, 194.0, 166.9 — a spread of ~16%, which is why the WebKit column
+ * above is rounded. Treat anything under ~1.2x there as unresolved. Blink held
+ * 12.8 opening against 12.6 repeat, but that is one pair, so its variant cells
+ * are single samples too. Measure with nothing else running: one contaminated
+ * run here inflated cells by a third to double, and stacking two runs is easy to
+ * do by accident.
  *
  * WHAT THE NUMBERS SAY.
  *
@@ -69,9 +69,8 @@
  *    magnitude in WebKit, ~40x in Blink. "Don't write inherited things on the
  *    root" would be the wrong lesson; "WebKit resolves custom properties per
  *    element on every root write" is the right one, and it is what the #9926 fix
- *    is built on. This is the single most useful line in the file: without the
- *    `root-inherited-standard` control the root-vs-leaf gap reads as the wrong
- *    conclusion, and it read that way here until 2026-09.
+ *    is built on. Without the `root-inherited-standard` control the root-vs-leaf
+ *    gap reads as the wrong conclusion, and it read that way here until 2026-09.
  * 2. Only the root custom-property write scales with row count. Everything else
  *    in both tables is flat from 0 to 201 rows.
  * 3. Blink charges the same mechanism roughly an order of magnitude less (~180ms
@@ -85,10 +84,11 @@
  *    workaround, removes the rows from the DOM outright
  *    (`collapsible.component.html` wraps its panel in a structural `@if`) and
  *    lands between the two, as it should at 128 rows instead of 201.
- * 5. `content-visibility` is a real ~3.7x cut in Blink and does nothing legible
- *    in WebKit: 171.8 and 169.8 across two runs, against unmodified samples
- *    spanning 166.9-194.0. That is not "no effect" — it is below what this setup
- *    can resolve, and a small real win is not excluded.
+ * 5. `content-visibility` is a ~3.7x cut in Blink (one run, so treat the factor
+ *    as approximate) and does nothing legible in WebKit: 171.8 and 169.8 across
+ *    two runs, against unmodified samples spanning 166.9-194.0. That is not "no
+ *    effect" — it is below what this setup can resolve, and a small real win is
+ *    not excluded.
  *
  * KNOWN BLIND SPOTS. These are hand-simulated writes, not the real event
  * sequence: `IosKeyboardService` is gated on native iOS and never runs here.

--- a/e2e/measure/ios-keyboard-relayout.measure.ts
+++ b/e2e/measure/ios-keyboard-relayout.measure.ts
@@ -18,8 +18,8 @@
  * publishes them on the CDK overlay container. The root write survives on the
  * NON-iOS path — `GlobalThemeService._initVisualViewportKeyboardTracking()`
  * (`global-theme.service.ts`) sets `--keyboard-height` on `document.documentElement`
- * for Android and mobile web — so the Blink column below is the live consumer of
- * this measurement, and the WebKit column is the record of what was fixed.
+ * for Android and mobile web — so the Blink numbers are the live consumer of this
+ * measurement, and the WebKit ones are the record of what was fixed.
  *
  * The measurements:
  *
@@ -33,62 +33,21 @@
  * - `shell-height-write` — the `height` + `min-height` that `IosKeyboardService`
  *   drives onto `.app-container` while the keyboard animates.
  *
- * Findings, measured 2026-09 (WebKit 26.5 / Chromium 149, iPhone 13 viewport
- * 390x664, `ng serve` build, median ms per write over 5 runs of 20). The engine
- * build is printed by the harness, so check it against your own run rather than
- * trusting this line:
- *
- *   WebKit                       0 rows   201    201 c-v   201 d:none   128 collapsed
- *   root-custom-property             ~9   ~180      ~170            8          ~125
- *   root-inherited-standard         0.1    0.1       0.1          0.1
- *   leaf-custom-property            0.1    0.1       0.1          0.1
- *   plain-property                  0.0    0.0       0.1          0.0
- *   shell-height-write x30            5      5         5            5
- *
- *   Blink                        0 rows   201    201 c-v   201 d:none   128 collapsed
- *   root-custom-property           0.7    12.8       3.5          1.6           8.7
- *   root-inherited-standard        0.3     0.3       0.3          0.3
- *   leaf-custom-property           0.1     0.1       0.1          0.0
- *   plain-property                 0.3     0.3       0.4          0.2
- *   shell-height-write x30         0.5     0.6       0.6          0.5
+ * THE FINDINGS LIVE IN `docs/android-edge-to-edge-keyboard.md`, under "What a
+ * `--keyboard-height` write on `<html>` costs". Numbers, the cross-engine
+ * comparison and the decision not to port the iOS fix to Android are all there,
+ * because that is the file someone reads before making an Android keyboard
+ * change — nobody greps `e2e/measure/`. What stays here is how to run the thing
+ * and how to read what it prints.
  *
  * HOW MUCH OF THIS IS NOISE. Clean WebKit runs gave these samples of the same
  * unmodified 201-row root write (opening and `[rows: none, repeat]`): 180.4,
- * 193.4, 194.0, 166.9, 174.3 — a spread of ~16%, which is why the WebKit column
- * above is rounded. Treat anything under ~1.2x there as unresolved. Blink held
+ * 193.4, 194.0, 166.9, 174.3 — a spread of ~16%, which is why the published
+ * WebKit figures are rounded. Treat anything under ~1.2x there as unresolved. Blink held
  * 12.8 opening against 12.6 repeat, but that is one pair, so its variant cells
  * are single samples too. Measure with nothing else running: one contaminated
  * run here inflated cells by a third to double, and stacking two runs is easy to
  * do by accident.
- *
- * WHAT THE NUMBERS SAY.
- *
- * 1. It is custom properties specifically, not inherited properties. A `color`
- *    write on `<html>` invalidates exactly the same set of elements and stays at
- *    the 0.1ms floor while the custom property costs ~180ms — three orders of
- *    magnitude in WebKit, ~40x in Blink. "Don't write inherited things on the
- *    root" would be the wrong lesson; "WebKit resolves custom properties per
- *    element on every root write" is the right one, and it is what the #9926 fix
- *    is built on. Without the `root-inherited-standard` control the root-vs-leaf
- *    gap reads as the wrong conclusion, and it read that way here until 2026-09.
- * 2. Only the root custom-property write scales with row count. Everything else
- *    in both tables is flat from 0 to 201 rows.
- * 3. Blink charges the same mechanism roughly an order of magnitude less (~180ms
- *    vs 12.8ms at 201 rows). That is why the iOS fix was not ported to the
- *    Android path — see `docs/android-edge-to-edge-keyboard.md` for that call.
- * 4. Rows that are not rendered are barely charged. `display: none` takes
- *    WebKit's ~180ms to 8.2 and 7.6ms across the two runs — the empty-list floor
- *    (8.0-10.3ms) — so in WebKit the cost tracks rendered rows, not DOM nodes.
- *    Blink also drops hard but not to its floor (1.6ms against 0.7ms), so state
- *    this one per engine. Collapsing Completed Tasks, the reporter's own
- *    workaround, removes the rows from the DOM outright
- *    (`collapsible.component.html` wraps its panel in a structural `@if`) and
- *    lands between the two, as it should at 128 rows instead of 201.
- * 5. `content-visibility` is a ~3.7x cut in Blink (one run, so treat the factor
- *    as approximate) and does nothing legible in WebKit: 171.8, 169.8 and 177.1
- *    across three runs, against unmodified samples spanning 166.9-194.0 — and in
- *    the third run it came in ABOVE its own baseline (177.1 vs 174.3). Below what
- *    this setup resolves, so a small real win is not excluded either way.
  *
  * KNOWN BLIND SPOTS. These are hand-simulated writes, not the real event
  * sequence: `IosKeyboardService` is gated on native iOS and never runs here.

--- a/e2e/measure/ios-keyboard-relayout.measure.ts
+++ b/e2e/measure/ios-keyboard-relayout.measure.ts
@@ -1,0 +1,510 @@
+/**
+ * Manual measurement harness for #9779 — "opening the add-task bar on iOS is
+ * laggy, and it gets worse the more task rows are on screen".
+ *
+ * Not a test: it asserts only that its own setup worked, prints numbers, and
+ * always passes. Run it by hand:
+ *
+ *   npx playwright test --config e2e/measure/playwright.measure.config.ts \
+ *     --project=measure-webkit
+ *
+ * MEASURE_OPEN_TASK_COUNT / MEASURE_DONE_TASK_COUNT override the seeded list
+ * (default 128 open + 73 done — the reporter's own Inbox).
+ *
+ * What it measures, and why each one is here:
+ *
+ * - `root-custom-property write` — `keyboardWillShow` sets `--keyboard-height`
+ *   on `document.documentElement`, and `keyboardWillHide` resets it along with
+ *   `--keyboard-overlay-offset` (`global-theme.service.ts`).
+ * - `leaf-custom-property write` — the same write aimed at an element nothing
+ *   inherits from. The pair is the measurement: it prices the #9809 treatment of
+ *   `--visual-viewport-height` if applied to these two as well.
+ * - `plain-property write` — a non-inherited property on the root. Weaker: it
+ *   does NOT move the rows (the label says so), so it prices the write plus the
+ *   forced rect read, not layout.
+ * - `shell-height-write` — `iosShellHeight` writes a height on `.app-container`
+ *   once per visualViewport resize while the keyboard animates.
+ * - `resize-dispatch` — `_notifyIOSViewportChange` fires a synthetic window
+ *   resize per animation frame, waking CdkTextareaAutosize and every connected
+ *   CDK overlay's ViewportRuler.
+ * - `add-task-bar-open` — tap on the mobile FAB to the input holding focus.
+ *
+ * Findings as of 2026-09 (WebKit 26, iPhone 13 viewport, `ng serve` build):
+ *
+ *                                   0 rows   201 rows   128 rows, done collapsed
+ *   root-custom-property write        9.2ms    219.5ms                    121.9ms
+ *   leaf-custom-property write        0.1ms      0.1ms                          -
+ *   plain-property write              0.1ms      0.1ms                          -
+ *   shell-height-write x30            5.0ms      5.0ms                          -
+ *   resize-dispatch x30               0.0ms      0.0ms                          -
+ *   add-task-bar-open                49.0ms     37.0ms                     41.0ms
+ *
+ * Only the root custom-property write scales, and it scales hard. The identical
+ * write on a leaf stays at 0.1ms with 201 rows on screen, so the cost is style
+ * invalidation across everything that could inherit the property — not the write,
+ * and not layout. Collapsing the Completed Tasks section, the reporter's own
+ * workaround, drops it to 121.9ms because `collapsible.component.html` wraps its
+ * panel in a structural `@if`: those rows leave the DOM. `display: none` does NOT
+ * help, because WebKit still computes style for display-none subtrees, and
+ * neither does `content-visibility` — both land inside the run-to-run drift that
+ * the repeated `[rows: none, repeat]` baseline exists to expose.
+ *
+ * The shell-height write and the synthetic resize are genuinely flat. The resize
+ * costs nothing here partly because the app is zoneless
+ * (`provideZonelessChangeDetection`), and partly because this harness runs it
+ * with no overlay open, which is not the state the real keyboard opens in.
+ *
+ * KNOWN BLIND SPOTS. `_initIOSKeyboardHandling` is gated on native iOS, so it
+ * never runs here: these are hand-simulated writes, not the real event sequence.
+ * Headless WebKit also does no real tile rasterization and has no soft keyboard,
+ * so the cost of Capacitor `resize: 'native'` animating the WKWebView frame is
+ * out of reach at any list size. Absolute numbers are relative indicators only —
+ * an A15 is not this machine.
+ *
+ * Timing note: WebKit clamps `performance.now()` to 1ms, so nothing below times
+ * a single operation directly. `shell-height-write` and `resize-dispatch` report
+ * the total across N iterations; `root ... write` divides its N-iteration total
+ * back down to a per-write figure, which is only meaningful because each write
+ * is far above the clamp. `add-task-bar-open` polls with requestAnimationFrame,
+ * so it is quantised to ~16.7ms — differences under one frame are not real.
+ */
+import { expect, test } from '../fixtures/test.fixture';
+import type { Page } from '@playwright/test';
+
+/** The reporter's Inbox: 128 open + 73 done. */
+const OPEN_TASK_COUNT = Number(process.env.MEASURE_OPEN_TASK_COUNT ?? 128);
+const DONE_TASK_COUNT = Number(process.env.MEASURE_DONE_TASK_COUNT ?? 73);
+const TASK_COUNT = OPEN_TASK_COUNT + DONE_TASK_COUNT;
+/** Mirrors the op-log batch cap; only affects how the seed is chunked. */
+const MAX_BATCH_OPERATIONS_SIZE = 50;
+const SHELL_WRITE_FRAMES = 30;
+const RESIZE_DISPATCHES = 30;
+const ROOT_WRITES = 20;
+const WRITE_KINDS = [
+  'root-custom-property',
+  'leaf-custom-property',
+  'plain-property',
+] as const;
+const OPEN_REPS = 11;
+/** The first open of each variant pays for lazy work that never repeats. */
+const OPEN_WARMUP_REPS = 2;
+const INBOX_PROJECT_ID = 'INBOX_PROJECT';
+
+/** Row-level CSS whose effect on each measurement is worth knowing. */
+const ROW_VARIANTS: readonly { label: string; css: string }[] = [
+  { label: 'none', css: '' },
+  {
+    label: 'content-visibility',
+    css: 'task { content-visibility: auto; contain-intrinsic-size: auto 52px; }',
+  },
+  // The discriminator: `display: none` removes the rows from layout but not from
+  // style computation, so a cost that survives it is style invalidation.
+  { label: 'display:none', css: 'task { display: none; }' },
+];
+
+const STYLE_ID = 'measure-variant-style';
+
+const applyRowVariant = async (page: Page, css: string): Promise<void> => {
+  await page.evaluate(
+    ({ id, variantCss }) => {
+      document.getElementById(id)?.remove();
+      if (variantCss) {
+        const style = document.createElement('style');
+        style.id = id;
+        style.textContent = variantCss;
+        document.head.appendChild(style);
+      }
+      // Settle the new styles so they are not charged to the next measurement.
+      document.body.getBoundingClientRect();
+    },
+    { id: STYLE_ID, variantCss: css },
+  );
+};
+
+const clearRowVariant = (page: Page): Promise<void> => applyRowVariant(page, '');
+
+const seedProjectTasks = async (
+  page: Page,
+  taskIdPrefix: string,
+  openCount: number,
+  doneCount: number,
+): Promise<void> => {
+  await page.evaluate(
+    ({ batchSize, doneTaskCount, idPrefix, openTaskCount, projectId }) => {
+      const count = openTaskCount + doneTaskCount;
+      const store = (
+        window as unknown as {
+          __e2eTestHelpers?: { store?: { dispatch: (action: unknown) => void } };
+        }
+      ).__e2eTestHelpers?.store;
+      if (!store) {
+        throw new Error('__e2eTestHelpers.store missing — is this a dev/stage build?');
+      }
+      const operations = Array.from({ length: count }, (_, index) => ({
+        type: 'create',
+        tempId: `temp-${index}`,
+        // Done rows land in the collapsible Completed Tasks section, which is
+        // what the reporter collapses to make the lag go away.
+        data: { title: `Measure seed ${index + 1}`, isDone: index >= openTaskCount },
+      }));
+      const createdTaskIds = Object.fromEntries(
+        operations.map(({ tempId }, index) => [
+          tempId,
+          `${idPrefix}${String(index).padStart(4, '0')}`,
+        ]),
+      );
+      for (let offset = 0; offset < operations.length; offset += batchSize) {
+        store.dispatch({
+          type: '[Task Shared] batchUpdateForProject',
+          projectId,
+          operations: operations.slice(offset, offset + batchSize),
+          createdTaskIds,
+          createdTaskTimestamp: 1_750_000_000_000,
+          meta: {
+            isPersistent: true,
+            entityType: 'PROJECT',
+            entityId: projectId,
+            opType: 'BATCH',
+          },
+        });
+      }
+    },
+    {
+      batchSize: MAX_BATCH_OPERATIONS_SIZE,
+      doneTaskCount: doneCount,
+      idPrefix: taskIdPrefix,
+      openTaskCount: openCount,
+      projectId: INBOX_PROJECT_ID,
+    },
+  );
+};
+
+interface Sample {
+  readonly label: string;
+  readonly rowCount: number;
+  readonly values: number[];
+}
+
+const median = (values: readonly number[]): number =>
+  [...values].sort((a, b) => a - b)[Math.floor(values.length / 2)];
+
+const summarize = ({ label, rowCount, values }: Sample, unit: string): string => {
+  const sorted = [...values].sort((a, b) => a - b);
+  return (
+    `${label.padEnd(38)} rows=${String(rowCount).padStart(4)} ` +
+    `median=${median(values).toFixed(1)}${unit} ` +
+    `min=${sorted[0].toFixed(1)}${unit} max=${sorted[sorted.length - 1].toFixed(1)}${unit}`
+  );
+};
+
+/**
+ * Shell-height write plus the forced layout the browser would do before paint,
+ * totalled over `frames` because of the 1ms clock clamp.
+ */
+const measureShellHeightWrites = async (page: Page, frames: number): Promise<Sample> =>
+  page.evaluate((frameCount) => {
+    const shell = document.querySelector('.app-container') as HTMLElement | null;
+    if (!shell) {
+      throw new Error('.app-container missing');
+    }
+    const base = window.innerHeight;
+    // Mimic the shrink animation: a different height every frame, which is what
+    // iosShellHeight writes as visualViewport resize events land.
+    const writeFrame = (i: number): void => {
+      const height = base - 300 - (i % 7);
+      shell.style.height = `${height}px`;
+      shell.style.minHeight = `${height}px`;
+      shell.getBoundingClientRect();
+    };
+    const runs: number[] = [];
+    for (let run = 0; run < 5; run++) {
+      for (let i = 0; i < 5; i++) {
+        writeFrame(i);
+      }
+      const started = performance.now();
+      for (let i = 0; i < frameCount; i++) {
+        writeFrame(i);
+      }
+      runs.push(performance.now() - started);
+    }
+    shell.style.height = '';
+    shell.style.minHeight = '';
+    shell.getBoundingClientRect();
+    return {
+      label: `shell-height-write x${frameCount}`,
+      rowCount: document.querySelectorAll('task').length,
+      values: runs,
+    };
+  }, frames);
+
+/**
+ * The write `keyboardWillShow`/`keyboardWillHide` still make on the root
+ * (`global-theme.service.ts`: `--keyboard-height`, `--keyboard-overlay-offset`),
+ * against the same write aimed at a leaf element.
+ *
+ * A custom property invalidates the computed style of everything that could
+ * inherit it, so on `document.documentElement` its cost scales with the whole
+ * rendered tree, and on a leaf it does not. That pair is the measurement: it is
+ * the difference the #9809 treatment of `--visual-viewport-height` would make if
+ * applied to these two as well.
+ *
+ * `plain-property` is a third, weaker reading: a non-inherited property on the
+ * root. It reports whether the write plus the forced rect read is itself free —
+ * NOT whether layout is free, since it does not move the rows (the returned
+ * label says which, so a 0ms reading is never mistaken for the latter).
+ */
+type WriteKind = 'root-custom-property' | 'leaf-custom-property' | 'plain-property';
+
+const measureCssVarWrites = async (
+  page: Page,
+  kind: WriteKind,
+  writes: number,
+): Promise<Sample> =>
+  page.evaluate(
+    ({ propertyKind, writeCount }) => {
+      const root = document.documentElement;
+      const leaf = document.querySelector('.add-task-button') as HTMLElement | null;
+      if (propertyKind === 'leaf-custom-property' && !leaf) {
+        throw new Error('.add-task-button missing — no leaf to write to');
+      }
+      const lastRow = (): Element | null => document.querySelector('task:last-of-type');
+      const write = (i: number): void => {
+        if (propertyKind === 'root-custom-property') {
+          root.style.setProperty('--keyboard-height', `${300 + (i % 7)}px`);
+        } else if (propertyKind === 'leaf-custom-property') {
+          leaf!.style.setProperty('--keyboard-height', `${300 + (i % 7)}px`);
+        } else {
+          root.style.setProperty('padding-top', `${i % 7}px`);
+        }
+        // Force the style recalculation the browser would do before paint.
+        document.body.getBoundingClientRect();
+      };
+      // A reading of ~0ms only means "cheap"; whether it also relayouts the rows
+      // is a separate question, and reporting it stops the two being conflated.
+      write(0);
+      const before = lastRow()?.getBoundingClientRect().top;
+      write(5);
+      const movesRows = before !== lastRow()?.getBoundingClientRect().top;
+
+      const runs: number[] = [];
+      for (let run = 0; run < 5; run++) {
+        const started = performance.now();
+        for (let i = 0; i < writeCount; i++) {
+          write(i);
+        }
+        runs.push((performance.now() - started) / writeCount);
+      }
+      root.style.removeProperty('--keyboard-height');
+      root.style.removeProperty('padding-top');
+      leaf?.style.removeProperty('--keyboard-height');
+      document.body.getBoundingClientRect();
+      return {
+        label: `${propertyKind} write (moves rows: ${movesRows})`,
+        rowCount: document.querySelectorAll('task').length,
+        values: runs,
+      };
+    },
+    { propertyKind: kind, writeCount: writes },
+  );
+
+/** The synthetic window resize `_notifyIOSViewportChange` fires per frame. */
+const measureResizeDispatch = async (page: Page, dispatches: number): Promise<Sample> =>
+  page.evaluate((count) => {
+    const burst = (): void => {
+      for (let i = 0; i < count; i++) {
+        window.dispatchEvent(new Event('resize'));
+      }
+      // Charge the layout the app would be forced into before the next paint.
+      document.body.getBoundingClientRect();
+    };
+    burst();
+    const runs: number[] = [];
+    for (let run = 0; run < 5; run++) {
+      const started = performance.now();
+      burst();
+      runs.push(performance.now() - started);
+    }
+    return {
+      label: `resize-dispatch x${count}`,
+      rowCount: document.querySelectorAll('task').length,
+      values: runs,
+    };
+  }, dispatches);
+
+/**
+ * The reported interaction, timed in-page so Playwright IPC and actionability
+ * checks stay out of the number.
+ */
+const measureAddTaskBarOpen = async (
+  page: Page,
+  label: string,
+  reps: number,
+): Promise<Sample> => {
+  const values: number[] = [];
+  for (let rep = 0; rep < reps + OPEN_WARMUP_REPS; rep++) {
+    const elapsed = await page.evaluate(async () => {
+      const button = document.querySelector('.add-task-button') as HTMLElement | null;
+      if (!button) {
+        throw new Error('.add-task-button missing — is the mobile bottom nav shown?');
+      }
+      if (document.querySelector('add-task-bar.global')) {
+        throw new Error('add-task-bar already open — the previous rep did not close');
+      }
+      const until = (predicate: () => boolean): Promise<number> =>
+        new Promise((resolve, reject) => {
+          const deadline = performance.now() + 20000;
+          const check = (): void => {
+            if (predicate()) {
+              resolve(performance.now());
+            } else if (performance.now() > deadline) {
+              reject(new Error('timed out waiting for the add-task bar'));
+            } else {
+              requestAnimationFrame(check);
+            }
+          };
+          check();
+        });
+
+      const started = performance.now();
+      button.click();
+      // Focus, not mere presence: the reporter's complaint is the delay before
+      // they can type, which is what the keyboard hangs off.
+      const focusedAt = await until(
+        () => !!document.activeElement?.closest('add-task-bar.global'),
+      );
+      return focusedAt - started;
+    });
+    if (rep >= OPEN_WARMUP_REPS) {
+      values.push(elapsed);
+    }
+
+    // Closed through the store, not Escape: a keypress that lands a frame before
+    // the input takes focus is silently dropped, and the next rep then aborts on
+    // an already-open bar.
+    await page.evaluate(() => {
+      const store = (
+        window as unknown as {
+          __e2eTestHelpers?: { store?: { dispatch: (action: unknown) => void } };
+        }
+      ).__e2eTestHelpers?.store;
+      store?.dispatch({ type: '[Layout] Hide AddTaskBar' });
+    });
+    await page.locator('add-task-bar.global').waitFor({ state: 'detached' });
+  }
+  return {
+    label: `add-task-bar-open [rows: ${label}]`,
+    rowCount: await page.locator('task').count(),
+    values,
+  };
+};
+
+test.describe('#9779 iOS add-task-bar open cost', () => {
+  test('what scales with the number of rendered task rows', async ({
+    page,
+    workViewPage,
+    testPrefix,
+  }) => {
+    const lines: string[] = [];
+    lines.push(
+      await page.evaluate(
+        () =>
+          `engine=${navigator.userAgent.includes('Chrome') ? 'chromium' : 'webkit'} ` +
+          `viewport=${window.innerWidth}x${window.innerHeight}`,
+      ),
+    );
+
+    // Seed straight into the built-in Inbox project: creating one through the UI
+    // needs the side nav, which is collapsed at this viewport.
+    await page.evaluate((projectId) => {
+      window.location.hash = `#/project/${projectId}/tasks`;
+    }, INBOX_PROJECT_ID);
+    await workViewPage.waitForTaskList();
+    // The FAB is the entry point every open measurement uses; without it the
+    // harness would silently measure nothing.
+    await expect(page.locator('.add-task-button')).toBeVisible();
+
+    // Boot work (lazy chunks, first render, initial sync) keeps running for a
+    // while after the list appears, and it lands squarely on whatever is measured
+    // first. Burn it off, otherwise the empty-list baseline reads slower than the
+    // 200-row case and the comparison inverts.
+    // `waitForTimeout` is banned in e2e/tests for good reason; here there is no
+    // event to wait for — the point is to let unrelated boot work drain.
+    await page.waitForTimeout(2000);
+    await measureShellHeightWrites(page, SHELL_WRITE_FRAMES);
+    await measureAddTaskBarOpen(page, 'warmup', 1);
+
+    lines.push('--- empty list ---');
+    for (const kind of WRITE_KINDS) {
+      lines.push(summarize(await measureCssVarWrites(page, kind, ROOT_WRITES), 'ms'));
+    }
+    lines.push(summarize(await measureShellHeightWrites(page, SHELL_WRITE_FRAMES), 'ms'));
+    lines.push(summarize(await measureResizeDispatch(page, RESIZE_DISPATCHES), 'ms'));
+    lines.push(summarize(await measureAddTaskBarOpen(page, 'none', OPEN_REPS), 'ms'));
+
+    const taskIdPrefix = `${testPrefix}-measure-`;
+    await seedProjectTasks(page, taskIdPrefix, OPEN_TASK_COUNT, DONE_TASK_COUNT);
+    // A silent seeding failure would look exactly like "cost does not scale",
+    // so the row count is asserted rather than merely reported.
+    await expect(page.locator(`task[data-task-id^="${taskIdPrefix}"]`)).toHaveCount(
+      TASK_COUNT,
+      { timeout: 30000 },
+    );
+    await page.waitForTimeout(1500);
+
+    lines.push(
+      `--- ${TASK_COUNT} tasks (${OPEN_TASK_COUNT} open + ${DONE_TASK_COUNT} done) ---`,
+    );
+    for (const { label, css } of ROW_VARIANTS) {
+      await applyRowVariant(page, css);
+      for (const kind of WRITE_KINDS) {
+        lines.push(
+          summarize(await measureCssVarWrites(page, kind, ROOT_WRITES), 'ms') +
+            `  [rows: ${label}]`,
+        );
+      }
+      lines.push(
+        summarize(await measureShellHeightWrites(page, SHELL_WRITE_FRAMES), 'ms') +
+          `  [rows: ${label}]`,
+      );
+      lines.push(
+        summarize(await measureResizeDispatch(page, RESIZE_DISPATCHES), 'ms') +
+          `  [rows: ${label}]`,
+      );
+      await clearRowVariant(page);
+    }
+    // Variants run in fixed order, and these numbers drift upward over a run.
+    // Repeating the unmodified baseline last is what tells a real variant effect
+    // apart from that drift — compare each variant to BOTH baselines.
+    lines.push(
+      summarize(
+        await measureCssVarWrites(page, 'root-custom-property', ROOT_WRITES),
+        'ms',
+      ) + '  [rows: none, repeat]',
+    );
+    for (const { label, css } of ROW_VARIANTS) {
+      await applyRowVariant(page, css);
+      lines.push(summarize(await measureAddTaskBarOpen(page, label, OPEN_REPS), 'ms'));
+      await clearRowVariant(page);
+    }
+
+    // The reporter's own workaround, run as an A/B. Collapsing is not hiding:
+    // `collapsible.component.html` wraps its panel in a structural `@if`, so the
+    // done rows leave the DOM entirely rather than becoming `display: none`.
+    const doneHeader = page
+      .locator('collapsible', { hasText: 'Completed Tasks' })
+      .locator('.collapsible-header')
+      .first();
+    await doneHeader.click();
+    await expect(page.locator('task')).toHaveCount(OPEN_TASK_COUNT);
+    lines.push(`--- ${OPEN_TASK_COUNT} tasks, Completed Tasks collapsed ---`);
+    lines.push(
+      summarize(
+        await measureCssVarWrites(page, 'root-custom-property', ROOT_WRITES),
+        'ms',
+      ),
+    );
+    lines.push(summarize(await measureAddTaskBarOpen(page, 'none', OPEN_REPS), 'ms'));
+
+    console.log(`\n===== #9779 MEASUREMENT =====\n${lines.join('\n')}\n`);
+  });
+});

--- a/e2e/measure/ios-keyboard-relayout.measure.ts
+++ b/e2e/measure/ios-keyboard-relayout.measure.ts
@@ -2,8 +2,10 @@
  * Manual measurement harness for #9779 — "opening the add-task bar on iOS is
  * laggy, and it gets worse the more task rows are on screen".
  *
- * Not a test: it asserts only that its own setup worked, prints numbers, and
- * always passes. Run it by hand:
+ * Not a performance assertion: it prints numbers and asserts only that its own
+ * setup worked. It can still fail — the shared fixture throws on any uncaught
+ * browser error — but it will never fail because a number got worse. Run it by
+ * hand:
  *
  *   npx playwright test --config e2e/measure/playwright.measure.config.ts \
  *     --project=measure-webkit
@@ -11,131 +13,171 @@
  * MEASURE_OPEN_TASK_COUNT / MEASURE_DONE_TASK_COUNT override the seeded list
  * (default 128 open + 73 done — the reporter's own Inbox).
  *
- * What it measures, and why each one is here:
+ * WHAT THIS STILL PRICES, now that #9779 is fixed. The iOS path no longer writes
+ * these variables on the root: `IosKeyboardService` (`ios-keyboard.service.ts`)
+ * publishes them on the CDK overlay container. The root write survives on the
+ * NON-iOS path — `GlobalThemeService._initVisualViewportKeyboardTracking()`
+ * (`global-theme.service.ts`) sets `--keyboard-height` on `document.documentElement`
+ * for Android and mobile web — so the Blink column below is the live consumer of
+ * this measurement, and the WebKit column is the record of what was fixed.
  *
- * - `root-custom-property write` — `keyboardWillShow` sets `--keyboard-height`
- *   on `document.documentElement`, and `keyboardWillHide` resets it along with
- *   `--keyboard-overlay-offset` (`global-theme.service.ts`).
- * - `leaf-custom-property write` — the same write aimed at an element nothing
- *   inherits from. The pair is the measurement: it prices the #9809 treatment of
- *   `--visual-viewport-height` if applied to these two as well.
- * - `plain-property write` — a non-inherited property on the root. Weaker: it
- *   does NOT move the rows (the label says so), so it prices the write plus the
- *   forced rect read, not layout.
- * - `shell-height-write` — `iosShellHeight` writes a height on `.app-container`
- *   once per visualViewport resize while the keyboard animates.
- * - `resize-dispatch` — `_notifyIOSViewportChange` fires a synthetic window
- *   resize per animation frame, waking CdkTextareaAutosize and every connected
- *   CDK overlay's ViewportRuler.
- * - `add-task-bar-open` — tap on the mobile FAB to the input holding focus.
+ * The measurements:
  *
- * Findings as of 2026-09 (WebKit 26, iPhone 13 viewport, `ng serve` build):
+ * - `root-custom-property` — a custom property on `document.documentElement`.
+ * - `root-inherited-standard` — an ordinary *inherited* property (`color`) on the
+ *   same element. Identical invalidation scope, so this is the pair that isolates
+ *   "custom property"; root-vs-leaf alone only isolates "inheritance scope".
+ * - `leaf-custom-property` — the same custom-property write aimed at a small
+ *   subtree (the FAB, ~6 elements) instead of the root.
+ * - `plain-property` — a non-inherited property (`padding-top`) on the root.
+ * - `shell-height-write` — the `height` + `min-height` that `IosKeyboardService`
+ *   drives onto `.app-container` while the keyboard animates.
  *
- *                                   0 rows   201 rows   128 rows, done collapsed
- *   root-custom-property write        9.2ms    219.5ms                    121.9ms
- *   leaf-custom-property write        0.1ms      0.1ms                          -
- *   plain-property write              0.1ms      0.1ms                          -
- *   shell-height-write x30            5.0ms      5.0ms                          -
- *   resize-dispatch x30               0.0ms      0.0ms                          -
- *   add-task-bar-open                49.0ms     37.0ms                     41.0ms
+ * Findings, measured 2026-09 (WebKit 26 / Chromium 151, iPhone 13 viewport
+ * 390x664, `ng serve` build, median ms per write over 5 runs of 20):
  *
- * The same run under `--project=measure-chromium` (Blink, 2026-09):
+ *   WebKit                       0 rows   201    201 c-v   201 d:none   128 collapsed
+ *   root-custom-property           8.0   180.4     171.8          8.2         117.2
+ *   root-inherited-standard        0.1     0.1       0.1          0.1
+ *   leaf-custom-property           0.1     0.1       0.1          0.1
+ *   plain-property                 0.0     0.0       0.1          0.0
+ *   shell-height-write x30         5.0     5.0       5.0          5.0
  *
- *                                   0 rows   201 rows   201 rows, content-vis
- *   root-custom-property write        1.0ms     14.1ms                 1.9-4.0ms
- *   leaf-custom-property write        0.1ms      0.0ms                     0.1ms
- *   plain-property write              0.3ms      0.3ms                     0.3ms
+ *   Blink                        0 rows   201    201 c-v   201 d:none   128 collapsed
+ *   root-custom-property           0.7    12.8       3.5          1.6           8.7
+ *   root-inherited-standard        0.3     0.3       0.3          0.3
+ *   leaf-custom-property           0.1     0.1       0.1          0.0
+ *   plain-property                 0.3     0.3       0.4          0.2
+ *   shell-height-write x30         0.5     0.6       0.6          0.5
  *
- * Blink charges the same mechanism roughly an order of magnitude less: still 14x
- * the leaf write and still scaling with row count, but ~14ms rather than
- * hundreds. Worth knowing before porting an iOS fix to the Android path on the
- * strength of the WebKit number alone — and note `content-visibility` cuts it
- * severalfold here while doing nothing at all in WebKit.
+ * Drift check (the `[rows: none, repeat]` line, measured last): WebKit 193.4 vs
+ * an opening 180.4, Blink 12.6 vs 12.8. So in WebKit anything inside ±10% is
+ * noise; Blink is stable enough to read directly.
  *
- * Only the root custom-property write scales, and it scales hard. The identical
- * write on a leaf stays at 0.1ms with 201 rows on screen, so the cost is style
- * invalidation across everything that could inherit the property — not the write,
- * and not layout. Collapsing the Completed Tasks section, the reporter's own
- * workaround, drops it to 121.9ms because `collapsible.component.html` wraps its
- * panel in a structural `@if`: those rows leave the DOM. `display: none` does NOT
- * help, because WebKit still computes style for display-none subtrees, and
- * neither does `content-visibility` — both land inside the run-to-run drift that
- * the repeated `[rows: none, repeat]` baseline exists to expose.
+ * WHAT THE NUMBERS SAY.
  *
- * The shell-height write and the synthetic resize are genuinely flat. The resize
- * costs nothing here partly because the app is zoneless
- * (`provideZonelessChangeDetection`), and partly because this harness runs it
- * with no overlay open, which is not the state the real keyboard opens in.
+ * 1. It is custom properties specifically, not inherited properties. A `color`
+ *    write on `<html>` invalidates exactly the same set of elements and costs
+ *    0.1ms against the custom property's 180.4ms — a ratio of ~1800x in WebKit,
+ *    ~40x in Blink. "Don't write inherited things on the root" would be the wrong
+ *    lesson; "WebKit resolves custom properties per element on every root write"
+ *    is the right one, and it is what the #9926 fix is built on.
+ * 2. Only the root custom-property write scales with row count. Everything else
+ *    in both tables is flat from 0 to 201 rows.
+ * 3. Blink charges the same mechanism ~14x less (180.4 vs 12.8 at 201 rows).
+ *    That is why the iOS fix was not ported to the Android path.
+ * 4. Rows that are not rendered are not charged. `display: none` takes WebKit's
+ *    180.4ms down to 8.2ms — the empty-list floor (8.0ms) — so the cost tracks
+ *    rendered rows, not DOM nodes. Collapsing Completed Tasks, the reporter's own
+ *    workaround, gets 117.2ms by removing rows from the DOM outright
+ *    (`collapsible.component.html` wraps its panel in a structural `@if`).
+ *    `content-visibility` cuts Blink 3.7x but lands inside WebKit's drift band.
  *
- * KNOWN BLIND SPOTS. `_initIOSKeyboardHandling` is gated on native iOS, so it
- * never runs here: these are hand-simulated writes, not the real event sequence.
- * Headless WebKit also does no real tile rasterization and has no soft keyboard,
- * so the cost of Capacitor `resize: 'native'` animating the WKWebView frame is
- * out of reach at any list size. Absolute numbers are relative indicators only —
- * an A15 is not this machine.
+ * KNOWN BLIND SPOTS. These are hand-simulated writes, not the real event
+ * sequence: `IosKeyboardService` is gated on native iOS and never runs here.
+ * Headless WebKit does no real tile rasterization and has no soft keyboard, so
+ * the cost of Capacitor `resize: 'native'` animating the WKWebView frame is out
+ * of reach at any list size. `ng serve` is an unoptimized build. An A15 is not
+ * this machine — read the ratios, not the milliseconds. `ios-keyboard.service.ts`
+ * quotes ~390ms for this write from the original #9779 investigation; that was a
+ * single write on a different machine, where this table divides a 20-write total.
+ * Same phenomenon, don't try to reconcile the absolute values.
  *
- * Timing note: WebKit clamps `performance.now()` to 1ms, so nothing below times
- * a single operation directly. `shell-height-write` and `resize-dispatch` report
- * the total across N iterations; `root ... write` divides its N-iteration total
- * back down to a per-write figure, which is only meaningful because each write
- * is far above the clamp. `add-task-bar-open` polls with requestAnimationFrame,
- * so it is quantised to ~16.7ms — differences under one frame are not real.
+ * TIMING. WebKit clamps `performance.now()` to 1ms, so no single operation is
+ * timed directly: every figure is an N-iteration total divided by N. The rule
+ * that follows is that the TOTAL must clear the clamp, and each per-write figure
+ * then carries ±(clamp/N) — ±0.05ms at N=20. That band is nothing against the
+ * root write's 180ms and is the whole value of every 0.0-0.1ms cell, so treat
+ * those as "below resolution", not as measured differences.
  *
- * These per-write figures do NOT extrapolate to a run of writes. The write
- * measurements force a layout read after every write, which is what isolates one
- * write's cost — but it also defeats the coalescing a real caller gets for free.
- * Measured against 201 rows in WebKit, relative to one write with a forced read:
+ * COALESCING — a scratch measurement, not reproduced by this file. Every write
+ * kind here forces a layout read after every write, which isolates one write's
+ * cost but defeats the coalescing a real caller gets for free. Measured
+ * separately in WebKit at 201 rows, relative to one write with a forced read:
  * four writes each followed by a forced read cost ~4x; four writes with a single
- * forced read at the end cost ~1x. So consecutive writes with no layout read
- * between them are about ONE recalc, not N. Ratios, not absolutes — each case
- * ran once in a fixed order, so the millisecond figures carry ordering noise
- * (creating a custom property is not the same work as updating one) and are
- * deliberately not quoted here; a 4x spread survives that, a 20% one would not.
- * The batched case also wrote dummy properties nothing consumes, so vars that
- * feed a `calc()` in the SCSS may cost more. Before citing these numbers against
- * code that writes several properties in a row — the four `--safe-area-inset-*`
- * writes in `_initSafeAreaInsets`, say — check whether it reads layout in
- * between. Usually it does not.
+ * forced read at the end cost ~1x. Consecutive writes with no layout read
+ * between them are about ONE recalc, not N. Ratios only — the cases ran once
+ * each in fixed order, and the batched case wrote dummy properties nothing
+ * consumes, so vars feeding a `calc()` may cost more. Before citing this table
+ * against code that writes several properties in a row — the four
+ * `--safe-area-inset-*` writes in `_initSafeAreaInsets`, say — check whether it
+ * reads layout in between. Usually it does not.
  */
 import { expect, test } from '../fixtures/test.fixture';
 import type { Page } from '@playwright/test';
 
+/**
+ * `??` does not catch an empty string and `Number('x')` is NaN; both used to
+ * seed zero tasks and then fail 30s later inside `toHaveCount(NaN)`.
+ */
+const readCount = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer, got "${raw}"`);
+  }
+  return value;
+};
+
 /** The reporter's Inbox: 128 open + 73 done. */
-const OPEN_TASK_COUNT = Number(process.env.MEASURE_OPEN_TASK_COUNT ?? 128);
-const DONE_TASK_COUNT = Number(process.env.MEASURE_DONE_TASK_COUNT ?? 73);
+const OPEN_TASK_COUNT = readCount('MEASURE_OPEN_TASK_COUNT', 128);
+const DONE_TASK_COUNT = readCount('MEASURE_DONE_TASK_COUNT', 73);
 const TASK_COUNT = OPEN_TASK_COUNT + DONE_TASK_COUNT;
 /** Mirrors the op-log batch cap; only affects how the seed is chunked. */
 const MAX_BATCH_OPERATIONS_SIZE = 50;
 const SHELL_WRITE_FRAMES = 30;
-const RESIZE_DISPATCHES = 30;
 const ROOT_WRITES = 20;
 const WRITE_KINDS = [
   'root-custom-property',
   'leaf-custom-property',
+  'root-inherited-standard',
   'plain-property',
 ] as const;
-const OPEN_REPS = 11;
-/** The first open of each variant pays for lazy work that never repeats. */
-const OPEN_WARMUP_REPS = 2;
 const INBOX_PROJECT_ID = 'INBOX_PROJECT';
 
-/** Row-level CSS whose effect on each measurement is worth knowing. */
-const ROW_VARIANTS: readonly { label: string; css: string }[] = [
+/**
+ * Row-level CSS whose effect on each measurement is worth knowing.
+ *
+ * `verify` is not optional decoration. `task { display: none }` (specificity
+ * 0,0,1) silently lost to the `:host { display: block }` in `_task-base.scss`,
+ * which Angular's emulated encapsulation compiles to `[_nghost-*]` (0,1,0) — so
+ * for one whole generation of this harness the `display:none` rows were plain
+ * baselines printed under a different label, and nothing could tell. Every
+ * variant now states the computed value it must produce, and `applyRowVariant`
+ * throws if the cascade did not go its way.
+ */
+const ROW_VARIANTS: readonly {
+  label: string;
+  css: string;
+  verify?: { property: string; expected: string };
+}[] = [
   { label: 'none', css: '' },
   {
     label: 'content-visibility',
     css: 'task { content-visibility: auto; contain-intrinsic-size: auto 52px; }',
+    verify: { property: 'content-visibility', expected: 'auto' },
   },
-  // The discriminator: `display: none` removes the rows from layout but not from
-  // style computation, so a cost that survives it is style invalidation.
-  { label: 'display:none', css: 'task { display: none; }' },
+  // `!important` beats the host rule's higher specificity. Rows leave layout but
+  // stay in the DOM, so this is the closest thing here to a style-vs-layout split.
+  {
+    label: 'display:none',
+    css: 'task { display: none !important; }',
+    verify: { property: 'display', expected: 'none' },
+  },
 ];
 
 const STYLE_ID = 'measure-variant-style';
 
-const applyRowVariant = async (page: Page, css: string): Promise<void> => {
+const applyRowVariant = async (
+  page: Page,
+  css: string,
+  verify?: { property: string; expected: string },
+): Promise<void> => {
   await page.evaluate(
-    ({ id, variantCss }) => {
+    ({ id, variantCss, check }) => {
       document.getElementById(id)?.remove();
       if (variantCss) {
         const style = document.createElement('style');
@@ -145,8 +187,23 @@ const applyRowVariant = async (page: Page, css: string): Promise<void> => {
       }
       // Settle the new styles so they are not charged to the next measurement.
       document.body.getBoundingClientRect();
+      if (!check) {
+        return;
+      }
+      const row = document.querySelector('task');
+      if (!row) {
+        throw new Error('no task row to verify the variant against');
+      }
+      const actual = getComputedStyle(row).getPropertyValue(check.property).trim();
+      if (actual !== check.expected) {
+        throw new Error(
+          `row variant did not apply: ${check.property} is "${actual}", ` +
+            `expected "${check.expected}" — the cascade lost, so this run would ` +
+            `have printed a baseline under the wrong label`,
+        );
+      }
     },
-    { id: STYLE_ID, variantCss: css },
+    { id: STYLE_ID, variantCss: css, check: verify ?? null },
   );
 };
 
@@ -245,6 +302,16 @@ const measureShellHeightWrites = async (page: Page, frames: number): Promise<Sam
       shell.style.minHeight = `${height}px`;
       shell.getBoundingClientRect();
     };
+    // A flat reading is only meaningful if the write moved something; without
+    // this probe an inert write and a cheap one print the same number.
+    const lastRow = document.querySelectorAll('task');
+    const rowTopBefore = lastRow[lastRow.length - 1]?.getBoundingClientRect().top;
+    const shellHeightBefore = shell.getBoundingClientRect().height;
+    writeFrame(0);
+    const hasEffect =
+      shell.getBoundingClientRect().height !== shellHeightBefore ||
+      lastRow[lastRow.length - 1]?.getBoundingClientRect().top !== rowTopBefore;
+
     const runs: number[] = [];
     for (let run = 0; run < 5; run++) {
       for (let i = 0; i < 5; i++) {
@@ -260,29 +327,31 @@ const measureShellHeightWrites = async (page: Page, frames: number): Promise<Sam
     shell.style.minHeight = '';
     shell.getBoundingClientRect();
     return {
-      label: `shell-height-write x${frameCount}`,
+      label: `shell-height-write x${frameCount} (has effect: ${hasEffect})`,
       rowCount: document.querySelectorAll('task').length,
       values: runs,
     };
   }, frames);
 
 /**
- * The write `keyboardWillShow`/`keyboardWillHide` still make on the root
- * (`global-theme.service.ts`: `--keyboard-height`, `--keyboard-overlay-offset`),
- * against the same write aimed at a leaf element.
+ * The root custom-property write — still live on the non-iOS path
+ * (`GlobalThemeService._initVisualViewportKeyboardTracking`) — against three
+ * controls that each hold one variable steady:
  *
- * A custom property invalidates the computed style of everything that could
- * inherit it, so on `document.documentElement` its cost scales with the whole
- * rendered tree, and on a leaf it does not. That pair is the measurement: it is
- * the difference the #9809 treatment of `--visual-viewport-height` would make if
- * applied to these two as well.
+ * - `root-inherited-standard` keeps the element and the inheritance scope and
+ *   changes only the kind of property. This is the load-bearing control: without
+ *   it the root-vs-leaf gap reads as "inherited properties are expensive", which
+ *   the numbers say is false.
+ * - `leaf-custom-property` keeps the property kind and shrinks the scope.
+ * - `plain-property` keeps the element and drops inheritance.
  *
- * `plain-property` is a third, weaker reading: a non-inherited property on the
- * root. It reports whether the write plus the forced rect read is itself free —
- * NOT whether layout is free, since it does not move the rows (the returned
- * label says which, so a 0ms reading is never mistaken for the latter).
+ * Every timed write is followed by a forced layout read, which is what makes the
+ * per-write division legitimate — the N iterations are homogeneous. `movesRows`
+ * is probed separately and folded into the label, so a 0ms reading is never
+ * mistaken for "layout is free". Note it reads `false` vacuously when there are
+ * no rows, and under `display: none` where every rect is zero.
  */
-type WriteKind = 'root-custom-property' | 'leaf-custom-property' | 'plain-property';
+type WriteKind = (typeof WRITE_KINDS)[number];
 
 const measureCssVarWrites = async (
   page: Page,
@@ -296,12 +365,20 @@ const measureCssVarWrites = async (
       if (propertyKind === 'leaf-custom-property' && !leaf) {
         throw new Error('.add-task-button missing — no leaf to write to');
       }
-      const lastRow = (): Element | null => document.querySelector('task:last-of-type');
+      const lastRow = (): Element | null => {
+        const rows = document.querySelectorAll('task');
+        return rows[rows.length - 1] ?? null;
+      };
       const write = (i: number): void => {
         if (propertyKind === 'root-custom-property') {
           root.style.setProperty('--keyboard-height', `${300 + (i % 7)}px`);
         } else if (propertyKind === 'leaf-custom-property') {
           leaf!.style.setProperty('--keyboard-height', `${300 + (i % 7)}px`);
+        } else if (propertyKind === 'root-inherited-standard') {
+          // Same inheritance scope as the root custom property, different
+          // property kind. This is the pair that isolates "custom property",
+          // where root-vs-leaf only isolates "inheritance scope".
+          root.style.setProperty('color', `rgb(${i % 7}, 0, 0)`);
         } else {
           root.style.setProperty('padding-top', `${i % 7}px`);
         }
@@ -324,6 +401,7 @@ const measureCssVarWrites = async (
         runs.push((performance.now() - started) / writeCount);
       }
       root.style.removeProperty('--keyboard-height');
+      root.style.removeProperty('color');
       root.style.removeProperty('padding-top');
       leaf?.style.removeProperty('--keyboard-height');
       document.body.getBoundingClientRect();
@@ -336,109 +414,23 @@ const measureCssVarWrites = async (
     { propertyKind: kind, writeCount: writes },
   );
 
-/** The synthetic window resize `_notifyIOSViewportChange` fires per frame. */
-const measureResizeDispatch = async (page: Page, dispatches: number): Promise<Sample> =>
-  page.evaluate((count) => {
-    const burst = (): void => {
-      for (let i = 0; i < count; i++) {
-        window.dispatchEvent(new Event('resize'));
-      }
-      // Charge the layout the app would be forced into before the next paint.
-      document.body.getBoundingClientRect();
-    };
-    burst();
-    const runs: number[] = [];
-    for (let run = 0; run < 5; run++) {
-      const started = performance.now();
-      burst();
-      runs.push(performance.now() - started);
-    }
-    return {
-      label: `resize-dispatch x${count}`,
-      rowCount: document.querySelectorAll('task').length,
-      values: runs,
-    };
-  }, dispatches);
-
-/**
- * The reported interaction, timed in-page so Playwright IPC and actionability
- * checks stay out of the number.
- */
-const measureAddTaskBarOpen = async (
-  page: Page,
-  label: string,
-  reps: number,
-): Promise<Sample> => {
-  const values: number[] = [];
-  for (let rep = 0; rep < reps + OPEN_WARMUP_REPS; rep++) {
-    const elapsed = await page.evaluate(async () => {
-      const button = document.querySelector('.add-task-button') as HTMLElement | null;
-      if (!button) {
-        throw new Error('.add-task-button missing — is the mobile bottom nav shown?');
-      }
-      if (document.querySelector('add-task-bar.global')) {
-        throw new Error('add-task-bar already open — the previous rep did not close');
-      }
-      const until = (predicate: () => boolean): Promise<number> =>
-        new Promise((resolve, reject) => {
-          const deadline = performance.now() + 20000;
-          const check = (): void => {
-            if (predicate()) {
-              resolve(performance.now());
-            } else if (performance.now() > deadline) {
-              reject(new Error('timed out waiting for the add-task bar'));
-            } else {
-              requestAnimationFrame(check);
-            }
-          };
-          check();
-        });
-
-      const started = performance.now();
-      button.click();
-      // Focus, not mere presence: the reporter's complaint is the delay before
-      // they can type, which is what the keyboard hangs off.
-      const focusedAt = await until(
-        () => !!document.activeElement?.closest('add-task-bar.global'),
-      );
-      return focusedAt - started;
-    });
-    if (rep >= OPEN_WARMUP_REPS) {
-      values.push(elapsed);
-    }
-
-    // Closed through the store, not Escape: a keypress that lands a frame before
-    // the input takes focus is silently dropped, and the next rep then aborts on
-    // an already-open bar.
-    await page.evaluate(() => {
-      const store = (
-        window as unknown as {
-          __e2eTestHelpers?: { store?: { dispatch: (action: unknown) => void } };
-        }
-      ).__e2eTestHelpers?.store;
-      store?.dispatch({ type: '[Layout] Hide AddTaskBar' });
-    });
-    await page.locator('add-task-bar.global').waitFor({ state: 'detached' });
-  }
-  return {
-    label: `add-task-bar-open [rows: ${label}]`,
-    rowCount: await page.locator('task').count(),
-    values,
-  };
-};
-
-test.describe('#9779 iOS add-task-bar open cost', () => {
+test.describe('#9779 root custom-property write cost', () => {
   test('what scales with the number of rendered task rows', async ({
     page,
     workViewPage,
     testPrefix,
     browserName,
   }) => {
-    const lines: string[] = [];
+    // Streamed, not buffered to the end: the run is minutes long, and a timeout
+    // or a mid-run throw used to discard every number already measured.
+    const record = (line: string): void => {
+      // eslint-disable-next-line no-console
+      console.log(`[measure] ${line}`);
+    };
     // browserName, not a user-agent sniff: the shared fixture overrides the UA
     // with "PLAYWRIGHT", so sniffing for "Chrome" reported webkit under both
     // projects and silently mislabelled every Chromium run.
-    lines.push(
+    record(
       `engine=${browserName} ` +
         (await page.evaluate(
           () => `viewport=${window.innerWidth}x${window.innerHeight}`,
@@ -451,27 +443,20 @@ test.describe('#9779 iOS add-task-bar open cost', () => {
       window.location.hash = `#/project/${projectId}/tasks`;
     }, INBOX_PROJECT_ID);
     await workViewPage.waitForTaskList();
-    // The FAB is the entry point every open measurement uses; without it the
-    // harness would silently measure nothing.
-    await expect(page.locator('.add-task-button')).toBeVisible();
 
     // Boot work (lazy chunks, first render, initial sync) keeps running for a
     // while after the list appears, and it lands squarely on whatever is measured
-    // first. Burn it off, otherwise the empty-list baseline reads slower than the
-    // 200-row case and the comparison inverts.
+    // first.
     // `waitForTimeout` is banned in e2e/tests for good reason; here there is no
     // event to wait for — the point is to let unrelated boot work drain.
     await page.waitForTimeout(2000);
     await measureShellHeightWrites(page, SHELL_WRITE_FRAMES);
-    await measureAddTaskBarOpen(page, 'warmup', 1);
 
-    lines.push('--- empty list ---');
+    record('--- empty list ---');
     for (const kind of WRITE_KINDS) {
-      lines.push(summarize(await measureCssVarWrites(page, kind, ROOT_WRITES), 'ms'));
+      record(summarize(await measureCssVarWrites(page, kind, ROOT_WRITES), 'ms'));
     }
-    lines.push(summarize(await measureShellHeightWrites(page, SHELL_WRITE_FRAMES), 'ms'));
-    lines.push(summarize(await measureResizeDispatch(page, RESIZE_DISPATCHES), 'ms'));
-    lines.push(summarize(await measureAddTaskBarOpen(page, 'none', OPEN_REPS), 'ms'));
+    record(summarize(await measureShellHeightWrites(page, SHELL_WRITE_FRAMES), 'ms'));
 
     const taskIdPrefix = `${testPrefix}-measure-`;
     await seedProjectTasks(page, taskIdPrefix, OPEN_TASK_COUNT, DONE_TASK_COUNT);
@@ -483,23 +468,19 @@ test.describe('#9779 iOS add-task-bar open cost', () => {
     );
     await page.waitForTimeout(1500);
 
-    lines.push(
+    record(
       `--- ${TASK_COUNT} tasks (${OPEN_TASK_COUNT} open + ${DONE_TASK_COUNT} done) ---`,
     );
-    for (const { label, css } of ROW_VARIANTS) {
-      await applyRowVariant(page, css);
+    for (const { label, css, verify } of ROW_VARIANTS) {
+      await applyRowVariant(page, css, verify);
       for (const kind of WRITE_KINDS) {
-        lines.push(
+        record(
           summarize(await measureCssVarWrites(page, kind, ROOT_WRITES), 'ms') +
             `  [rows: ${label}]`,
         );
       }
-      lines.push(
+      record(
         summarize(await measureShellHeightWrites(page, SHELL_WRITE_FRAMES), 'ms') +
-          `  [rows: ${label}]`,
-      );
-      lines.push(
-        summarize(await measureResizeDispatch(page, RESIZE_DISPATCHES), 'ms') +
           `  [rows: ${label}]`,
       );
       await clearRowVariant(page);
@@ -507,17 +488,12 @@ test.describe('#9779 iOS add-task-bar open cost', () => {
     // Variants run in fixed order, and these numbers drift upward over a run.
     // Repeating the unmodified baseline last is what tells a real variant effect
     // apart from that drift — compare each variant to BOTH baselines.
-    lines.push(
+    record(
       summarize(
         await measureCssVarWrites(page, 'root-custom-property', ROOT_WRITES),
         'ms',
       ) + '  [rows: none, repeat]',
     );
-    for (const { label, css } of ROW_VARIANTS) {
-      await applyRowVariant(page, css);
-      lines.push(summarize(await measureAddTaskBarOpen(page, label, OPEN_REPS), 'ms'));
-      await clearRowVariant(page);
-    }
 
     // The reporter's own workaround, run as an A/B. Collapsing is not hiding:
     // `collapsible.component.html` wraps its panel in a structural `@if`, so the
@@ -528,15 +504,12 @@ test.describe('#9779 iOS add-task-bar open cost', () => {
       .first();
     await doneHeader.click();
     await expect(page.locator('task')).toHaveCount(OPEN_TASK_COUNT);
-    lines.push(`--- ${OPEN_TASK_COUNT} tasks, Completed Tasks collapsed ---`);
-    lines.push(
+    record(`--- ${OPEN_TASK_COUNT} tasks, Completed Tasks collapsed ---`);
+    record(
       summarize(
         await measureCssVarWrites(page, 'root-custom-property', ROOT_WRITES),
         'ms',
       ),
     );
-    lines.push(summarize(await measureAddTaskBarOpen(page, 'none', OPEN_REPS), 'ms'));
-
-    console.log(`\n===== #9779 MEASUREMENT =====\n${lines.join('\n')}\n`);
   });
 });

--- a/e2e/measure/ios-keyboard-relayout.measure.ts
+++ b/e2e/measure/ios-keyboard-relayout.measure.ts
@@ -39,6 +39,19 @@
  *   resize-dispatch x30               0.0ms      0.0ms                          -
  *   add-task-bar-open                49.0ms     37.0ms                     41.0ms
  *
+ * The same run under `--project=measure-chromium` (Blink, 2026-09):
+ *
+ *                                   0 rows   201 rows   201 rows, content-vis
+ *   root-custom-property write        1.0ms     14.1ms                 1.9-4.0ms
+ *   leaf-custom-property write        0.1ms      0.0ms                     0.1ms
+ *   plain-property write              0.3ms      0.3ms                     0.3ms
+ *
+ * Blink charges the same mechanism roughly an order of magnitude less: still 14x
+ * the leaf write and still scaling with row count, but ~14ms rather than
+ * hundreds. Worth knowing before porting an iOS fix to the Android path on the
+ * strength of the WebKit number alone — and note `content-visibility` cuts it
+ * severalfold here while doing nothing at all in WebKit.
+ *
  * Only the root custom-property write scales, and it scales hard. The identical
  * write on a leaf stays at 0.1ms with 201 rows on screen, so the cost is style
  * invalidation across everything that could inherit the property — not the write,
@@ -403,14 +416,17 @@ test.describe('#9779 iOS add-task-bar open cost', () => {
     page,
     workViewPage,
     testPrefix,
+    browserName,
   }) => {
     const lines: string[] = [];
+    // browserName, not a user-agent sniff: the shared fixture overrides the UA
+    // with "PLAYWRIGHT", so sniffing for "Chrome" reported webkit under both
+    // projects and silently mislabelled every Chromium run.
     lines.push(
-      await page.evaluate(
-        () =>
-          `engine=${navigator.userAgent.includes('Chrome') ? 'chromium' : 'webkit'} ` +
-          `viewport=${window.innerWidth}x${window.innerHeight}`,
-      ),
+      `engine=${browserName} ` +
+        (await page.evaluate(
+          () => `viewport=${window.innerWidth}x${window.innerHeight}`,
+        )),
     );
 
     // Seed straight into the built-in Inbox project: creating one through the UI

--- a/e2e/measure/playwright.measure.config.ts
+++ b/e2e/measure/playwright.measure.config.ts
@@ -26,8 +26,9 @@ const MOBILE_CONTEXT = {
 
 export default defineConfig({
   testDir: __dirname,
-  // `*.measure.ts`, deliberately not `*.spec.ts`: the default Playwright pattern
-  // is what keeps `npm run e2e` from ever collecting these.
+  // What actually keeps `npm run e2e` off these is `e2e/playwright.config.ts`
+  // setting `testDir: e2e/tests` — this folder is outside its collected tree
+  // entirely. The `*.measure.ts` suffix is a second, independent barrier.
   testMatch: /.*\.measure\.ts$/,
   // No globalSetup: the harnesses need no bundled plugins and no SuperSync server.
   fullyParallel: false,
@@ -48,7 +49,11 @@ export default defineConfig({
         browserName: 'webkit' as const,
         // The isolated-context fixture consumes contextOptions, so the mobile
         // descriptor has to be nested here rather than spread at use level.
-        contextOptions: { ...MOBILE_CONTEXT, userAgent: IPHONE_13.userAgent },
+        // No userAgent here on purpose: `test.fixture.ts` reads
+        // `userAgent ?? contextOptions.userAgent`, and `use.userAgent` below is
+        // always set, so a nested one would be dead. Both engines therefore run
+        // as PLAYWRIGHT, which is what makes the two columns comparable.
+        contextOptions: MOBILE_CONTEXT,
       },
     },
     {
@@ -64,7 +69,10 @@ export default defineConfig({
     : {
         command: 'npm run startFrontend:e2e',
         url: 'http://localhost:4242',
-        reuseExistingServer: true,
+        // Never reuse: attaching to a stray server on :4242 would file the
+        // numbers under the wrong build, which is the one thing a measurement
+        // harness must not do.
+        reuseExistingServer: false,
         timeout: 4 * 60 * 1000,
         stdout: 'ignore',
         stderr: 'pipe',

--- a/e2e/measure/playwright.measure.config.ts
+++ b/e2e/measure/playwright.measure.config.ts
@@ -1,0 +1,75 @@
+/**
+ * Config for the manual measurement harnesses in this folder. They are profiling
+ * tools, not assertions: they print numbers and always pass, so they live outside
+ * `e2e/tests` and are never collected by `npm run e2e`.
+ *
+ *   npx playwright test --config e2e/measure/playwright.measure.config.ts \
+ *     --project=measure-webkit
+ *
+ * WebKit is the point — it is the closest engine to the iOS WKWebView available
+ * without a device. `measure-chromium` runs the same harness for comparison.
+ */
+import { defineConfig, devices } from '@playwright/test';
+import path from 'path';
+
+const IPHONE_13 = devices['iPhone 13'];
+const REPO_ROOT = path.join(__dirname, '..', '..');
+
+const MOBILE_CONTEXT = {
+  viewport: IPHONE_13.viewport,
+  screen: IPHONE_13.screen,
+  deviceScaleFactor: IPHONE_13.deviceScaleFactor,
+  isMobile: IPHONE_13.isMobile,
+  hasTouch: IPHONE_13.hasTouch,
+  locale: 'en-GB',
+};
+
+export default defineConfig({
+  testDir: __dirname,
+  // `*.measure.ts`, deliberately not `*.spec.ts`: the default Playwright pattern
+  // is what keeps `npm run e2e` from ever collecting these.
+  testMatch: /.*\.measure\.ts$/,
+  // No globalSetup: the harnesses need no bundled plugins and no SuperSync server.
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    baseURL: process.env.E2E_BASE_URL || 'http://localhost:4242',
+    locale: 'en-GB',
+    userAgent: 'PLAYWRIGHT',
+    navigationTimeout: 60000,
+    actionTimeout: 30000,
+  },
+  projects: [
+    {
+      name: 'measure-webkit',
+      use: {
+        browserName: 'webkit' as const,
+        // The isolated-context fixture consumes contextOptions, so the mobile
+        // descriptor has to be nested here rather than spread at use level.
+        contextOptions: { ...MOBILE_CONTEXT, userAgent: IPHONE_13.userAgent },
+      },
+    },
+    {
+      name: 'measure-chromium',
+      use: {
+        browserName: 'chromium' as const,
+        contextOptions: MOBILE_CONTEXT,
+      },
+    },
+  ],
+  webServer: process.env.E2E_BASE_URL
+    ? undefined
+    : {
+        command: 'npm run startFrontend:e2e',
+        url: 'http://localhost:4242',
+        reuseExistingServer: true,
+        timeout: 4 * 60 * 1000,
+        stdout: 'ignore',
+        stderr: 'pipe',
+      },
+  outputDir: path.join(REPO_ROOT, '.tmp', 'e2e-measure-results'),
+  timeout: 300 * 1000,
+  expect: { timeout: 30 * 1000 },
+});

--- a/src/app/core/theme/ios-keyboard.service.ts
+++ b/src/app/core/theme/ios-keyboard.service.ts
@@ -51,9 +51,10 @@ import {
  * keyboard — and never onto `<html>`. WebKit re-resolves custom properties per
  * element on every root write, so one write restyles the whole task list: on a
  * 200-task list that is three orders of magnitude more than an ordinary
- * inherited property (`color`) with the identical invalidation set. It is custom properties specifically,
- * not inheritance, and it is the "insane lag" of #9779. Numbers, both engines,
- * and how to re-measure: `e2e/measure/ios-keyboard-relayout.measure.ts`. So:
+ * inherited property (`color`) with the identical invalidation set. It is custom
+ * properties specifically, not inheritance, and it is the "insane lag" of #9779.
+ * Numbers and the cross-engine comparison: `docs/android-edge-to-edge-keyboard.md`,
+ * "What a `--keyboard-height` write on `<html>` costs". So:
  *
  * - the CDK overlay container carries `--visual-viewport-height`,
  *   `--keyboard-height` and `--keyboard-overlay-offset` for dialogs, bottom

--- a/src/app/core/theme/ios-keyboard.service.ts
+++ b/src/app/core/theme/ios-keyboard.service.ts
@@ -48,9 +48,12 @@ import {
  * iOS keyboard geometry → layout, for the Capacitor iOS build.
  *
  * Publishes what the fixed and overlay layers need to stay clear of the
- * keyboard — and never onto `<html>`. A custom property there is inherited by
- * every element, and WebKit restyles each of them on a write: measured at
- * ~390ms per write on a 200-task list, which is the "insane lag" of #9779. So:
+ * keyboard — and never onto `<html>`. WebKit re-resolves custom properties per
+ * element on every root write, so one write restyles the whole task list: on a
+ * 200-task list that is three orders of magnitude more than an ordinary
+ * inherited property (`color`) with the identical invalidation set. It is custom properties specifically,
+ * not inheritance, and it is the "insane lag" of #9779. Numbers, both engines,
+ * and how to re-measure: `e2e/measure/ios-keyboard-relayout.measure.ts`. So:
  *
  * - the CDK overlay container carries `--visual-viewport-height`,
  *   `--keyboard-height` and `--keyboard-overlay-offset` for dialogs, bottom


### PR DESCRIPTION
Adds the hand-run measurement harness built while investigating #9779 ("opening the add-task bar on iOS is laggy, and it gets worse the more task rows are on screen"), files its findings where they'll be read, and corrects a wrong mechanism claim the investigation left in shipped code.

The **fix** for #9779 already shipped in #9926. This PR is the tool that priced it and the record of what it measured, so the numbers stay re-derivable instead of living as prose nobody can check.

## What's here

| file | what |
| --- | --- |
| `docs/android-edge-to-edge-keyboard.md` | the findings: cross-engine table, conclusions, the Android decision |
| `e2e/measure/ios-keyboard-relayout.measure.ts` | the harness |
| `e2e/measure/playwright.measure.config.ts` | its config — WebKit + Chromium projects |
| `src/app/core/theme/ios-keyboard.service.ts` | comment only: corrects the stated mechanism, points at the doc |

The findings live in the **doc**, not the harness header, because `docs/android-edge-to-edge-keyboard.md` is what someone actually opens before an Android keyboard change — it starts with "Read this before touching anything keyboard/IME-related on Android" and already documents the tracker that makes the write being priced. Nobody greps `e2e/measure/`. The harness header keeps how to run it, what each measurement isolates, and the run-to-run spread.

Not part of `npm run e2e`: `e2e/playwright.config.ts` sets `testDir: e2e/tests`, so `e2e/measure/` is outside the collected tree; the `*.measure.ts` suffix and the separate config are two further barriers. Run it by hand:

```
npx playwright test --config e2e/measure/playwright.measure.config.ts --project=measure-webkit
```

No performance assertion — it will never fail because a figure got worse. It *can* fail on setup, deliberately: every row-CSS variant declares the computed value it must produce and throws if the cascade went the other way.

## What it found

201 rows, iPhone 13 viewport, WebKit 26.5 / Chromium 149, median ms per write:

| write | WebKit | Blink |
|---|---|---|
| root **custom** property | ~180 | 12.8 |
| root **inherited standard** (`color`) | 0.1 | 0.3 |
| custom property on a leaf | 0.1 | 0.1 |
| root custom, rows `display: none` | 8 | 1.6 |
| empty list | ~9 | 0.7 |

1. **It is custom properties specifically, not inherited properties.** A `color` write on `<html>` invalidates exactly the same set of elements and stays at the floor. That distinction is what #9926 is built on, and nothing stated it — `IosKeyboardService`'s own comment attributed the cost to inheritance. Corrected here.
2. **Blink charges it ~an order of magnitude less**, which is why the fix was not ported to the Android path, where `GlobalThemeService._initVisualViewportKeyboardTracking` still writes on `<html>`. The doc records the condition that would reverse that call.
3. **Only the root custom-property write scales with row count.**

## Review history

Five rounds, each of which found a claim the harness was publishing that the code did not support. Recording them because the pattern is the point:

- the engine label reported `webkit` for both projects — the shared fixture overwrites the UA with `PLAYWRIGHT` and the original sniffed for `Chrome`
- `task { display: none }` silently lost the cascade to `:host { display: block }` in `_task-base.scss`, which emulated encapsulation compiles to `[_nghost-*]`. Three published lines were baselines under a false label, and the header concluded from them that `display: none` does not help. It does — 23x.
- the mechanism claim was wrong (see 1)
- `Chromium 151` was inherited text nobody had checked; it is 149. The build is now printed by the run.
- the table quoted one decimal while the note below said not to read it that way; run-to-run spread is ~16%

Removed along the way: `resize-dispatch` (every consumer sits behind `auditTime`, so no subscriber work can land in the synchronous timed window) and `add-task-bar-open` (three values inside one rAF quantum, trending opposite to the reported symptom).

`CSS_VAR_KEYBOARD_HEIGHT` is now imported from the app rather than hardcoded, so a rename breaks a grep here — two symbols this header named went stale silently when #9926 landed.

## Known limits

Hand-simulated writes, not the real event sequence — `IosKeyboardService` is gated on native iOS and never runs here. Headless WebKit has no soft keyboard. `ng serve` is unoptimized. WebKit spread is ~16%, so anything under ~1.2x is unresolved; Blink variant cells are single samples.

## Not done

`seedProjectTasks` duplicates `e2e/tests/performance/large-list-interaction.spec.ts:8-66` — extracting to `e2e/utils/` would cut ~55 lines and remove a second hand-written copy of the op-log batch envelope. Separate PR. There's also no npm script yet, and the config nests in `e2e/measure/` rather than joining its four siblings at `e2e/playwright.*.config.ts`.