### PR TITLE
feat(config): hot-reload styles.css

### DIFF
--- a/docs/wiki/3.06-User-Data.md
+++ b/docs/wiki/3.06-User-Data.md
@@ -70,6 +70,7 @@ The Windows Store build may use a different path that includes the Windows Store
 - Custom theme file for desktop styling.
 - Must be created manually by the user and placed directly in the User Data Folder (not in a subfolder).
 - Loaded by the main process and injected into the renderer; invalid CSS may fail to load and is logged.
+- Watched while the app runs: creating, editing, or replacing the file re-applies it to the open window without a restart. Deleting it leaves the last loaded styles in place until the app is restarted.
 
 ### local-rest-api-token (optional)
 

--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -14,7 +14,7 @@ import { pathToFileURL } from 'node:url';
 import { IPC } from './shared-with-frontend/ipc-events.const';
 import { isExternalUrlSchemeAllowed } from './shared-with-frontend/is-external-url-allowed';
 import { isLocalFileUrl, openLocalPath } from './open-url';
-import { readFileSync, stat } from 'fs';
+import { readFileSync, watch } from 'fs';
 import { error, log } from 'electron-log/main';
 import { IS_MAC, IS_GNOME_WAYLAND } from './common.const';
 import {
@@ -355,22 +355,48 @@ export const createWindow = async ({
       mainWin.setTitle('Super Productivity D');
     }
 
-    // load custom stylesheet if any
-    const CSS_FILE_PATH = app.getPath('userData') + '/styles.css';
-    stat(app.getPath('userData') + '/styles.css', (err) => {
-      if (err) {
-        log('No custom styles detected at ' + CSS_FILE_PATH);
-      } else {
-        log('Loading custom styles from ' + CSS_FILE_PATH);
+    // load custom stylesheet if any, and re-apply it whenever the file changes
+    const CSS_FILE_PATH = path.join(app.getPath('userData'), 'styles.css');
+    let insertedCssKey: string | undefined;
+    const applyCustomCss = async (): Promise<void> => {
+      try {
         const styles = readFileSync(CSS_FILE_PATH, { encoding: 'utf8' });
-        try {
-          mainWin.webContents.insertCSS(styles);
-          log('Custom styles loaded successfully');
-        } catch (cssError) {
+        const prevKey = insertedCssKey;
+        insertedCssKey = await mainWin.webContents.insertCSS(styles);
+        if (prevKey) {
+          await mainWin.webContents.removeInsertedCSS(prevKey);
+        }
+        log('Custom styles loaded from ' + CSS_FILE_PATH);
+      } catch (cssError) {
+        if ((cssError as NodeJS.ErrnoException).code === 'ENOENT') {
+          log('No custom styles detected at ' + CSS_FILE_PATH);
+        } else {
           error('Failed to load custom styles:', cssError);
         }
       }
-    });
+    };
+    void applyCustomCss();
+
+    // Watch the folder rather than the file itself: the file may not exist
+    // yet, and editors often save atomically (write temp + rename), which
+    // detaches a watch bound to the original file. Debounced because a
+    // single save usually emits several events.
+    let cssReloadTimer: NodeJS.Timeout | undefined;
+    try {
+      const cssWatcher = watch(app.getPath('userData'), (_ev, fileName) => {
+        if (fileName && path.basename(fileName.toString()) !== 'styles.css') {
+          return;
+        }
+        clearTimeout(cssReloadTimer);
+        cssReloadTimer = setTimeout(() => void applyCustomCss(), 150);
+      });
+      mainWin.webContents.once('destroyed', () => {
+        clearTimeout(cssReloadTimer);
+        cssWatcher.close();
+      });
+    } catch (watchError) {
+      error('Could not watch for custom style changes:', watchError);
+    }
   });
 
   // show gracefully

--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -354,15 +354,48 @@ export const createWindow = async ({
     if (IS_DEV) {
       mainWin.setTitle('Super Productivity D');
     }
+  });
 
-    // load custom stylesheet if any, and re-apply it whenever the file changes
-    const CSS_FILE_PATH = path.join(app.getPath('userData'), 'styles.css');
-    let insertedCssKey: string | undefined;
-    const applyCustomCss = async (): Promise<void> => {
+  // load custom stylesheet if any, and re-apply it whenever the file changes
+  const CSS_FILE_PATH = path.join(app.getPath('userData'), 'styles.css');
+  // An inserted-stylesheet key is a counter scoped to the renderer process, so
+  // it only means anything for the document it was inserted into: after a
+  // reload the old key is inert, and after a renderer crash the counter starts
+  // over at 1 and a stale key can collide with — and silently remove — a live
+  // sheet (measured against Electron 43). So tag every key with the document it
+  // belongs to, and never touch a key from an earlier one.
+  let documentGeneration = 0;
+  let insertedCssKey: string | undefined;
+  let insertedCssGeneration = -1;
+  const onDidStartNavigation = (
+    _ev: Electron.Event,
+    _url: string,
+    isInPlace: boolean,
+    isMainFrame: boolean,
+  ): void => {
+    if (isMainFrame && !isInPlace) {
+      documentGeneration++;
+    }
+  };
+  mainWin.webContents.on('did-start-navigation', onDidStartNavigation);
+  // Applies are serialized through a promise chain: the key is read before and
+  // written after the `insertCSS` round-trip, which can take seconds while the
+  // renderer is still booting, so two overlapping runs would otherwise capture
+  // the same previous key and leave the sheet inserted in between untracked.
+  let cssApplyQueue: Promise<void> = Promise.resolve();
+  const applyCustomCss = (): Promise<void> => {
+    cssApplyQueue = cssApplyQueue.then(async () => {
+      if (mainWin.isDestroyed() || mainWin.webContents.isDestroyed()) {
+        return;
+      }
       try {
         const styles = readFileSync(CSS_FILE_PATH, { encoding: 'utf8' });
-        const prevKey = insertedCssKey;
+        const isKeyFromCurrentDoc = insertedCssGeneration === documentGeneration;
+        const prevKey = isKeyFromCurrentDoc ? insertedCssKey : undefined;
         insertedCssKey = await mainWin.webContents.insertCSS(styles);
+        // re-read after the await: if a navigation started while we were
+        // inserting, the sheet belongs to the document that is current now
+        insertedCssGeneration = documentGeneration;
         if (prevKey) {
           await mainWin.webContents.removeInsertedCSS(prevKey);
         }
@@ -374,30 +407,33 @@ export const createWindow = async ({
           error('Failed to load custom styles:', cssError);
         }
       }
-    };
-    void applyCustomCss();
+    });
+    return cssApplyQueue;
+  };
+  // covers the initial load as well as every renderer reload (e.g.
+  // `window.ea.reloadMainWin()`), which would otherwise drop the custom CSS
+  mainWin.webContents.on('did-finish-load', () => void applyCustomCss());
 
-    // Watch the folder rather than the file itself: the file may not exist
-    // yet, and editors often save atomically (write temp + rename), which
-    // detaches a watch bound to the original file. Debounced because a
-    // single save usually emits several events.
-    let cssReloadTimer: NodeJS.Timeout | undefined;
-    try {
-      const cssWatcher = watch(app.getPath('userData'), (_ev, fileName) => {
-        if (fileName && path.basename(fileName.toString()) !== 'styles.css') {
-          return;
-        }
-        clearTimeout(cssReloadTimer);
-        cssReloadTimer = setTimeout(() => void applyCustomCss(), 150);
-      });
-      mainWin.webContents.once('destroyed', () => {
-        clearTimeout(cssReloadTimer);
-        cssWatcher.close();
-      });
-    } catch (watchError) {
-      error('Could not watch for custom style changes:', watchError);
-    }
-  });
+  // Watch the folder rather than the file itself: the file may not exist
+  // yet, and editors often save atomically (write temp + rename), which
+  // detaches a watch bound to the original file. Debounced because a
+  // single save usually emits several events.
+  let cssReloadTimer: NodeJS.Timeout | undefined;
+  try {
+    const cssWatcher = watch(app.getPath('userData'), (_ev, fileName) => {
+      if (fileName && path.basename(fileName.toString()) !== 'styles.css') {
+        return;
+      }
+      clearTimeout(cssReloadTimer);
+      cssReloadTimer = setTimeout(() => void applyCustomCss(), 150);
+    });
+    mainWin.webContents.once('destroyed', () => {
+      clearTimeout(cssReloadTimer);
+      cssWatcher.close();
+    });
+  } catch (watchError) {
+    error('Could not watch for custom style changes:', watchError);
+  }
 
   // show gracefully
   mainWin.once('ready-to-show', () => {


### PR DESCRIPTION
## Problem

Any change to a styles.css requires a complete restart of the app, which is a bit cumbersome to work with. In addition, if the theme file gets replaced by a themes manager or something automatic (think light/dark mode change in the evening), this doesn't take effect until the app is restarted.

## Solution

This adds a watcher to the configuration directory. When the styles.css file gets updated, the theme will be applied immediately. The reason it doesn't watch on styles.css itself is that many editors will swap out the entire file instead of editing it in place. For what it's worth, this replicates the behavior of how Obsidian handles changes to its themes files.

I have not added any tests for this, as I'm not sure how to achieve this or whether this is desirable at all.

Thanks for creating an awesome app :)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] Other (minor improvement)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
