### PR TITLE
fix(nav): round sidenav additional-btn to match the row's hover shape

### DIFF
--- a/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.scss
+++ b/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.scss
@@ -54,10 +54,28 @@
     }
   }
 
+  // Fixed 32px rounded chip, matching the row's hover radius and the
+  // additional-btn used inside nav-list-tree — otherwise :host's
+  // align-items:stretch stretches this to the full (square) row height.
   .additional-btn {
     flex-shrink: 0;
-    width: 40px !important;
-    min-width: 40px !important;
+    align-self: center;
+    width: 32px !important;
+    height: 32px !important;
+    min-width: 32px !important;
+    border-radius: 6px !important;
+
+    &.mat-mdc-icon-button {
+      --mdc-icon-button-state-layer-size: 32px;
+      border-radius: 6px !important;
+    }
+
+    ::ng-deep {
+      .mat-mdc-button-persistent-ripple,
+      .mat-ripple-element {
+        border-radius: 6px !important;
+      }
+    }
   }
 
   &.isHidden {

--- a/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.scss
+++ b/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.scss
@@ -54,9 +54,11 @@
     }
   }
 
-  // Fixed 32px rounded chip, matching the row's hover radius and the
-  // additional-btn used inside nav-list-tree — otherwise :host's
-  // align-items:stretch stretches this to the full (square) row height.
+  // Fixed 32px chip, matching the additional-btn used inside nav-list-tree —
+  // otherwise :host's align-items:stretch stretches this to the full (square)
+  // row height. The rounded shape itself now comes from the shared
+  // src/styles/components/multi-btn-wrapper.scss layer (this button is a
+  // direct child of the .g-multi-btn-wrapper host), not from local overrides.
   // Without a gap, this button's rounded corners sit flush against
   // .nav-link's, and two same-color rounded boxes touching at zero gap
   // pinch into a visible notch.
@@ -66,19 +68,13 @@
     width: 32px !important;
     height: 32px !important;
     min-width: 32px !important;
+    padding: var(--s-half) !important;
     margin-left: var(--s-half);
-    border-radius: 6px !important;
 
-    &.mat-mdc-icon-button {
-      --mdc-icon-button-state-layer-size: 32px;
-      border-radius: 6px !important;
-    }
-
-    ::ng-deep {
-      .mat-mdc-button-persistent-ripple,
-      .mat-ripple-element {
-        border-radius: 6px !important;
-      }
+    mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
     }
   }
 

--- a/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.scss
+++ b/src/app/core-ui/magic-side-nav/nav-item/nav-item.component.scss
@@ -57,12 +57,16 @@
   // Fixed 32px rounded chip, matching the row's hover radius and the
   // additional-btn used inside nav-list-tree — otherwise :host's
   // align-items:stretch stretches this to the full (square) row height.
+  // Without a gap, this button's rounded corners sit flush against
+  // .nav-link's, and two same-color rounded boxes touching at zero gap
+  // pinch into a visible notch.
   .additional-btn {
     flex-shrink: 0;
     align-self: center;
     width: 32px !important;
     height: 32px !important;
     min-width: 32px !important;
+    margin-left: var(--s-half);
     border-radius: 6px !important;
 
     &.mat-mdc-icon-button {

--- a/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.scss
+++ b/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.scss
@@ -76,27 +76,34 @@
   color: var(--sidenav-text-secondary);
   background: transparent;
   border: none;
-  // Match .nav-link's rounded hover shape (6px) instead of Material's default
+  // Match .nav-link's rounded hover shape instead of Material's default
   // circle, so the row and its buttons read as one consistent hover language.
-  border-radius: 6px !important;
+  // This button sits inside an extra .additional-btns wrapper div, so it's
+  // not a direct child of .g-multi-btn-wrapper — the shared
+  // src/styles/components/multi-btn-wrapper.scss layer's radius fix doesn't
+  // reach it, so it still needs its own override here.
+  border-radius: var(--radius-sm) !important;
   cursor: pointer;
 
   // Override Material Design button styles
   &.mat-mdc-icon-button {
     --mdc-icon-button-state-layer-size: 32px;
     --mdc-icon-button-icon-size: 18px;
-    border-radius: 6px !important;
+    border-radius: var(--radius-sm) !important;
     width: 32px !important;
     height: 32px !important;
     padding: var(--s-half) !important;
   }
 
-  // Material's ripple/state-layer defaults to a circle regardless of the
-  // button's own border-radius — match it to the button above.
+  // .mat-mdc-button-persistent-ripple (the hover/focus state layer) defaults
+  // to a circle regardless of the button's own border-radius — match it to
+  // the button above. .mat-ripple-element (the press ripple) doesn't need
+  // this: it's already clipped to the button's shape by its container's
+  // border-radius:inherit + overflow:hidden, and forcing a radius on it would
+  // turn Material's expanding circle into an expanding rounded square.
   ::ng-deep {
-    .mat-mdc-button-persistent-ripple,
-    .mat-ripple-element {
-      border-radius: 6px !important;
+    .mat-mdc-button-persistent-ripple {
+      border-radius: var(--radius-sm) !important;
     }
   }
 

--- a/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.scss
+++ b/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.scss
@@ -76,26 +76,27 @@
   color: var(--sidenav-text-secondary);
   background: transparent;
   border: none;
-  border-radius: 0 !important; // Override Material Design rounded corners
+  // Match .nav-link's rounded hover shape (6px) instead of Material's default
+  // circle, so the row and its buttons read as one consistent hover language.
+  border-radius: 6px !important;
   cursor: pointer;
 
   // Override Material Design button styles
   &.mat-mdc-icon-button {
     --mdc-icon-button-state-layer-size: 32px;
     --mdc-icon-button-icon-size: 18px;
-    border-radius: 0 !important;
+    border-radius: 6px !important;
     width: 32px !important;
     height: 32px !important;
     padding: var(--s-half) !important;
   }
 
-  // The button itself is squared off above, but Material's ripple/state-layer
-  // defaults to a circle unless told otherwise — match it so hover/focus/ripple
-  // don't show a circle inside a square.
+  // Material's ripple/state-layer defaults to a circle regardless of the
+  // button's own border-radius — match it to the button above.
   ::ng-deep {
     .mat-mdc-button-persistent-ripple,
     .mat-ripple-element {
-      border-radius: 0 !important;
+      border-radius: 6px !important;
     }
   }
 

--- a/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.scss
+++ b/src/app/core-ui/magic-side-nav/nav-list/nav-list-tree.component.scss
@@ -89,6 +89,16 @@
     padding: var(--s-half) !important;
   }
 
+  // The button itself is squared off above, but Material's ripple/state-layer
+  // defaults to a circle unless told otherwise — match it so hover/focus/ripple
+  // don't show a circle inside a square.
+  ::ng-deep {
+    .mat-mdc-button-persistent-ripple,
+    .mat-ripple-element {
+      border-radius: 0 !important;
+    }
+  }
+
   &:focus,
   &:hover {
     background-color: var(--sidenav-hover-bg);

--- a/src/styles/components/multi-btn-wrapper.scss
+++ b/src/styles/components/multi-btn-wrapper.scss
@@ -20,7 +20,7 @@
   > button:nth-of-type(n + 2),
   > .additional-btn {
     //>  button:last-of-type {
-    border-radius: 0;
+    border-radius: var(--radius-sm);
     align-self: stretch;
     display: inline-flex;
     min-width: 48px;
@@ -31,7 +31,7 @@
     justify-content: center;
 
     .mat-mdc-button-persistent-ripple {
-      border-radius: 0 !important;
+      border-radius: var(--radius-sm) !important;
     }
 
     .mat-mdc-button-touch-target {


### PR DESCRIPTION
## Problem

The small icon buttons in the sidenav (`...` on Today/Inbox/tags/projects, `+`/eye on the Projects/Tags headers) had an inconsistent, glitchy hover shape:

- They were forced square (`border-radius: 0`) while the row around them (`.nav-link`) has a rounded 6px hover.
- Material's ripple/state-layer elements (`.mat-mdc-button-persistent-ripple`, `.mat-ripple-element`) hardcode their own `border-radius: 50%` independent of the button's shape, so hovering showed a circle inside a square box.
- Today/Inbox's `...` button additionally had no explicit `height`, so it stretched to the full row height instead of a fixed size, and sat with zero gap against `.nav-link` — two same-colored rounded corners touching at zero gap pinch into a visible notch on hover.

**Before:** square button, circular ripple inside it, and (on Today/Inbox) a pinched seam where the button touches the row.
**After:** button, ripple, and row all share the same 6px rounded shape, sized consistently, with a small gap so corners never touch.

_(before/after)_
<img width="285" height="58" alt="Screenshot 2026-09-08 222049" src="https://github.com/user-attachments/assets/d58bff38-7562-4694-9069-b8861846e3fb" /> <img width="273" height="54" alt="Screenshot 2026-09-08 222044" src="https://github.com/user-attachments/assets/2ac1cfbd-2883-47c5-9988-e060c0c83280" />


<img width="303" height="50" alt="Screenshot 2026-09-08 222821" src="https://github.com/user-attachments/assets/0f233bc0-5883-4c84-a33a-6d5ffff77566" />
<img width="285" height="57" alt="Screenshot 2026-09-08 222811" src="https://github.com/user-attachments/assets/5c344c5e-55b5-4694-8d27-2043126f127a" />



## Solution

- `nav-list-tree.component.scss`: round the Projects/Tags header `+`/eye buttons and folder `...` buttons to 6px (was hard-forced square), and match the ripple/state-layer shape to it.
- `nav-item.component.scss`: give Today/Inbox's (and tree leaf items') `...` button an explicit 32px size instead of stretching to row height, round it and its ripple to match, and add a small left margin so it doesn't visually pinch against the row on hover.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
