### PR TITLE
docs(plugins): add OKR to community catalog

### DIFF
--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -158,5 +158,13 @@
     "author": "BigWebstas",
     "authorUrl": "https://github.com/BigWebstas",
     "stars": 0
+  },
+  {
+    "name": "OKR",
+    "shortDescription": "Manage objectives and key results in fixed two-month periods, with reordering, carry-over, and self-reviews for past objectives.",
+    "url": "https://github.com/x850044053wwt/super-productivity-okr",
+    "author": "dave",
+    "authorUrl": "https://github.com/x850044053wwt",
+    "stars": 0
   }
 ]


### PR DESCRIPTION
## Problem

The independently maintained MIT-licensed OKR plugin is not listed in the community catalog. It supports objectives and key results in fixed two-month periods, reordering, carry-over, and self-reviews for past objectives.

## Solution

Add one entry to `src/assets/community-plugins.json` linking to the public source repository:
https://github.com/x850044053wwt/super-productivity-okr

Preview release and installable ZIP:
https://github.com/x850044053wwt/super-productivity-okr/releases/tag/v1.2.0

This is a draft pending compatibility validation on an unmodified official host. The plugin was developed with a custom persistence-completion fix that is not in upstream master as checked on 2026-09-08. ZIP installation, reload durability, and cross-device sync on an official release still need validation before this catalog entry is ready to merge. The preview release documents this limitation.

## Type of Change

- [x] Documentation / community plugin catalog

## Validation

- Catalog JSON parses; entry URL is unique and URL fields are valid.
- `git diff --check` passes.
- Plugin: 11 model tests, build, and ZIP packaging passed; ZIP includes MIT LICENSE.
- No TypeScript or SCSS files changed. Full host test suite was not run for this catalog-only change.

## Before ready for review

- [ ] Verify installation and reload durability in an unmodified official release.
- [ ] Verify cross-device sync and establish the supported minimum host version.
- [ ] Add a screenshot of the plugin in the official host.