### PR TITLE
fix(magic-side-nav): keep mobile side nav anchored to the left

### DIFF
--- a/src/app/core-ui/magic-side-nav/magic-side-nav.animations.ts
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.animations.ts
@@ -2,14 +2,14 @@ import { animate, style, transition, trigger } from '@angular/animations';
 import { ANI_ENTER_TIMING, ANI_LEAVE_TIMING } from '../../ui/animations/animation.const';
 
 export const magicSideNavAnimations = [
-  // Mobile animation - slides from right
-  trigger('mobileNavRight', [
+  // Mobile animation - slides from left
+  trigger('mobileNavLeft', [
     transition('void => visible', [
-      style({ transform: 'translateX(100%)', opacity: 0 }),
+      style({ transform: 'translateX(-100%)', opacity: 0 }),
       animate(ANI_ENTER_TIMING, style({ transform: 'translateX(0)', opacity: 1 })),
     ]),
     transition('visible => void', [
-      animate(ANI_LEAVE_TIMING, style({ transform: 'translateX(100%)' })),
+      animate(ANI_LEAVE_TIMING, style({ transform: 'translateX(-100%)' })),
     ]),
   ]),
   trigger('mobileBackdrop', [

--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.html
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.html
@@ -32,11 +32,10 @@
   <!-- Main Navigation Sidebar -->
   <nav
     class="nav-sidenav"
-    [@mobileNavRight]="isMobile() ? 'visible' : 'desktop'"
+    [@mobileNavLeft]="isMobile() ? 'visible' : 'desktop'"
     [class.fullMode]="isFullMode() || isMobile()"
     [class.compactMode]="!isFullMode() && !isMobile()"
     [class.mobile]="isMobile()"
-    [class.position-right]="isMobile()"
     [class.animate]="animateWidth()"
     [class.resizing]="isResizing()"
     [style.width.px]="sidenavWidth()"
@@ -44,7 +43,7 @@
     [cdkTrapFocus]="isMobile()"
     [cdkTrapFocusAutoCapture]="isMobile()"
     (keydown)="onNavKeyDown($event)"
-    (swiperight)="onMobileNavSwipeRight()"
+    (swipeleft)="onMobileNavSwipeLeft()"
     swipeGesture
     [swipeEnabled]="swipeEnabled()"
   >

--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.scss
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.scss
@@ -211,23 +211,6 @@
     top: var(--safe-area-top);
   }
 
-  // Position right
-  &.position-right {
-    left: auto;
-    right: 0;
-    border-right: none;
-    border-left: 1px solid var(--sidenav-border-color);
-
-    .mode-toggle {
-      left: 16px;
-      right: auto;
-    }
-
-    &.mobile {
-      box-shadow: -4px 0 16px var(--c-dark-30);
-    }
-  }
-
   // Note: Theme colors are handled by CSS variables above
 }
 

--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.spec.ts
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.spec.ts
@@ -174,6 +174,18 @@ describe('MagicSideNavComponent mobile behavior', () => {
     }
   });
 
+  it('positions the mobile drawer on the left, matching desktop', () => {
+    isXs.set(true);
+    fixture = TestBed.createComponent(MagicSideNavComponent);
+    fixture.componentInstance.showMobileMenuOverlay.set(true);
+    fixture.detectChanges();
+
+    const drawer = fixture.nativeElement.querySelector('.nav-sidenav') as HTMLElement;
+
+    expect(drawer.classList.contains('position-right')).toBe(false);
+    expect(getComputedStyle(drawer).left).toBe('0px');
+  });
+
   it('removes the mobile drawer and its focus trap while closed', () => {
     isXs.set(true);
     fixture = TestBed.createComponent(MagicSideNavComponent);

--- a/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
+++ b/src/app/core-ui/magic-side-nav/magic-side-nav.component.ts
@@ -332,7 +332,7 @@ export class MagicSideNavComponent implements OnDestroy, AfterViewInit {
     }
   }
 
-  onMobileNavSwipeRight(): void {
+  onMobileNavSwipeLeft(): void {
     if (this.isMobile() && this.showMobileMenuOverlay()) {
       this.toggleMobileNav();
     }


### PR DESCRIPTION
The mobile side nav template forced the drawer to the right edge whenever the layout was in its mobile (narrow) breakpoint, while the desktop layout always anchored it to the left, so the menu jumped sides depending on orientation and viewport width. I removed the mobile-only right positioning and its now-unused CSS block, flipped the slide-in animation and swipe-to-close gesture to match a left-anchored drawer, and added a regression test asserting the mobile drawer stays on the left.

Fixes #8534.

On commit `3dff785631ec6c9d1c676495bbc2ac9ac9131ffa`, fork CI passed lint, CodeQL, Lighthouse, Android native tests and the Linux packaged Electron build. The fork's Tests job was skipped, and Dependency Vulnerability Review reported that the repository lacked the required Dependency graph support. The added regression test was not executed by fork CI; Android orientation and swipe behavior have not been manually tested.
