### PR TITLE
fix(notes): open x-devonthink-item links and schemeless markdown links

### DIFF
--- a/e2e/tests/migration/legacy-partial-model-slices-9770.spec.ts
+++ b/e2e/tests/migration/legacy-partial-model-slices-9770.spec.ts
@@ -187,9 +187,13 @@ test.describe('@migration #9770 legacy data missing newer model slices', () => {
       await expect(page.locator('dialog-legacy-migration')).toHaveCount(0);
 
       // The load-bearing half: the legacy data is still on disk, untouched.
-      const remaining = await readLegacyKeys(page);
-      expect(remaining).toContain('globalConfig');
-      expect(remaining).toContain('_migration_skipped');
+      // Polled, not read once: neither wait above is a settle point for the
+      // marker. The dialog is closed in the `finally` BEFORE _skipLegacyData()
+      // writes it, and the app shell renders behind the dialog anyway — so a
+      // single read here loses the race on a loaded machine.
+      await expect
+        .poll(() => readLegacyKeys(page), { timeout: 10000 })
+        .toEqual(expect.arrayContaining(['globalConfig', '_migration_skipped']));
 
       // ...and the next boot does NOT walk back into the failed migration.
       await page.reload({ waitUntil: 'domcontentloaded' });

--- a/e2e/tests/notes/note-link-href.spec.ts
+++ b/e2e/tests/notes/note-link-href.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '../../fixtures/test.fixture';
+
+/**
+ * Both note renderers resolve a link target through the same helper
+ * (`toRenderableHref`): the markdown renderer for an unlocked note, and
+ * `renderLinks` for a locked one ("Disable Markdown Parsing"). These tests pin
+ * the three outcomes at runtime, in both renderers:
+ *
+ * - a schemeless web host becomes an `http://` link,
+ * - a bare filename stays text (`.md` is a registrable TLD — a relative file
+ *   reference must never become a visit to a stranger's domain),
+ * - an app deep-link scheme keeps its scheme verbatim.
+ */
+const linkLine = (unique: string): string =>
+  `[${unique}-www](www.example.com) [${unique}-file](readme.md) [${unique}-dt](x-devonthink-item://abc123)`;
+
+test.describe('note link hrefs', () => {
+  test('unlocked note (markdown renderer) normalizes, blocks and preserves hrefs', async ({
+    page,
+    workViewPage,
+    notePage,
+    testPrefix,
+  }) => {
+    await workViewPage.waitForTaskList();
+
+    const unique = `${testPrefix}-href`;
+    await notePage.addNote(linkLine(unique));
+
+    const note = page.locator('note', { hasText: `${unique}-www` }).first();
+    await expect(note).toBeVisible();
+
+    const wwwAnchor = note.locator(`a:has-text("${unique}-www")`);
+    await expect(wwwAnchor).toBeVisible();
+    expect(await wwwAnchor.getAttribute('href')).toBe('http://www.example.com');
+
+    // Rendered as inert text, so the link text is still readable.
+    await expect(note.locator(`a:has-text("${unique}-file")`)).toHaveCount(0);
+    await expect(note).toContainText(`${unique}-file`);
+
+    const deepLinkAnchor = note.locator(`a:has-text("${unique}-dt")`);
+    await expect(deepLinkAnchor).toBeVisible();
+    expect(await deepLinkAnchor.getAttribute('href')).toBe('x-devonthink-item://abc123');
+  });
+
+  test('locked note (renderLinks) resolves the same hrefs as the markdown renderer', async ({
+    page,
+    workViewPage,
+    notePage,
+    testPrefix,
+  }) => {
+    await workViewPage.waitForTaskList();
+
+    const unique = `${testPrefix}-href-locked`;
+    await notePage.addNote(linkLine(unique));
+
+    const note = page.locator('note', { hasText: `${unique}-www` }).first();
+    await expect(note).toBeVisible();
+
+    // Toggle lock via context menu ("Disable Markdown Parsing")
+    await note.hover();
+    const menuBtn = note.locator('button:has(mat-icon:has-text("more_vert"))');
+    await menuBtn.click();
+    const lockBtn = page
+      .locator('.mat-mdc-menu-content button')
+      .filter({ has: page.locator('mat-icon:has-text("lock_open")') });
+    await lockBtn.click();
+
+    const wwwAnchor = note.locator(`a:has-text("${unique}-www")`);
+    await expect(wwwAnchor).toBeVisible();
+    expect(await wwwAnchor.getAttribute('href')).toBe('http://www.example.com');
+
+    await expect(note.locator(`a:has-text("${unique}-file")`)).toHaveCount(0);
+    await expect(note).toContainText(`${unique}-file`);
+
+    const deepLinkAnchor = note.locator(`a:has-text("${unique}-dt")`);
+    await expect(deepLinkAnchor).toBeVisible();
+    expect(await deepLinkAnchor.getAttribute('href')).toBe('x-devonthink-item://abc123');
+  });
+});

--- a/electron/shared-with-frontend/is-external-url-allowed.ts
+++ b/electron/shared-with-frontend/is-external-url-allowed.ts
@@ -14,10 +14,13 @@
  * exists to block. They are allow-listed because productivity users routinely
  * link tasks to such apps (#8429: obsidian:// links stopped opening after the
  * GHSA-hr87 fix; #8859: outlook: deep-links to mail items; #9292: siyuan://
- * links to notes). The GHSA-hr87 fix was a regression that silently broke every
- * previously-working scheme at once, so the popular note/task apps in this same
- * low-risk class (notion:, things:, omnifocus:, bear:, joplin:) are restored
- * proactively alongside #8859.
+ * links to notes; x-devonthink-item: links to DEVONthink documents, reported by
+ * email with no issue). The GHSA-hr87 fix was a regression that silently broke
+ * every previously-working scheme at once, so the popular note/task apps in this
+ * same low-risk class (notion:, things:, omnifocus:, bear:, joplin:) are
+ * restored proactively alongside #8859.
+ * Admission criterion: the payload must be an opaque app-internal identifier —
+ * reject any scheme that takes a filesystem path, URL, content body or command.
  * shortcut: a curated set — if a user needs a scheme that isn't here, the
  * upgrade path is a user-configurable allowlist in settings (MiscConfig).
  *
@@ -44,6 +47,7 @@ export const ALLOWED_EXTERNAL_URL_SCHEMES = [
   'siyuan:',
   'outlook:', // #8859 — Outlook desktop deep-links (outlook:<EntryID>)
   'webexteams:',
+  'x-devonthink-item:', // DEVONthink item links (x-devonthink-item://<uuid>)
 ];
 
 const LOCAL_FILE_URL_PREFIX = 'file:///';

--- a/src/app/ui/is-external-url-allowed.spec.ts
+++ b/src/app/ui/is-external-url-allowed.spec.ts
@@ -33,6 +33,8 @@ describe('isExternalUrlSchemeAllowed', () => {
       // #8859 — Outlook desktop deep-link: opaque EntryID, no `//` authority.
       'outlook:0000000067E6410516B83D47AC4C8EB786CE10920700A34574545A43BF41AC9C4F77801FE8E100000000010C0000A34574545A43BF41AC9C4F77801FE8E10009672045BC0000',
       'webexteams://im?space=ff135070-68f8-11f1-9229-c7e6cca7a7cd&message=f4f13440-6b50-11f1-8868-03e71232fa87',
+      // DEVONthink item link — same app-deep-link class as obsidian:/zotero:.
+      'x-devonthink-item://23082026-1234-5678-9ABC-DEF012345678',
     ];
     allowed.forEach((url) => {
       it(`allows "${url}"`, () => {
@@ -61,6 +63,7 @@ describe('isExternalUrlSchemeAllowed', () => {
         'siyuan:',
         'outlook:',
         'webexteams:',
+        'x-devonthink-item:',
       ]);
     });
   });

--- a/src/app/ui/link-href.util.spec.ts
+++ b/src/app/ui/link-href.util.spec.ts
@@ -1,0 +1,82 @@
+import { toRenderableHref } from './link-href.util';
+
+describe('toRenderableHref', () => {
+  describe('hrefs that already carry an allow-listed scheme', () => {
+    [
+      'http://example.com',
+      'https://example.com/path?q=1#frag',
+      'mailto:user@example.com',
+      'tel:+1234567890',
+      'file:///home/user/notes.txt',
+      'obsidian://open?vault=Notes',
+      'x-devonthink-item://23082026-1234-5678-9ABC-DEF012345678',
+    ].forEach((href) => {
+      it(`returns "${href}" untouched`, () => {
+        expect(toRenderableHref(href)).toBe(href);
+      });
+    });
+
+    it('trims surrounding whitespace so the validated and rendered strings match', () => {
+      expect(toRenderableHref('  https://example.com  ')).toBe('https://example.com');
+    });
+  });
+
+  describe('schemeless web hosts', () => {
+    [
+      ['www.example.com', 'http://www.example.com'],
+      ['www.example.com/path', 'http://www.example.com/path'],
+      ['example.com/path?q=1', 'http://example.com/path?q=1'],
+      ['sub.example.co.uk/x#frag', 'http://sub.example.co.uk/x#frag'],
+      ['//example.com/x', 'https://example.com/x'],
+    ].forEach(([raw, expected]) => {
+      it(`normalizes "${raw}" to "${expected}"`, () => {
+        expect(toRenderableHref(raw)).toBe(expected);
+      });
+    });
+  });
+
+  describe('not renderable as a link', () => {
+    [
+      // Unsafe schemes (GHSA-hr87-735w-hfq3).
+      'javascript:alert(1)',
+      'data:text/html,<script>alert(1)</script>',
+      'vbscript:msgbox(1)',
+      'ms-msdt:/id PCWDiagnostic',
+      'ftp://files.example.com',
+      'file://host/share',
+      '\\\\host\\share',
+      // Relative / in-document targets — nothing sensible to open externally.
+      '#section',
+      './notes.md',
+      '/abs/path',
+      '',
+      '   ',
+      // `.md`/`.zip`/`.mov` are registrable TLDs: a relative file reference must
+      // never become a one-click visit to a stranger's domain.
+      'readme.md',
+      'report.zip',
+      'screenshot.mov',
+      // A bare host is the same string shape as the above, so it stays text.
+      'example.com',
+      // Scheme-shaped hrefs must reach the gate unrewritten, so a future
+      // dot-containing allow-listed scheme cannot be hijacked by the prefix.
+      'com.acme.notes://abc',
+      'ms.msdt:1234',
+      // `host:port@other` is userinfo, not a port — never a bare host.
+      'trusted-bank.com:8080@evil.com/login',
+    ].forEach((href) => {
+      it(`returns null for "${href}"`, () => {
+        expect(toRenderableHref(href)).toBeNull();
+      });
+    });
+  });
+
+  it('normalizes to a string the scheme gate itself accepts', () => {
+    // The value handed to the anchor is the value that was validated — the
+    // check-one-thing-render-another gap is what makes this pattern leak.
+    ['www.example.com', 'example.com/x', '//example.com/x'].forEach((raw) => {
+      const href = toRenderableHref(raw) as string;
+      expect(href.startsWith('http://') || href.startsWith('https://')).toBe(true);
+    });
+  });
+});

--- a/src/app/ui/link-href.util.ts
+++ b/src/app/ui/link-href.util.ts
@@ -1,0 +1,54 @@
+import { isExternalUrlSchemeAllowed } from '../../../electron/shared-with-frontend/is-external-url-allowed';
+
+/**
+ * Schemeless href that is unambiguously a web host: a `www.` host, or a host
+ * followed by a path/query/fragment (`example.com/path?q=1`).
+ *
+ * A bare `readme.md` deliberately does NOT match: `.md`, `.zip` and `.mov` are
+ * registrable TLDs, so prefixing it would turn a relative file reference into a
+ * one-click visit to a stranger's domain. A bare `example.com` is the same
+ * string shape and is therefore left as text too — the two are indistinguishable
+ * without a TLD list, and rendering plain text is the safe half of that trade.
+ *
+ * A `:` never starts the tail, so a scheme-shaped href (`com.acme.notes://x`,
+ * `ms.msdt:1234`) and a userinfo-disguised host (`bank.com:8080@evil.com/x`)
+ * both stay out of the match set.
+ */
+const BARE_HOST_RE =
+  /^(?:www\.[a-z0-9-]+(?:\.[a-z0-9-]+)*|[a-z0-9][a-z0-9-]*(?:\.[a-z0-9-]+)+(?=[/?#]))/i;
+
+const _withScheme = (href: string): string => {
+  if (href.startsWith('//')) {
+    return `https:${href}`;
+  }
+  return BARE_HOST_RE.test(href) ? `http://${href}` : href;
+};
+
+/**
+ * Resolve a raw link target — a markdown href or an auto-detected URL — into the
+ * value to put into an anchor's `href`, or `null` when it must not be rendered
+ * as a link.
+ *
+ * Single source of truth for both link renderers (markdown notes via
+ * `markedOptionsFactory`, task titles via `renderLinks`) so the two cannot
+ * drift: the same string is both validated and rendered, and an href that
+ * already carries an allow-listed scheme is returned untouched — never
+ * rewritten before {@link isExternalUrlSchemeAllowed} has judged it.
+ *
+ * Anything else (relative paths, fragments, `\\host` UNC, unknown schemes) is
+ * left for the gate to reject, which is what makes the caller render it as
+ * inert text. See GHSA-hr87-735w-hfq3 for why the gate exists at all.
+ */
+export const toRenderableHref = (raw: string): string | null => {
+  const trimmed = typeof raw === 'string' ? raw.trim() : '';
+  if (!trimmed) {
+    return null;
+  }
+  if (isExternalUrlSchemeAllowed(trimmed)) {
+    return trimmed;
+  }
+  const withScheme = _withScheme(trimmed);
+  return withScheme !== trimmed && isExternalUrlSchemeAllowed(withScheme)
+    ? withScheme
+    : null;
+};

--- a/src/app/ui/marked-options-factory.spec.ts
+++ b/src/app/ui/marked-options-factory.spec.ts
@@ -391,6 +391,7 @@ describe('markedOptionsFactory', () => {
           'obsidian://open?vault=Notes',
           'vscode://file/home/user/x.ts',
           'siyuan://blocks/20240101000000-abcdefg',
+          'x-devonthink-item://23082026-1234-5678-9ABC-DEF012345678',
           'webexteams://im?space=ff135070-68f8-11f1-9229-c7e6cca7a7cd&message=f4f13440-6b50-11f1-8868-03e71232fa87',
         ].forEach((href) => {
           const result = linkRenderer({
@@ -399,6 +400,51 @@ describe('markedOptionsFactory', () => {
             tokens: [{ type: 'text', raw: 'L', text: 'L' }],
           } as any);
           expect(result).toContain(`href="${escapeHtmlAttr(href)}"`);
+        });
+      });
+
+      it('renders a schemeless bare-domain link as an http:// anchor', () => {
+        const linkRenderer = options.renderer!.link.bind({ parser: mockParser });
+        [
+          ['www.example.com', 'http://www.example.com'],
+          ['example.com/path?q=1', 'http://example.com/path?q=1'],
+          // Protocol-relative — same handling as in task titles (renderLinks).
+          ['//example.com', 'https://example.com'],
+        ].forEach(([href, expected]) => {
+          const result = linkRenderer({
+            href,
+            title: '',
+            tokens: [{ type: 'text', raw: 'L', text: 'L' }],
+          } as any);
+          expect(result).toContain(`href="${expected}"`);
+        });
+      });
+
+      it('leaves everything but a bare web host to the scheme gate (still blocked)', () => {
+        const linkRenderer = options.renderer!.link.bind({ parser: mockParser });
+        [
+          '#section',
+          './notes.md',
+          '/abs/path',
+          // Registrable TLDs: a note's relative file reference must not become a
+          // one-click visit to a stranger's domain.
+          'readme.md',
+          'report.zip',
+          'example.com',
+          // Scheme-shaped hrefs must reach the gate unrewritten, so a future
+          // dot-containing allowlisted scheme cannot be hijacked by the prefix.
+          'com.evil.app://x',
+          'ms.msdt:1234',
+          // `host:port@other` is userinfo, not a port — never a bare host.
+          'trusted-bank.com:8080@evil.com/login',
+        ].forEach((href) => {
+          const result = linkRenderer({
+            href,
+            title: '',
+            tokens: [{ type: 'text', raw: 'Click here', text: 'Click here' }],
+          } as any);
+          expect(result).withContext(href).not.toContain('<a ');
+          expect(result).withContext(href).toContain('Click here');
         });
       });
 

--- a/src/app/ui/marked-options-factory.ts
+++ b/src/app/ui/marked-options-factory.ts
@@ -5,10 +5,8 @@ import {
   type TokenizerExtensionFunction,
   type TokenizerStartFunction,
 } from 'marked';
-import {
-  isExternalUrlSchemeAllowed,
-  isPathSafeToOpen,
-} from '../../../electron/shared-with-frontend/is-external-url-allowed';
+import { isPathSafeToOpen } from '../../../electron/shared-with-frontend/is-external-url-allowed';
+import { toRenderableHref } from './link-href.util';
 import { escapeHtml } from '../util/escape-html';
 
 /**
@@ -165,10 +163,11 @@ export const markedOptionsFactory = (): MarkedOptions => {
     // Block unsafe URL schemes from rendering as clickable links. On click the
     // href is passed verbatim to shell.openExternal (Electron), which would let
     // note content silently invoke OS protocol handlers. See GHSA-hr87-735w-hfq3.
-    if (!isExternalUrlSchemeAllowed(href)) {
+    const url = toRenderableHref(href);
+    if (!url) {
       return `<span class="markdown-blocked-link" title="Link blocked: unsafe URL scheme">${text}</span>`;
     }
-    return `<a target="_blank" rel="noopener noreferrer" href="${escapeHtmlAttr(href)}" title="${escapeHtmlAttr(title || '')}">${text}</a>`;
+    return `<a target="_blank" rel="noopener noreferrer" href="${escapeHtmlAttr(url)}" title="${escapeHtmlAttr(title || '')}">${text}</a>`;
   };
 
   // Custom image renderer with support for sizing syntax

--- a/src/app/ui/pipes/render-links.pipe.ts
+++ b/src/app/ui/pipes/render-links.pipe.ts
@@ -1,6 +1,6 @@
 import { inject, Pipe, PipeTransform } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
-import { ALLOWED_EXTERNAL_URL_SCHEMES } from '../../../../electron/shared-with-frontend/is-external-url-allowed';
+import { toRenderableHref } from '../link-href.util';
 
 /** Hint substrings used for fast pre-checks to skip regex when no URLs/markdown are present. */
 export const LINK_HINT_PROTOCOL = '://';
@@ -15,7 +15,7 @@ export const hasLinkHints = (text: string): boolean =>
 
 // URL regex matching URLs with protocol (http, https, file, webexteams) or www prefix.
 // ftp://, ssh://, blob:, etc. are intentionally excluded — they are either
-// non-browsable or handled by _isUrlSchemeSafe's denylist for markdown links.
+// non-browsable or rejected by toRenderableHref's scheme gate anyway.
 // Limit URL length to 2000 chars to prevent ReDoS attacks.
 const URL_REGEX =
   /(?:(?:https?|file|webexteams):\/\/\S{1,2000}(?=\s|$)|www\.\S{1,2000}(?=\s|$))/gi;
@@ -39,7 +39,6 @@ const HTML_ESCAPE_MAP: Record<string, string> = {
   "'": '&#39;',
 };
 /* eslint-enable @typescript-eslint/naming-convention */
-const SCHEME_RE = /^[a-z]+:/i;
 const TRAILING_PUNCT_RE = /[.,;!?]+$/;
 
 interface LinkMatch {
@@ -93,53 +92,6 @@ const _stripUrlTrailing = (raw: string): string => {
   return end < url.length ? url.substring(0, end) : url;
 };
 
-const _isUrlSchemeSafe = (url: string): boolean => {
-  const lowerUrl = url.trimStart().toLowerCase();
-  if (!lowerUrl) return false;
-  if (
-    lowerUrl.startsWith('http://') ||
-    lowerUrl.startsWith('https://') ||
-    lowerUrl.startsWith('file://') ||
-    lowerUrl.startsWith('//')
-  ) {
-    return true;
-  }
-  // Allow the shared deep-link / standard schemes (mailto:, tel:, obsidian:,
-  // vscode:, …) so links behave the same here as in the markdown note renderer.
-  // The dangerous schemes (javascript:, data:, vbscript:, ms-msdt:, …) are not
-  // in the allowlist and fall through to the scheme-shaped rejection below. #8429
-  if (ALLOWED_EXTERNAL_URL_SCHEMES.some((scheme) => lowerUrl.startsWith(scheme))) {
-    return true;
-  }
-  // Reject any URL that looks like it has a scheme (letters followed by colon).
-  // This catches javascript:, data:, vbscript:, ftp://, ssh://, etc.
-  // Does NOT match host:port (e.g. www.example.com:8080) because dots precede the colon.
-  if (SCHEME_RE.test(lowerUrl)) {
-    return false;
-  }
-  return true;
-};
-
-const _normalizeHref = (url: string): string => {
-  if (
-    url.startsWith('http://') ||
-    url.startsWith('https://') ||
-    url.startsWith('file://')
-  ) {
-    return url;
-  }
-  if (url.startsWith('//')) {
-    return `https:${url}`;
-  }
-  // Preserve an allow-listed scheme (mailto:, tel:, obsidian:, vscode:, …)
-  // verbatim; only schemeless host-style URLs get an http:// prefix. #8429
-  const lower = url.toLowerCase();
-  if (ALLOWED_EXTERNAL_URL_SCHEMES.some((scheme) => lower.startsWith(scheme))) {
-    return url;
-  }
-  return `http://${url}`;
-};
-
 /**
  * Single-pass link rendering: collects all markdown-link and plain-URL
  * matches sorted by position, then walks the string once, HTML-escaping
@@ -190,10 +142,10 @@ const _buildLinksHtml = (text: string): string => {
   for (const match of matches) {
     out.push(_escapeHtml(text.slice(cursor, match.index)));
 
-    if (!_isUrlSchemeSafe(match.url)) {
+    const href = toRenderableHref(match.url);
+    if (!href) {
       out.push(_escapeHtml(match.title));
     } else {
-      const href = _normalizeHref(match.url);
       const ariaLabel = match.isMarkdown ? '' : _ariaLabelForUrl(href);
       out.push(
         `<a href="${_escapeHtml(href)}"${ariaLabel} target="_blank" rel="noopener noreferrer">${_escapeHtml(match.title)}</a>`,


### PR DESCRIPTION
Reported by email: on macOS, clicking a task attachment or note link like `x-devonthink-item://<uuid>` does nothing, and markdown links can show "Link blocked: unsafe URL scheme". Both work on iOS/iPadOS.

## The DEVONthink link

`x-devonthink-item:` was missing from `ALLOWED_EXTERNAL_URL_SCHEMES`, so `IPC.OPEN_EXTERNAL` returned silently — hence "nothing happens". Mobile never hit it because it doesn't go through that gate.

It's the same narrow app-deep-link class as `obsidian:`/`zotero:`/`siyuan:`: an opaque record id, no path, no command. A security review judged it a *smaller* surface than two schemes already on the list (`obsidian://new?path=…&content=…` can write vault files, `vscode://file/…` opens arbitrary paths), and nothing like the OS handlers the allowlist exists to block (`ms-msdt:`, `search-ms:`).

## The blocked markdown link

I could not reproduce this for a literal `http://` URL — that scheme is allow-listed and renders fine. What does produce that exact message is a **schemeless** href (`[test](www.example.com)`): `new URL()` throws, so the gate rejects it.

Both link renderers now resolve a target through one helper, `toRenderableHref()`, which returns the href to render or `null`:

- a `www.` host, or a host followed by a path/query/fragment, becomes an `http://` link; `//host` becomes `https:`
- a bare `readme.md` or `example.com` deliberately does **not** — `.md`, `.zip` and `.mov` are registrable TLDs, and a relative file reference must never become a one-click visit to a stranger's domain. The two shapes are indistinguishable without a TLD list, so the ambiguous case renders as text.
- an href that already carries an allow-listed scheme is returned untouched, so a future dot-containing scheme (`com.acme.notes:`) can't be rewritten before the gate sees it
- the validated string is the rendered string, so the renderer and the main-process re-check can't disagree

This replaces the divergent normalization that `markedOptionsFactory` and `renderLinks` each had (`render-links.pipe.ts` shrinks 236 → 188 lines).

## Behavior changes

All in **task titles** — notes were already the stricter side:

| href in a title | before | after |
| --- | --- | --- |
| `file://evil.com/share` | anchor, relied on the main-process gate | text |
| `./notes.md`, `#frag` | `http://./notes.md`, `http://#frag` | text |
| `readme.md`, `report.zip` | `http://readme.md` | text |
| `user@example.com` | `http://user@example.com` | text |
| bare `example.com` | link | text |

Notes gain one thing in return: `//example.com` resolves to `https://example.com`, matching titles.

## Verification

- New `link-href.util.spec.ts` (33) pins the whole href table, including `com.acme.notes://abc`, `ms.msdt:1234` and `bank.com:8080@evil.com/login`
- `marked-options-factory.spec.ts` 73, `render-links.pipe.spec.ts` 32 (unchanged), `is-external-url-allowed.spec.ts` 65, `npm run test:electron` 287, `tsc --noEmit` clean
- New e2e `e2e/tests/notes/note-link-href.spec.ts` asserts the three outcomes in **both** renderers (markdown + locked/`renderLinks`) in the real app. Verified as a regression test: both tests fail against `master` — the markdown renderer doesn't produce the `www` anchor, and `renderLinks` turns `readme.md` into one.
- Angular's `SAFE_URL_PATTERN` admits any non-`javascript:` scheme, so `x-devonthink-item:` survives the `SecurityContext.HTML` sanitization applied to markdown (checked in `node_modules`, not inferred from the obsidian precedent)

Not verified: the OS handler actually launching on macOS with DEVONthink installed — no browser-based test can reach that leg.

https://claude.ai/code/session_01E8LsQyU9aBRm5DdieFpXrS