### PR TITLE
fix(sync): skip already-applied ops re-delivered by forced downloads

### DIFF
--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -16,6 +16,11 @@ on:
         required: false
         type: string
         default: '@webdav'
+      run_webdav:
+        description: 'Run the WebDAV job (uncheck to skip it instead of passing a no-match grep)'
+        required: false
+        type: boolean
+        default: true
 
   push:
     branches: [master, release/*]
@@ -122,6 +127,10 @@ jobs:
   e2e-webdav:
     name: E2E Tests (WebDAV)
     needs: [build]
+    # Skip the job outright rather than handing it a no-match grep: Playwright
+    # exits 1 on "No tests found", which reds the whole run. `inputs` is empty
+    # for schedule/push, so gate on the event first.
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_webdav }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/docs/sync-and-op-log/vector-clocks.md
+++ b/docs/sync-and-op-log/vector-clocks.md
@@ -185,6 +185,7 @@ When the server rejects an operation:
 1. Client receives rejection with `existingClock`
 2. `SupersededOperationResolverService.resolveSupersededLocalOps()`:
    - Merges the global clock + all superseded ops' clocks + snapshot clock + extra clocks from force download
+     (the forced seq-0 download collects clocks from every re-fetched op, but does not _deliver_ ops that sit behind the persisted cursor AND are covered by the local clock — compaction may have pruned them from the local log, and re-applying a pruned `SYNC_IMPORT` would otherwise resurface it as a new incoming import; the cursor half keeps ops blocked on a newer schema version retryable, since this merge can cover them before they were ever applied)
    - Calls `mergeAndIncrementClocks()` — **no client-side pruning!**
    - Creates new LWW Update ops with the merged clock
 3. Re-uploads → server compares the full merged clock (which now has MAX+1 entries or more) → `GREATER_THAN` → accept

--- a/e2e/tests/sync/supersync-forced-download-pruned-import.spec.ts
+++ b/e2e/tests/sync/supersync-forced-download-pruned-import.spec.ts
@@ -1,0 +1,384 @@
+import { test, expect } from '../../fixtures/supersync.fixture';
+import type { Page } from '@playwright/test';
+import {
+  createTestUser,
+  getSuperSyncConfig,
+  createSimulatedClient,
+  closeClient,
+  waitForTask,
+  hasTask,
+  renameTask,
+  type SimulatedE2EClient,
+  SUPERSYNC_BASE_URL,
+} from '../../utils/supersync-helpers';
+import { waitForAppReady } from '../../utils/waits';
+
+/**
+ * Regression: a forced seq-0 download must not resurface an already-applied,
+ * locally compacted SYNC_IMPORT as a "new incoming import".
+ *
+ * Background: when an upload is rejected CONFLICT_CONCURRENT and the follow-up
+ * download brings nothing new, RejectedOpsHandlerService forces a download
+ * from seq 0 to rebuild clock state. The server fast-forwards such a request
+ * to its latest full-state op and includes it. If local compaction (7-day
+ * retention) already pruned that import from the op log, the applied-id
+ * filter no longer recognises it, the conflict gate treats it as an incoming
+ * import, and — with the rejected op still pending — shows the sync-import
+ * conflict dialog (reason: "password changed on another device", although
+ * nothing changed). Both dialog answers are harmful: USE_REMOTE discards the
+ * pending local work, USE_LOCAL uploads a fresh SYNC_IMPORT that prompts every
+ * other device.
+ *
+ * Fix: the forced download skips ops that sit behind the persisted cursor AND
+ * are covered by the local vector clock (OperationLogDownloadService).
+ *
+ * Discriminators: the "Incoming SYNC_IMPORT ... Showing conflict dialog" log
+ * line and the dialog itself must NOT appear on the client that hits the
+ * forced download; the "Skipped N re-delivered op(s)" line MUST appear.
+ * syncAndWait() auto-resolves the import dialog, so the dialog is watched
+ * independently — otherwise a buggy run would pass vacuously.
+ *
+ * Prerequisites:
+ * - super-sync-server running on localhost:1901 with TEST_MODE=true
+ * - Frontend running on localhost:4242
+ *
+ * Run with: npm run e2e:supersync:file e2e/tests/sync/supersync-forced-download-pruned-import.spec.ts
+ */
+
+interface ServerOperationSummary {
+  id: string;
+  opType: string;
+  serverSeq: number;
+  clientId?: string;
+}
+
+const getServerOperations = async (userId: number): Promise<ServerOperationSummary[]> => {
+  const response = await fetch(
+    `${SUPERSYNC_BASE_URL}/api/test/user/${userId}/ops?limit=200`,
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to inspect server operations: ${response.status} ${await response.text()}`,
+    );
+  }
+  const body = (await response.json()) as { ops: ServerOperationSummary[] };
+  return body.ops;
+};
+
+/**
+ * Mirrors OperationLogCompactionService's delete predicate as if the 7-day
+ * retention window had elapsed: every synced, fully applied op at or below the
+ * snapshot's lastAppliedOpSeq is deleted. The state cache and the durable
+ * vector clock stay untouched — exactly what real compaction leaves behind.
+ * The full-state ref index is dropped so the store rebuilds it from the
+ * remaining ops on next access.
+ */
+const pruneSyncedOpsLikeCompaction = (
+  page: Page,
+): Promise<{ deletedCount: number; deletedFullStateOpIds: string[] }> =>
+  page.evaluate(async () => {
+    const FULL_STATE_OP_TYPES = ['SYNC_IMPORT', 'BACKUP_IMPORT', 'REPAIR'];
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open('SUP_OPS');
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+    try {
+      const tx = db.transaction(['ops', 'state_cache', 'meta'], 'readwrite');
+      const snapshot = await new Promise<{ lastAppliedOpSeq?: number } | undefined>(
+        (resolve, reject) => {
+          const req = tx.objectStore('state_cache').get('current');
+          req.onsuccess = () =>
+            resolve(req.result as { lastAppliedOpSeq?: number } | undefined);
+          req.onerror = () => reject(req.error);
+        },
+      );
+      const lastAppliedOpSeq = snapshot?.lastAppliedOpSeq ?? 0;
+
+      let deletedCount = 0;
+      const deletedFullStateOpIds: string[] = [];
+      await new Promise<void>((resolve, reject) => {
+        const req = tx.objectStore('ops').openCursor();
+        req.onerror = () => reject(req.error);
+        req.onsuccess = () => {
+          const cursor = req.result;
+          if (!cursor) {
+            resolve();
+            return;
+          }
+          const entry = cursor.value as {
+            seq: number;
+            syncedAt?: number;
+            applicationStatus?: string;
+            op: { id?: string; opType?: string; o?: string };
+          };
+          const isApplied =
+            entry.applicationStatus === undefined ||
+            entry.applicationStatus === 'applied';
+          if (
+            entry.syncedAt !== undefined &&
+            isApplied &&
+            entry.seq <= lastAppliedOpSeq
+          ) {
+            const opType = entry.op.opType ?? entry.op.o;
+            if (opType && FULL_STATE_OP_TYPES.includes(opType) && entry.op.id) {
+              deletedFullStateOpIds.push(entry.op.id);
+            }
+            deletedCount++;
+            cursor.delete();
+          }
+          cursor.continue();
+        };
+      });
+      await new Promise<void>((resolve, reject) => {
+        const req = tx.objectStore('meta').delete('full_state_ops');
+        req.onsuccess = () => resolve();
+        req.onerror = () => reject(req.error);
+      });
+      await new Promise<void>((resolve, reject) => {
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+        tx.onabort = () => reject(tx.error);
+      });
+      return { deletedCount, deletedFullStateOpIds };
+    } finally {
+      db.close();
+    }
+  });
+
+/** Existing client picks up another device's password change. */
+const recoverWithNewPassword = async (
+  client: SimulatedE2EClient,
+  newPassword: string,
+): Promise<void> => {
+  const decryptErrorDialog = client.page.locator('dialog-handle-decrypt-error');
+  if (!(await decryptErrorDialog.isVisible().catch(() => false))) {
+    await client.sync.syncBtn.click();
+  }
+  await decryptErrorDialog.waitFor({ state: 'visible', timeout: 15000 });
+  const passwordInput = decryptErrorDialog.locator('input[type="password"]');
+  await passwordInput.waitFor({ state: 'visible', timeout: 5000 });
+  await passwordInput.fill(newPassword);
+  await decryptErrorDialog.locator('button:has-text("Retry Decrypt")').first().click();
+  await decryptErrorDialog.waitFor({ state: 'hidden', timeout: 10000 });
+
+  const importDialogAppeared = await client.sync.syncImportConflictDialog
+    .waitFor({ state: 'visible', timeout: 15000 })
+    .then(() => true)
+    .catch(() => false);
+  if (importDialogAppeared) {
+    await client.sync.chooseSyncImportUseRemote();
+  }
+  await client.sync.syncSpinner.waitFor({ state: 'hidden', timeout: 30000 });
+  await client.sync.syncAndWait();
+};
+
+/** Reboot the client so hydration writes a fresh snapshot and caches reset. */
+const reloadClient = async (client: SimulatedE2EClient): Promise<void> => {
+  await client.page.reload();
+  await waitForAppReady(client.page);
+  await client.sync.syncAndWait();
+};
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+test.describe('@supersync Forced download re-delivering a pruned SYNC_IMPORT', () => {
+  test('a concurrent-rejection retry does not raise the import conflict dialog for an already-applied import', async ({
+    browser,
+    baseURL,
+    testRunId,
+  }) => {
+    test.setTimeout(240000);
+    const appUrl = baseURL || 'http://localhost:4242';
+    let clientA: SimulatedE2EClient | null = null;
+    let clientB: SimulatedE2EClient | null = null;
+
+    try {
+      const user = await createTestUser(testRunId);
+      const baseConfig = getSuperSyncConfig(user);
+      const oldPassword = `oldpass-${testRunId}`;
+      const newPassword = `newpass-${testRunId}`;
+
+      clientA = await createSimulatedClient(browser, appUrl, 'A', testRunId);
+      await clientA.sync.setupSuperSync({ ...baseConfig, password: oldPassword });
+      clientB = await createSimulatedClient(browser, appUrl, 'B', testRunId);
+      await clientB.sync.setupSuperSync({ ...baseConfig, password: oldPassword });
+
+      // 1. Shared task, both clients in sync.
+      const sharedTask = `Shared-${testRunId}`;
+      await clientA.workView.addTask(sharedTask);
+      await clientA.sync.syncAndWait();
+      await clientB.sync.syncAndWait();
+      await waitForTask(clientB.page, sharedTask);
+
+      // 2. B changes the password → B uploads a SYNC_IMPORT (PASSWORD_CHANGED),
+      //    then some ordinary post-import work.
+      await clientB.sync.changeEncryptionPassword(newPassword);
+      const postImportTask = `PostImport-B-${testRunId}`;
+      await clientB.workView.addTask(postImportTask);
+      await clientB.sync.syncAndWait();
+
+      const serverOps = await getServerOperations(user.userId);
+      const importOp = serverOps.find((op) => op.opType === 'SYNC_IMPORT');
+      expect(importOp).toBeDefined();
+      if (!importOp) throw new Error('Expected a SYNC_IMPORT on the server');
+
+      // 3. A adopts the new password and applies B's import + follow-up ops.
+      await recoverWithNewPassword(clientA, newPassword);
+      await waitForTask(clientA.page, sharedTask);
+      await waitForTask(clientA.page, postImportTask);
+
+      // 4. Age out A's log the way compaction does: reboot so the snapshot
+      //    covers everything, prune synced ops behind it, reboot again so the
+      //    in-memory applied-id cache forgets them.
+      await reloadClient(clientA);
+      const pruned = await pruneSyncedOpsLikeCompaction(clientA.page);
+      console.log(
+        `[Pruned import] deleted ${pruned.deletedCount} op(s), full-state: ${pruned.deletedFullStateOpIds.join(',')}`,
+      );
+      // Precondition guard: the import is gone from A's log, as after 7 days.
+      expect(pruned.deletedFullStateOpIds).toContain(importOp.id);
+      await reloadClient(clientA);
+      await waitForTask(clientA.page, sharedTask);
+      await waitForTask(clientA.page, postImportTask);
+
+      // 5. Concurrent edits on the shared task; B's reaches the server first.
+      const titleFromB = `${sharedTask}-B`;
+      const titleFromA = `${sharedTask}-A`;
+      await renameTask(clientB, sharedTask, titleFromB);
+      await clientB.sync.syncAndWait();
+      await renameTask(clientA, sharedTask, titleFromA);
+
+      // 6. Steer A's sync into the forced seq-0 path (same technique as the
+      //    #8331 spec): keep the pre-upload download empty so A uploads a
+      //    genuinely concurrent op and the real server rejects it; strip the
+      //    piggybacked remote op so the client falls back to the resolution
+      //    download; keep that one empty too so the handler forces seq 0.
+      //    The forced download (sinceSeq=0) goes to the real server untouched.
+      let sawUploadAttempt = false;
+      let strippedPreUploadDownloads = 0;
+      let strippedResolutionDownloads = 0;
+      let forcedDownloads = 0;
+      let concurrentRejectedOpId: string | null = null;
+      await clientA.page.route('**/api/sync/ops*', async (route) => {
+        const method = route.request().method();
+        if (method === 'GET') {
+          const sinceSeq = Number(
+            new URL(route.request().url()).searchParams.get('sinceSeq') ?? 0,
+          );
+          if (sinceSeq === 0) {
+            forcedDownloads++;
+            await route.continue();
+            return;
+          }
+          const response = await route.fetch();
+          const json = await response.json();
+          json.ops = [];
+          json.hasMore = false;
+          json.latestSeq = sinceSeq;
+          if (sawUploadAttempt) {
+            strippedResolutionDownloads++;
+          } else {
+            strippedPreUploadDownloads++;
+          }
+          await route.fulfill({
+            status: response.status(),
+            contentType: 'application/json',
+            body: JSON.stringify(json),
+          });
+          return;
+        }
+        if (method === 'POST') {
+          sawUploadAttempt = true;
+          const response = await route.fetch();
+          const json = await response.json();
+          const concurrentResult = Array.isArray(json.results)
+            ? json.results.find(
+                (result: { errorCode?: unknown }) =>
+                  result.errorCode === 'CONFLICT_CONCURRENT',
+              )
+            : undefined;
+          if (typeof concurrentResult?.opId === 'string') {
+            concurrentRejectedOpId = concurrentResult.opId;
+          }
+          if (Array.isArray(json.newOps) && json.newOps.length > 0) {
+            json.newOps = [];
+            json.hasMorePiggyback = false;
+          }
+          await route.fulfill({
+            status: response.status(),
+            contentType: 'application/json',
+            body: JSON.stringify(json),
+          });
+          return;
+        }
+        await route.continue();
+      });
+
+      // Watch the discriminators independently of syncAndWait(), which would
+      // otherwise answer the dialog itself.
+      const consoleLines: string[] = [];
+      const onConsole = (msg: { text: () => string }): void => {
+        consoleLines.push(msg.text());
+      };
+      clientA.page.on('console', onConsole);
+      let importDialogSeen = false;
+      let stopWatching = false;
+      const importDialog = clientA.page.locator('dialog-sync-import-conflict');
+      const dialogWatcher = (async () => {
+        while (!stopWatching) {
+          if (await importDialog.isVisible().catch(() => false)) {
+            importDialogSeen = true;
+            return;
+          }
+          await sleep(100);
+        }
+      })();
+
+      try {
+        await clientA.sync.syncAndWait({ timeout: 60000 });
+      } finally {
+        stopWatching = true;
+        await dialogWatcher;
+        clientA.page.off('console', onConsole);
+        await clientA.page.unroute('**/api/sync/ops*');
+      }
+
+      // Setup guards: the path under test must actually have run.
+      expect(strippedPreUploadDownloads).toBeGreaterThanOrEqual(1);
+      expect(concurrentRejectedOpId).not.toBeNull();
+      expect(strippedResolutionDownloads).toBeGreaterThanOrEqual(1);
+      expect(forcedDownloads).toBeGreaterThanOrEqual(1);
+
+      // Discriminators.
+      const incomingImportLines = consoleLines.filter((line) =>
+        /Incoming SYNC_IMPORT from client .* Showing conflict dialog/.test(line),
+      );
+      expect(incomingImportLines).toEqual([]);
+      expect(importDialogSeen).toBe(false);
+      const skippedMatch = consoleLines
+        .map((line) => /Skipped (\d+) re-delivered op\(s\)/.exec(line))
+        .find((match) => match !== null);
+      expect(skippedMatch).toBeDefined();
+      expect(Number(skippedMatch?.[1])).toBeGreaterThanOrEqual(1);
+
+      // 7. Recovery proof: both clients converge on one title for the shared
+      //    task and keep the post-import task.
+      await clientA.sync.syncAndWait();
+      await clientB.sync.syncAndWait();
+      await clientA.sync.syncAndWait();
+      await waitForTask(clientA.page, postImportTask);
+      await waitForTask(clientB.page, postImportTask);
+      const aHasA = await hasTask(clientA.page, titleFromA);
+      const aHasB = await hasTask(clientA.page, titleFromB);
+      const bHasA = await hasTask(clientB.page, titleFromA);
+      const bHasB = await hasTask(clientB.page, titleFromB);
+      expect(aHasA || aHasB).toBe(true);
+      expect(aHasA).toBe(bHasA);
+      expect(aHasB).toBe(bHasB);
+    } finally {
+      if (clientA) await closeClient(clientA);
+      if (clientB) await closeClient(clientB);
+    }
+  });
+});

--- a/src/app/op-log/sync/operation-log-download.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-download.service.spec.ts
@@ -1449,6 +1449,37 @@ describe('OperationLogDownloadService', () => {
             expect(result.newOps.length).toBe(6);
             expect(mockOpLogStore.getVectorClock).not.toHaveBeenCalled();
           });
+
+          it('should stop filtering after a gap reset (new server epoch, stale cursor)', async () => {
+            // A gap means the server was reset or replaced, so the re-fetched ops
+            // carry seqs from a fresh epoch. The old cursor (14) would wrongly
+            // cover them and the clock check passes for the same authors, so
+            // without disabling the filter these are dropped and lost silently.
+            mockApiProvider.downloadOps.and.returnValues(
+              Promise.resolve({
+                ops: [],
+                hasMore: false,
+                latestSeq: 2,
+                gapDetected: true,
+              }),
+              Promise.resolve({
+                ops: [
+                  makeServerOp(1, 'fresh-a', 'importClient', { importClient: 3 }),
+                  makeServerOp(2, 'fresh-b', 'importClient', { importClient: 4 }),
+                ],
+                hasMore: false,
+                latestSeq: 2,
+                gapDetected: false,
+              }),
+            );
+
+            const result = await service.downloadRemoteOps(mockApiProvider, {
+              forceFromSeq0: true,
+            });
+
+            expect(mockApiProvider.downloadOps).toHaveBeenCalledTimes(2);
+            expect(result.newOps.map((op) => op.id)).toEqual(['fresh-a', 'fresh-b']);
+          });
         });
       });
 

--- a/src/app/op-log/sync/operation-log-download.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-download.service.spec.ts
@@ -34,6 +34,7 @@ describe('OperationLogDownloadService', () => {
     mockOpLogStore = jasmine.createSpyObj('OperationLogStoreService', [
       'getAppliedOpIds',
       'hasSyncedOps',
+      'getVectorClock',
     ]);
     mockLockService = jasmine.createSpyObj('LockService', ['request']);
     mockSnackService = jasmine.createSpyObj('SnackService', ['open']);
@@ -60,6 +61,7 @@ describe('OperationLogDownloadService', () => {
     });
     mockOpLogStore.getAppliedOpIds.and.returnValue(Promise.resolve(new Set<string>()));
     mockOpLogStore.hasSyncedOps.and.returnValue(Promise.resolve(false));
+    mockOpLogStore.getVectorClock.and.returnValue(Promise.resolve(null));
 
     TestBed.configureTestingModule({
       providers: [
@@ -1348,6 +1350,105 @@ describe('OperationLogDownloadService', () => {
 
           // No ops means no clocks to collect
           expect(result.allOpClocks).toBeUndefined();
+        });
+
+        describe('re-delivered ops already covered by the local vector clock', () => {
+          // A forced seq-0 download re-fetches everything after the server's latest
+          // full-state op. Ops that compaction already pruned from the local log are
+          // invisible to the applied-id filter, so without the clock filter an old
+          // SYNC_IMPORT resurfaces as a "new incoming import" on every
+          // concurrent-rejection retry and raises the conflict dialog.
+          const makeServerOp = (
+            serverSeq: number,
+            id: string,
+            clientId: string,
+            vectorClock: Record<string, number>,
+            opType: OpType = OpType.Update,
+          ): { serverSeq: number; receivedAt: number; op: SyncOperation } => ({
+            serverSeq,
+            receivedAt: Date.now(),
+            op: {
+              id,
+              clientId,
+              actionType: '[Task] Update' as ActionType,
+              opType,
+              entityType: 'TASK',
+              payload: {},
+              vectorClock,
+              timestamp: Date.now(),
+              schemaVersion: 1,
+            },
+          });
+          const serverOps = [
+            makeServerOp(
+              10,
+              'old-import',
+              'importClient',
+              { importClient: 3 },
+              OpType.SyncImport,
+            ),
+            makeServerOp(11, 'old-update', 'importClient', {
+              importClient: 40,
+              other: 2,
+            }),
+            makeServerOp(12, 'boundary-update', 'importClient', { importClient: 50 }),
+            makeServerOp(13, 'newer-update', 'importClient', { importClient: 51 }),
+            makeServerOp(14, 'unknown-client', 'clientX', { clientX: 1 }),
+            // Past the persisted cursor, so never processed here (e.g. blocked on a
+            // newer schema version) even though a resolver-merged clock covers it.
+            makeServerOp(15, 'beyond-cursor', 'importClient', { importClient: 45 }),
+          ];
+
+          beforeEach(() => {
+            mockOpLogStore.getVectorClock.and.returnValue(
+              Promise.resolve({ importClient: 50, ownClient: 10 }),
+            );
+            mockApiProvider.getLastServerSeq.and.returnValue(Promise.resolve(14));
+            mockApiProvider.downloadOps.and.returnValue(
+              Promise.resolve({ ops: serverOps, hasMore: false, latestSeq: 15 }),
+            );
+          });
+
+          it('should skip ops behind the cursor whose author counter the local clock covers, but keep their clocks', async () => {
+            const result = await service.downloadRemoteOps(mockApiProvider, {
+              forceFromSeq0: true,
+            });
+
+            expect(result.newOps.map((op) => op.id)).toEqual([
+              'newer-update',
+              'unknown-client',
+              'beyond-cursor',
+            ]);
+            // Rebuilding clock state is the point of the forced download
+            expect(result.allOpClocks!.length).toBe(6);
+          });
+
+          it('should deliver everything in raw-rebuild mode (includeOwnAndAppliedOps)', async () => {
+            const result = await service.downloadRemoteOps(mockApiProvider, {
+              forceFromSeq0: true,
+              includeOwnAndAppliedOps: true,
+            });
+
+            expect(result.newOps.length).toBe(6);
+          });
+
+          it('should leave the normal (non-forced) download untouched', async () => {
+            const result = await service.downloadRemoteOps(mockApiProvider);
+
+            expect(result.newOps.length).toBe(6);
+            expect(mockOpLogStore.getVectorClock).not.toHaveBeenCalled();
+          });
+
+          it('should deliver everything for file-based providers (synthetic serverSeq)', async () => {
+            mockApiProvider.providerMode = 'fileSnapshotOps';
+
+            const result = await service.downloadRemoteOps(mockApiProvider, {
+              forceFromSeq0: true,
+            });
+
+            expect(result.newOps.length).toBe(6);
+            expect(mockOpLogStore.getVectorClock).not.toHaveBeenCalled();
+          });
         });
       });
 

--- a/src/app/op-log/sync/operation-log-download.service.ts
+++ b/src/app/op-log/sync/operation-log-download.service.ts
@@ -187,10 +187,13 @@ export class OperationLogDownloadService implements OnDestroy {
       // (it is reflected in local state — a rebuilt log can sit behind a stale
       // cursor; and the rejection resolver merges server clocks into the local
       // clock, so the clock alone could cover a blocked op).
-      // Raw rebuild wants every op, so it keeps this filter off. File-based
-      // providers hand out synthetic per-download `serverSeq` values while
-      // their cursor is the file's sync version, so the `<=` check is
-      // meaningless there; the reproduced bug is SuperSync-only anyway.
+      // Raw rebuild wants every op, so it keeps this filter off. The provider
+      // gate is an allowlist: only SuperSync hands out a real monotonic server
+      // seq to compare against. File-based providers use synthetic per-download
+      // `serverSeq` values while their cursor is the file's sync version, so the
+      // `<=` check is meaningless there — and the reproduced bug is
+      // SuperSync-only anyway, so a future provider mode must opt in explicitly
+      // rather than inherit a filter nobody reasoned about for it.
       const isReDeliveryFilterActive =
         forceFromSeq0 &&
         !options?.includeOwnAndAppliedOps &&

--- a/src/app/op-log/sync/operation-log-download.service.ts
+++ b/src/app/op-log/sync/operation-log-download.service.ts
@@ -194,8 +194,10 @@ export class OperationLogDownloadService implements OnDestroy {
       const isReDeliveryFilterActive =
         forceFromSeq0 &&
         !options?.includeOwnAndAppliedOps &&
-        syncProvider.providerMode !== 'fileSnapshotOps';
-      const deliveredUpToSeq = isReDeliveryFilterActive
+        syncProvider.providerMode === 'superSyncOps';
+      // Not const: a gap reset below switches to a new server epoch whose seq
+      // space is unrelated to this cursor, so the filter must be disabled.
+      let deliveredUpToSeq = isReDeliveryFilterActive
         ? await syncProvider.getLastServerSeq()
         : 0;
       const localClock = isReDeliveryFilterActive
@@ -294,6 +296,13 @@ export class OperationLogDownloadService implements OnDestroy {
           hasResetForGap = true;
           allNewOps.length = 0; // Clear any ops we may have accumulated
           allOpClocks.length = 0; // Clear clocks too
+          // The re-delivery filter compares against the OLD server's cursor. A
+          // gap means a reset/replaced server, so the re-fetched ops carry seqs
+          // from a fresh epoch that the old cursor would wrongly cover — and
+          // dropping them here would lose them silently. 0 disables the filter
+          // for the rest of this download (every real serverSeq is >= 1).
+          deliveredUpToSeq = 0;
+          reDeliveredCount = 0; // pre-reset skips belong to the discarded epoch
           snapshotVectorClock = undefined; // Clear snapshot clock to capture fresh one after reset
           snapshotState = undefined; // Clear snapshot state to capture fresh one after reset
           snapshotAppliedOpIds = undefined; // Clear snapshot boundary with the stale state

--- a/src/app/op-log/sync/operation-log-download.service.ts
+++ b/src/app/op-log/sync/operation-log-download.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@sp/sync-core';
 import { OperationLogStoreService } from '../persistence/operation-log-store.service';
 import { LockService } from './lock.service';
-import { Operation } from '../core/operation.types';
+import { Operation, VectorClock } from '../core/operation.types';
 import { OpLog } from '../../core/log';
 import {
   OperationSyncCapable,
@@ -32,6 +32,28 @@ import { assertOpsEncryptedWhenExpected } from './assert-ops-encryption-expected
 import { SuperSyncStatusService } from './super-sync-status.service';
 import { DownloadResult } from '../core/types/sync-results.types';
 import { CLIENT_ID_PROVIDER } from '../util/client-id.provider';
+
+/**
+ * True when this client's vector clock already accounts for `op`: an author's
+ * counter is monotonic, so a counter at or below our entry for that author was
+ * processed here before. Missing entries (pruned or import-reset clock) yield
+ * false so the op falls through to the regular filters.
+ */
+const isOpCoveredByLocalClock = (
+  op: Pick<SyncOperation, 'clientId' | 'vectorClock'>,
+  localClock: VectorClock | null,
+): boolean => {
+  if (!localClock || !op.clientId) {
+    return false;
+  }
+  const authorCounter = op.vectorClock?.[op.clientId];
+  const knownCounter = localClock[op.clientId];
+  return (
+    authorCounter !== undefined &&
+    knownCounter !== undefined &&
+    authorCounter <= knownCounter
+  );
+};
 
 // Re-export for consumers that import from this service
 export type { DownloadResult } from '../core/types/sync-results.types';
@@ -153,6 +175,33 @@ export class OperationLogDownloadService implements OnDestroy {
       const clientId = options?.includeOwnAndAppliedOps
         ? null
         : await this.clientIdProvider.loadClientId();
+      // A forced seq-0 download re-fetches everything after the server's latest
+      // full-state op, including ops compaction already pruned from the local
+      // log. Those are invisible to the applied-id filter. Without a second
+      // filter an already-applied SYNC_IMPORT resurfaces as a new incoming
+      // import on every concurrent-rejection retry and raises the conflict
+      // dialog (or, with nothing pending, replaces state wholesale).
+      // An op is treated as re-delivered only when BOTH hold: the persisted
+      // cursor is past it (it was processed here — a schema-version block keeps
+      // the cursor behind the blocked op) AND the local vector clock covers it
+      // (it is reflected in local state — a rebuilt log can sit behind a stale
+      // cursor; and the rejection resolver merges server clocks into the local
+      // clock, so the clock alone could cover a blocked op).
+      // Raw rebuild wants every op, so it keeps this filter off. File-based
+      // providers hand out synthetic per-download `serverSeq` values while
+      // their cursor is the file's sync version, so the `<=` check is
+      // meaningless there; the reproduced bug is SuperSync-only anyway.
+      const isReDeliveryFilterActive =
+        forceFromSeq0 &&
+        !options?.includeOwnAndAppliedOps &&
+        syncProvider.providerMode !== 'fileSnapshotOps';
+      const deliveredUpToSeq = isReDeliveryFilterActive
+        ? await syncProvider.getLastServerSeq()
+        : 0;
+      const localClock = isReDeliveryFilterActive
+        ? await this.opLogStore.getVectorClock()
+        : null;
+      let reDeliveredCount = 0;
       OpLog.verbose(
         `OperationLogDownloadService: [DEBUG] Starting download. ` +
           `lastServerSeq=${lastServerSeq}, appliedOpIds.size=${appliedOpIds.size}, clientId=${clientId}`,
@@ -307,9 +356,19 @@ export class OperationLogDownloadService implements OnDestroy {
         }
 
         // Filter already applied ops
-        const newServerOps = response.ops.filter(
-          (serverOp) => !appliedOpIds.has(serverOp.op.id),
-        );
+        const newServerOps = response.ops.filter((serverOp) => {
+          if (appliedOpIds.has(serverOp.op.id)) {
+            return false;
+          }
+          if (
+            serverOp.serverSeq <= deliveredUpToSeq &&
+            isOpCoveredByLocalClock(serverOp.op, localClock)
+          ) {
+            reDeliveredCount++;
+            return false;
+          }
+          return true;
+        });
         let syncOps: SyncOperation[] = newServerOps.map((serverOp) => serverOp.op);
 
         // Fail closed on a plaintext op when SuperSync encryption is enabled: the
@@ -416,6 +475,14 @@ export class OperationLogDownloadService implements OnDestroy {
       // cleans up stale devices after 50 days (STALE_DEVICE_THRESHOLD_MS).
       // Removing ACK simplifies the flow and avoids issues with fresh clients
       // (device not registered until first upload would cause 403 errors).
+
+      if (reDeliveredCount > 0) {
+        OpLog.normal(
+          `OperationLogDownloadService: Skipped ${reDeliveredCount} re-delivered op(s) ` +
+            `behind cursor ${deliveredUpToSeq} and covered by the local vector clock ` +
+            '(compacted out of the local log).',
+        );
+      }
 
       // Server migration detection:
       // If we detected a gap AND the server is empty (no ops to download),

--- a/src/app/op-log/testing/integration/forced-download-pruned-import.integration.spec.ts
+++ b/src/app/op-log/testing/integration/forced-download-pruned-import.integration.spec.ts
@@ -1,0 +1,498 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { MatDialog } from '@angular/material/dialog';
+import { TranslateService } from '@ngx-translate/core';
+import { provideMockStore } from '@ngrx/store/testing';
+import { CURRENT_SCHEMA_VERSION } from '@sp/shared-schema';
+import { OperationLogSyncService } from '../../sync/operation-log-sync.service';
+import { OperationLogUploadService } from '../../sync/operation-log-upload.service';
+import { OperationLogDownloadService } from '../../sync/operation-log-download.service';
+import { OperationEncryptionService } from '../../sync/operation-encryption.service';
+import { OperationLogStoreService } from '../../persistence/operation-log-store.service';
+import { OperationLogCompactionService } from '../../persistence/operation-log-compaction.service';
+import { COMPACTION_RETENTION_MS } from '../../core/operation-log.const';
+import { VectorClockService } from '../../sync/vector-clock.service';
+import { OperationApplierService } from '../../apply/operation-applier.service';
+import { ConflictResolutionService } from '../../sync/conflict-resolution.service';
+import { ValidateStateService } from '../../validation/validate-state.service';
+import { RepairOperationService } from '../../validation/repair-operation.service';
+import { StateSnapshotService } from '../../backup/state-snapshot.service';
+import {
+  OpDownloadResponse,
+  OperationSyncCapable,
+  OpUploadResponse,
+  ServerSyncOperation,
+  SyncOperation,
+  SyncProviderBase,
+} from '../../sync-providers/provider.interface';
+import { SyncProviderId } from '../../sync-providers/provider.const';
+import type { SuperSyncPrivateCfg } from '@sp/sync-providers/super-sync';
+import { ActionType, Operation, OpType, VectorClock } from '../../core/operation.types';
+import { UserInputWaitStateService } from '../../../imex/sync/user-input-wait-state.service';
+import { SnackService } from '../../../core/snack/snack.service';
+import { resetTestUuidCounter } from './helpers/test-client.helper';
+import { LockService } from '../../sync/lock.service';
+import { SchemaMigrationService } from '../../persistence/schema-migration.service';
+import { SuperSyncStatusService } from '../../sync/super-sync-status.service';
+import { ServerMigrationService } from '../../sync/server-migration.service';
+import { OperationWriteFlushService } from '../../sync/operation-write-flush.service';
+import { RemoteOpsProcessingService } from '../../sync/remote-ops-processing.service';
+import { RejectedOpsHandlerService } from '../../sync/rejected-ops-handler.service';
+import { SyncHydrationService } from '../../persistence/sync-hydration.service';
+import { SyncImportFilterService } from '../../sync/sync-import-filter.service';
+import { SyncImportConflictDialogService } from '../../sync/sync-import-conflict-dialog.service';
+import { OperationLogEffects } from '../../capture/operation-log.effects';
+import { clearDeferredActions } from '../../capture/operation-capture.meta-reducer';
+import { createValidAppData } from '../../validation/state-validity-test-utils';
+import { DEFAULT_GLOBAL_CONFIG } from '../../../features/config/default-global-config.const';
+import { selectSyncConfig } from '../../../features/config/store/global-config.reducer';
+import { CLIENT_ID_PROVIDER } from '../../util/client-id.provider';
+
+/**
+ * A forced seq-0 download re-delivers ops that compaction already pruned from
+ * the local log. This spec drives the REAL store, compaction, download service,
+ * conflict gate and sync service (only state application and UI are mocked)
+ * through the scenario the unit specs can only stub:
+ *
+ * 1. An installed client applies another device's SYNC_IMPORT plus follow-up ops.
+ * 2. The 7-day retention window elapses; real compaction prunes them, so the
+ *    applied-id filter no longer knows the import.
+ * 3. A forced seq-0 download (concurrent-rejection retry, provider switch)
+ *    re-delivers the import. It must NOT resurface as a new incoming import
+ *    while local work is pending — that is the sync-import conflict dialog
+ *    from the field report, whose every answer destroys data.
+ *
+ * The second case guards the filter's false-positive edge: an op the local
+ * clock covers only because the rejection resolver merged its clock, but
+ * that was never applied because it is schema-blocked, sits ABOVE the cursor
+ * and must still be delivered (and stay blocked).
+ */
+
+const IMPORTER = 'importer-client';
+const OTHER = 'other-client';
+const SHARED_TASK_ID = 'shared-task';
+
+/**
+ * In-memory SuperSync stand-in with the two server behaviours that matter here:
+ * real per-op `serverSeq`, and the seq-0 fast-forward to the latest full-state
+ * op (super-sync-server `operation-download.service.ts`). Own ops are excluded
+ * like the real endpoint does.
+ */
+class PrunedImportSyncProvider
+  implements SyncProviderBase<SyncProviderId>, OperationSyncCapable
+{
+  id = SyncProviderId.SuperSync;
+  supportsOperationSync = true;
+  providerMode = 'superSyncOps' as const;
+  maxConcurrentRequests = 1;
+  isEncryptionMandatory = false;
+
+  serverOps: ServerSyncOperation[] = [];
+  private _lastServerSeq = 0;
+  private _privateCfg: SuperSyncPrivateCfg = {
+    accessToken: 'test-token',
+    baseUrl: 'https://test.supersync.example',
+    isEncryptionEnabled: false,
+    encryptKey: undefined,
+  };
+  privateCfg = {
+    load: async () => this._privateCfg,
+  } as unknown as SyncProviderBase<SyncProviderId>['privateCfg'];
+
+  async getEncryptKey(): Promise<string | undefined> {
+    return undefined;
+  }
+
+  async isEncryptionEnabled(): Promise<boolean> {
+    return false;
+  }
+
+  async getLastServerSeq(): Promise<number> {
+    return this._lastServerSeq;
+  }
+
+  async setLastServerSeq(seq: number): Promise<void> {
+    this._lastServerSeq = seq;
+  }
+
+  async uploadOps(ops: SyncOperation[]): Promise<OpUploadResponse> {
+    throw new Error(`Unexpected upload of ${ops.length} op(s) in this spec`);
+  }
+
+  async downloadOps(
+    sinceSeq: number,
+    excludeClient: string,
+    limit: number,
+  ): Promise<OpDownloadResponse> {
+    const latestFullStateSeq = this.serverOps
+      .filter((stored) => stored.op.opType === OpType.SyncImport)
+      .reduce((max, stored) => Math.max(max, stored.serverSeq), 0);
+    const effectiveSince =
+      latestFullStateSeq > 0 && sinceSeq < latestFullStateSeq
+        ? latestFullStateSeq - 1
+        : sinceSeq;
+    const ops = this.serverOps
+      .filter(
+        (stored) =>
+          stored.serverSeq > effectiveSince && stored.op.clientId !== excludeClient,
+      )
+      .slice(0, limit);
+    return {
+      ops,
+      hasMore: false,
+      latestSeq: this.serverOps.reduce((max, s) => Math.max(max, s.serverSeq), 0),
+      gapDetected: false,
+    };
+  }
+
+  async uploadSnapshot(): Promise<{ accepted: boolean; serverSeq: number }> {
+    throw new Error('Unexpected snapshot upload in this spec');
+  }
+
+  async init(): Promise<void> {}
+  async isReady(): Promise<boolean> {
+    return true;
+  }
+  async setPrivateCfg(cfg: SuperSyncPrivateCfg): Promise<void> {
+    this._privateCfg = cfg;
+  }
+  async getFileRev(): Promise<{ rev: string }> {
+    return { rev: 'rev' };
+  }
+  async downloadFile(): Promise<{ rev: string; dataStr: string }> {
+    return { rev: 'rev', dataStr: '{}' };
+  }
+  async uploadFile(): Promise<{ rev: string }> {
+    return { rev: 'rev' };
+  }
+  async removeFile(): Promise<void> {}
+  async deleteAllData(): Promise<{ success: boolean }> {
+    this.serverOps = [];
+    this._lastServerSeq = 0;
+    return { success: true };
+  }
+}
+
+describe('Forced seq-0 download after compaction pruned an applied SYNC_IMPORT (integration)', () => {
+  let syncService: OperationLogSyncService;
+  let downloadService: OperationLogDownloadService;
+  let compactionService: OperationLogCompactionService;
+  let opLogStore: OperationLogStoreService;
+  let provider: PrunedImportSyncProvider;
+  let applierSpy: jasmine.SpyObj<OperationApplierService>;
+  let showConflictDialogSpy: jasmine.Spy;
+  let ownClientId: string;
+
+  const serverOp = (serverSeq: number, op: SyncOperation): ServerSyncOperation => ({
+    serverSeq,
+    op,
+    receivedAt: Date.now(),
+  });
+
+  const remoteSyncImport = (): SyncOperation => ({
+    id: 'remote-sync-import',
+    clientId: IMPORTER,
+    actionType: ActionType.LOAD_ALL_DATA,
+    opType: OpType.SyncImport,
+    entityType: 'ALL',
+    payload: { appDataComplete: structuredClone(createValidAppData()) },
+    vectorClock: { [IMPORTER]: 1 },
+    timestamp: Date.now(),
+    schemaVersion: CURRENT_SCHEMA_VERSION,
+    syncImportReason: 'PASSWORD_CHANGED',
+  });
+
+  const remoteTaskUpdate = (
+    id: string,
+    clientId: string,
+    vectorClock: VectorClock,
+    schemaVersion = CURRENT_SCHEMA_VERSION,
+  ): SyncOperation => ({
+    id,
+    clientId,
+    actionType: '[Task] Update Task' as ActionType,
+    opType: OpType.Update,
+    entityType: 'TASK',
+    entityId: SHARED_TASK_ID,
+    payload: { task: { id: SHARED_TASK_ID, changes: { title: id } } },
+    vectorClock,
+    timestamp: Date.now(),
+    schemaVersion,
+  });
+
+  const localTaskUpdate = (id: string, vectorClock: VectorClock): Operation => ({
+    id,
+    clientId: ownClientId,
+    actionType: '[Task] Update Task' as ActionType,
+    opType: OpType.Update,
+    entityType: 'TASK',
+    entityId: SHARED_TASK_ID,
+    payload: { task: { id: SHARED_TASK_ID, changes: { title: id } } },
+    vectorClock,
+    timestamp: Date.now(),
+    schemaVersion: CURRENT_SCHEMA_VERSION,
+  });
+
+  /** Appends a local op whose clock extends the durable clock by one own tick. */
+  const appendPendingLocalOp = async (
+    id: string,
+    extraClock: VectorClock = {},
+  ): Promise<Operation> => {
+    const durable = (await opLogStore.getVectorClock()) ?? {};
+    const clock: VectorClock = { ...durable, ...extraClock };
+    clock[ownClientId] = (clock[ownClientId] ?? 0) + 1;
+    const op = localTaskUpdate(id, clock);
+    await opLogStore.appendWithVectorClockOverwrite(op, 'local');
+    return op;
+  };
+
+  const forcedDownloadNewOpIds = async (): Promise<string[]> => {
+    const result = await downloadSpy.calls.mostRecent().returnValue;
+    return result.newOps.map((op) => op.id);
+  };
+  let downloadSpy: jasmine.Spy<OperationLogDownloadService['downloadRemoteOps']>;
+
+  /**
+   * Seeds the log the way real history does: the import and two follow-up ops
+   * arrive through the normal download path more than a retention window ago;
+   * one more follow-up arrives recently, so the client still counts as synced
+   * after compaction (exactly the state of a device that syncs daily).
+   */
+  const seedAppliedImportAndCompact = async (): Promise<void> => {
+    const oneHourMs = 60 * 60 * 1000;
+    const nowSpy = spyOn(Date, 'now').and.returnValue(
+      new Date().getTime() - COMPACTION_RETENTION_MS - oneHourMs,
+    );
+    // An installed client always carries a state cache from an earlier
+    // compaction. Without one, the first ordinary remote batch fires a
+    // background compaction (old snapshot format path) that would race the
+    // assertions below.
+    expect(await compactionService.compact()).toBeTrue();
+    provider.serverOps = [
+      serverOp(1, remoteSyncImport()),
+      serverOp(2, remoteTaskUpdate('importer-update-1', IMPORTER, { [IMPORTER]: 2 })),
+      serverOp(3, remoteTaskUpdate('importer-update-2', IMPORTER, { [IMPORTER]: 3 })),
+    ];
+    const oldOutcome = await syncService.downloadRemoteOps(provider);
+    expect(oldOutcome.kind).toBe('ops_processed');
+    nowSpy.and.callThrough();
+
+    provider.serverOps.push(
+      serverOp(4, remoteTaskUpdate('importer-update-3', IMPORTER, { [IMPORTER]: 4 })),
+    );
+    const recentOutcome = await syncService.downloadRemoteOps(provider);
+    expect(recentOutcome.kind).toBe('ops_processed');
+
+    // Precondition guards: everything applied, cursor advanced, clock covers it.
+    expect(await opLogStore.hasOp('remote-sync-import')).toBeTrue();
+    expect(await provider.getLastServerSeq()).toBe(4);
+    expect((await opLogStore.getVectorClock())?.[IMPORTER]).toBe(4);
+
+    // Real compaction with the production retention window.
+    expect(await compactionService.compact()).toBeTrue();
+    expect(await opLogStore.hasOp('remote-sync-import')).toBeFalse();
+    expect(await opLogStore.hasOp('importer-update-2')).toBeFalse();
+    expect(await opLogStore.hasOp('importer-update-3')).toBeTrue();
+    expect(await opLogStore.getLatestFullStateOpEntry()).toBeUndefined();
+    expect(await opLogStore.hasSyncedOps()).toBeTrue();
+    // Compaction keeps the durable clock, which is what the fix relies on.
+    expect((await opLogStore.getVectorClock())?.[IMPORTER]).toBe(4);
+  };
+
+  beforeEach(async () => {
+    if (!(window.confirm as jasmine.Spy).and) {
+      spyOn(window, 'confirm').and.returnValue(true);
+    } else {
+      (window.confirm as jasmine.Spy).and.returnValue(true);
+    }
+
+    const conflictServiceSpy = jasmine.createSpyObj('ConflictResolutionService', [
+      'autoResolveConflictsLWW',
+      'checkOpForConflicts',
+    ]);
+    conflictServiceSpy.autoResolveConflictsLWW.and.resolveTo({ localWinOpsCreated: 0 });
+    conflictServiceSpy.checkOpForConflicts.and.resolveTo({
+      isSupersededOrDuplicate: false,
+      conflicts: [],
+    });
+
+    // State application is mocked; the store-side persistence and clock merge
+    // still run through the real reducer-commit callback.
+    applierSpy = jasmine.createSpyObj('OperationApplierService', ['applyOperations']);
+    applierSpy.applyOperations.and.callFake(async (ops, options) => {
+      await options?.onReducersCommitted?.(ops);
+      return { appliedOps: ops };
+    });
+
+    const waitServiceSpy = jasmine.createSpyObj('UserInputWaitStateService', [
+      'startWaiting',
+    ]);
+    waitServiceSpy.startWaiting.and.returnValue(() => {});
+    const dialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
+    dialogSpy.open.and.returnValue({ afterClosed: () => of(true) });
+    const superSyncStatusSpy = jasmine.createSpyObj('SuperSyncStatusService', [
+      'markRemoteChecked',
+      'updatePendingOpsStatus',
+      'clearScope',
+    ]);
+    const serverMigrationSpy = jasmine.createSpyObj('ServerMigrationService', [
+      'checkAndHandleMigration',
+      'handleServerMigration',
+    ]);
+    serverMigrationSpy.checkAndHandleMigration.and.resolveTo();
+    serverMigrationSpy.handleServerMigration.and.resolveTo();
+    const writeFlushSpy = jasmine.createSpyObj('OperationWriteFlushService', [
+      'flushPendingWrites',
+      'flushThenRunExclusive',
+    ]);
+    writeFlushSpy.flushPendingWrites.and.resolveTo();
+    writeFlushSpy.flushThenRunExclusive.and.callFake(
+      async <T>(fn: () => Promise<T>): Promise<T> => fn(),
+    );
+    const rejectedOpsHandlerSpy = jasmine.createSpyObj('RejectedOpsHandlerService', [
+      'handleRejectedOps',
+    ]);
+    rejectedOpsHandlerSpy.handleRejectedOps.and.resolveTo(0);
+    const syncHydrationSpy = jasmine.createSpyObj('SyncHydrationService', [
+      'hydrateFromRemoteSync',
+    ]);
+    syncHydrationSpy.hydrateFromRemoteSync.and.resolveTo();
+    const stateSnapshotSpy = jasmine.createSpyObj('StateSnapshotService', [
+      'getStateSnapshot',
+      'getStateSnapshotForOperationLog',
+    ]);
+    // Never consulted: the seeded client carries a state cache, so the
+    // fresh-client guard does not run. Compaction snapshots this fixture; its
+    // INBOX project counts as meaningful data, which the guard there requires.
+    stateSnapshotSpy.getStateSnapshot.and.returnValue(undefined);
+    stateSnapshotSpy.getStateSnapshotForOperationLog.and.callFake(() =>
+      createValidAppData(),
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        OperationLogSyncService,
+        OperationLogUploadService,
+        OperationLogDownloadService,
+        OperationLogCompactionService,
+        OperationEncryptionService,
+        OperationLogStoreService,
+        LockService,
+        VectorClockService,
+        SchemaMigrationService,
+        RemoteOpsProcessingService,
+        SyncImportFilterService,
+        provideMockStore({
+          selectors: [{ selector: selectSyncConfig, value: DEFAULT_GLOBAL_CONFIG.sync }],
+        }),
+        { provide: ConflictResolutionService, useValue: conflictServiceSpy },
+        { provide: OperationApplierService, useValue: applierSpy },
+        { provide: SuperSyncStatusService, useValue: superSyncStatusSpy },
+        { provide: ServerMigrationService, useValue: serverMigrationSpy },
+        { provide: OperationWriteFlushService, useValue: writeFlushSpy },
+        { provide: RejectedOpsHandlerService, useValue: rejectedOpsHandlerSpy },
+        { provide: SyncHydrationService, useValue: syncHydrationSpy },
+        { provide: StateSnapshotService, useValue: stateSnapshotSpy },
+        {
+          provide: ValidateStateService,
+          useValue: jasmine.createSpyObj('ValidateStateService', [
+            'validateAndRepairCurrentState',
+          ]),
+        },
+        {
+          provide: RepairOperationService,
+          useValue: jasmine.createSpyObj('RepairOperationService', [
+            'createRepairOperation',
+          ]),
+        },
+        {
+          provide: SnackService,
+          useValue: jasmine.createSpyObj('SnackService', [
+            'open',
+            'hasPendingPersistentAction',
+          ]),
+        },
+        { provide: MatDialog, useValue: dialogSpy },
+        { provide: UserInputWaitStateService, useValue: waitServiceSpy },
+        {
+          provide: TranslateService,
+          useValue: jasmine.createSpyObj('TranslateService', ['instant']),
+        },
+        {
+          provide: OperationLogEffects,
+          useValue: { processDeferredActions: () => Promise.resolve() },
+        },
+      ],
+    });
+
+    syncService = TestBed.inject(OperationLogSyncService);
+    downloadService = TestBed.inject(OperationLogDownloadService);
+    compactionService = TestBed.inject(OperationLogCompactionService);
+    opLogStore = TestBed.inject(OperationLogStoreService);
+    // CANCEL keeps a regression on the assertions below instead of turning it
+    // into a state replacement that fails somewhere deeper.
+    showConflictDialogSpy = spyOn(
+      TestBed.inject(SyncImportConflictDialogService),
+      'showConflictDialog',
+    ).and.resolveTo('CANCEL');
+    downloadSpy = spyOn(downloadService, 'downloadRemoteOps').and.callThrough();
+    provider = new PrunedImportSyncProvider();
+
+    await opLogStore.init();
+    await opLogStore._clearAllDataForTesting();
+    resetTestUuidCounter();
+    clearDeferredActions();
+    ownClientId = await TestBed.inject(CLIENT_ID_PROVIDER).getOrGenerateClientId();
+  });
+
+  it('does not treat the re-delivered, already-applied import as a new incoming import while local work is pending', async () => {
+    await seedAppliedImportAndCompact();
+    const pendingOp = await appendPendingLocalOp('local-concurrent-edit');
+    applierSpy.applyOperations.calls.reset();
+
+    const outcome = await syncService.downloadRemoteOps(provider, {
+      forceFromSeq0: true,
+    });
+
+    // Server re-delivered 1..4 (fast-forwarded to the import); 1..3 are behind
+    // the cursor and covered by the clock, 4 is still in the applied-id set.
+    expect(await forcedDownloadNewOpIds()).toEqual([]);
+    expect(showConflictDialogSpy).not.toHaveBeenCalled();
+    expect(outcome.kind).toBe('no_new_ops');
+    expect(applierSpy.applyOperations).not.toHaveBeenCalled();
+    expect(await opLogStore.hasOp('remote-sync-import')).toBeFalse();
+    // The pending local work survives untouched (neither discarded nor rejected).
+    const pendingIds = (await opLogStore.getUnsynced()).map((entry) => entry.op.id);
+    expect(pendingIds).toEqual([pendingOp.id]);
+    expect(await provider.getLastServerSeq()).toBe(4);
+  });
+
+  it('still delivers a schema-blocked op above the cursor even though the local clock already covers it', async () => {
+    await seedAppliedImportAndCompact();
+    // A device on a newer app version uploads an op this client cannot apply.
+    const newerSchemaOp = remoteTaskUpdate(
+      'newer-schema-op',
+      OTHER,
+      { [IMPORTER]: 4, [OTHER]: 1 },
+      CURRENT_SCHEMA_VERSION + 1,
+    );
+    provider.serverOps.push(serverOp(5, newerSchemaOp));
+    // The rejection resolver merges every clock of a forced download into the
+    // new local ops it creates, so the durable clock can cover the blocked op
+    // before it was ever applied. Reproduce that over-claim through the store.
+    await appendPendingLocalOp('local-resolved-edit', { [OTHER]: 1 });
+    expect((await opLogStore.getVectorClock())?.[OTHER]).toBe(1);
+
+    const outcome = await syncService.downloadRemoteOps(provider, {
+      forceFromSeq0: true,
+    });
+
+    // Behind-cursor ops are skipped; the blocked op is above the cursor and delivered.
+    expect(await forcedDownloadNewOpIds()).toEqual(['newer-schema-op']);
+    expect(outcome.kind).toBe('blocked_incompatible');
+    expect(showConflictDialogSpy).not.toHaveBeenCalled();
+    expect(await opLogStore.hasOp('newer-schema-op')).toBeFalse();
+    // Cursor stays behind the blocked op so it is retried after an app update.
+    expect(await provider.getLastServerSeq()).toBe(4);
+  });
+});


### PR DESCRIPTION
## Problem

A concurrent-rejection retry (`RejectedOpsHandlerService`, and also a provider switch) forces a download from seq 0. The server fast-forwards that request to its latest full-state op and re-delivers everything from there. If local compaction (7-day retention) already pruned that `SYNC_IMPORT` from the op log, the applied-id filter no longer recognises it, the conflict gate treats it as a new incoming import, and with the rejected op still pending the user sees the sync-import conflict dialog with reason "password was changed on another device" although nothing changed.

Both dialog answers are harmful: USE_REMOTE discards the pending local work, USE_LOCAL uploads a fresh `SYNC_IMPORT` that then prompts every other device.

Field log that triggered this:

```
RejectedOpsHandlerService: Download returned no new ops but 1 concurrent ops still pending. Forcing full download from seq 0...
OperationLogDownloadService: Downloaded 2458 new operations via API.
OperationLogSyncService: Incoming SYNC_IMPORT from client E_Vrno5Q with 2 pending local ops. Showing conflict dialog.
```

## Fix

`OperationLogDownloadService`: on a forced seq-0 download, additionally skip ops that sit **behind the persisted server cursor AND are covered by the local vector clock** (author counter ≤ our entry for that author). Both halves are required:

- clock alone could cover a schema-blocked op whose clock `SupersededOperationResolverService` merged before it was ever applied (the cursor stays behind blocked ops, so the cursor half keeps them retryable)
- cursor alone could be stale after a log rebuild

Raw rebuild (`includeOwnAndAppliedOps`) keeps the filter off, as do file-based providers whose per-download `serverSeq` values are synthetic. Clocks of skipped ops are still collected for the resolver.

## Tests

- Unit: 4 new cases in `operation-log-download.service.spec.ts`: the forced download skips ops behind the cursor and covered by the clock while still delivering the newer, unknown-author, and beyond-cursor ones; raw rebuild, normal download, and file-based providers keep the filter off.
- E2E `@supersync`: `supersync-forced-download-pruned-import.spec.ts` — B changes the password (uploads a `SYNC_IMPORT`), A applies it, A's IndexedDB is pruned the way compaction does, then a real concurrent rejection forces the seq-0 path. Asserts the dialog never appears and the download reports skipped re-delivered ops. With the filter disabled it fails with the exact field log line. Ran locally against the docker SuperSync server (green with fix, red without).

## Audit of other cursor/clock writers

All safe under the filter's invariant. Pre-existing, out of scope: `SyncHydrationService.hydrateFromRemoteSync` merges the old local clock into the replacement clock (over-claims), not reachable by this filter.

https://claude.ai/code/session_01JiRhSBdad2PWxCNTeDTXQb
