### PR TITLE
ci(e2e): add a run_webdav input to skip the WebDAV job

### DIFF
--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -16,6 +16,11 @@ on:
         required: false
         type: string
         default: '@webdav'
+      run_webdav:
+        description: 'Run the WebDAV job (uncheck to skip it instead of passing a no-match grep)'
+        required: false
+        type: boolean
+        default: true
 
   push:
     branches: [master, release/*]
@@ -122,6 +127,10 @@ jobs:
   e2e-webdav:
     name: E2E Tests (WebDAV)
     needs: [build]
+    # Skip the job outright rather than handing it a no-match grep: Playwright
+    # exits 1 on "No tests found", which reds the whole run. `inputs` is empty
+    # for schedule/push, so gate on the event first.
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_webdav }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:


### PR DESCRIPTION
## Problem

Skipping the WebDAV job on a manual dispatch of `E2E Tests (Scheduled)` meant passing a `webdav_grep` that matches nothing. Playwright exits 1 on `Error: No tests found`, so the whole run goes red even when every test that actually ran passed.

Observed in [run 34246835048](https://github.com/super-productivity/super-productivity/actions/runs/34246835048): dispatched with `webdav_grep: "@webdav-none-match-zzz"`, every other job green, run reported as failed.

```
Running tests with 3 workers in TZ=America/Sao_Paulo
Error: No tests found
##[error]Process completed with exit code 1.
```

## Fix

Add a `run_webdav` boolean input (default `true`) and gate the job on it, so skipping is a skip rather than a failure.

```yaml
if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_webdav }}
```

`inputs` is empty for `schedule` and `push` events, so the condition checks the event name first — the job keeps running by default on every trigger, and only an explicit uncheck on a manual dispatch skips it.

## Notes

- No change to `webdav_grep`; narrowing the WebDAV suite still works as before.
- A skipped job is a more honest signal than a job that passes having run zero tests, which is why this is an input rather than adding `--pass-with-no-tests`.

https://claude.ai/code/session_015idT4iUokG8dsG36Uqy4Bn