### PR TITLE
feat(tasks): copy focused task and sub tasks as markdown checklist

### DIFF
--- a/docs/wiki/3.03-Keyboard-Shortcuts.md
+++ b/docs/wiki/3.03-Keyboard-Shortcuts.md
@@ -93,7 +93,7 @@ The following shortcuts apply for the currently selected task (selected via tab 
 - `Arrow keys`: Navigate around task list
 - In an empty or whitespace-only add-subtask input, `ArrowUp` focuses the preceding subtask or parent task, and `ArrowDown` focuses the next task when available. At the end of the list, focus stays on the closest task row or control.
 - `ArrowRight`: Open additional info panel for currently focused task
-- `Ctrl`+`C` / `Cmd`+`C`: Copy the currently focused task title when focus is on the task, no text is selected, and focus is not inside an input
+- `Ctrl`+`C` / `Cmd`+`C`: Copy the currently focused task and its sub tasks to the clipboard as a markdown checklist (e.g. `- [ ] Parent` with indented `  - [x] Sub task` lines) when focus is on the task, no text is selected, and focus is not inside an input
 
 ## Collapsible Groups
 

--- a/docs/wiki/3.03-Keyboard-Shortcuts.md
+++ b/docs/wiki/3.03-Keyboard-Shortcuts.md
@@ -93,7 +93,7 @@ The following shortcuts apply for the currently selected task (selected via tab 
 - `Arrow keys`: Navigate around task list
 - In an empty or whitespace-only add-subtask input, `ArrowUp` focuses the preceding subtask or parent task, and `ArrowDown` focuses the next task when available. At the end of the list, focus stays on the closest task row or control.
 - `ArrowRight`: Open additional info panel for currently focused task
-- `Ctrl`+`C` / `Cmd`+`C`: Copy the currently focused task and its sub tasks to the clipboard as a markdown checklist (e.g. `- [ ] Parent` with indented `  - [x] Sub task` lines) when focus is on the task, no text is selected, and focus is not inside an input
+- `Ctrl`+`C` / `Cmd`+`C`: Copy the currently focused task and its sub tasks to the clipboard as a markdown checklist (e.g. `- [ ] Parent`, with each sub task indented by two spaces as `- [x] Sub task`) when focus is on the task, no text is selected, and focus is not inside an input
 
 ## Collapsible Groups
 

--- a/e2e/tests/keyboard/copy-task-as-checklist.spec.ts
+++ b/e2e/tests/keyboard/copy-task-as-checklist.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '../../fixtures/test.fixture';
+
+declare global {
+  interface Window {
+    __copiedText?: string;
+  }
+}
+
+test.describe('Copy task as markdown checklist', () => {
+  test('Ctrl+C on a focused task copies it and its sub tasks', async ({
+    page,
+    workViewPage,
+    taskPage,
+    testPrefix,
+  }) => {
+    await workViewPage.waitForTaskList();
+    await workViewPage.addTask('Parent task');
+
+    const parent = taskPage.getTaskByText('Parent task');
+    await workViewPage.addSubTask(parent, 'Sub one');
+    await workViewPage.addSubTask(parent, 'Sub two');
+
+    // clipboard-read cannot be granted in this browser context, so record what
+    // the app hands to the real clipboard API instead of reading it back.
+    await page.evaluate(() => {
+      navigator.clipboard.writeText = (text: string): Promise<void> => {
+        window.__copiedText = text;
+        return Promise.resolve();
+      };
+    });
+
+    await parent.focus();
+    await page.keyboard.press('Control+c');
+
+    await expect
+      .poll(() => page.evaluate(() => window.__copiedText))
+      .toBe(`- [ ] ${testPrefix}-Parent task\n  - [ ] Sub one\n  - [ ] Sub two`);
+  });
+});

--- a/src/app/features/tasks/task-shortcut.service.spec.ts
+++ b/src/app/features/tasks/task-shortcut.service.spec.ts
@@ -606,8 +606,11 @@ describe('TaskShortcutService', () => {
       expect(event.preventDefault).toHaveBeenCalled();
     });
 
-    it('should swallow the key without copying when the task has no store data', () => {
-      stubFocusedTaskData(null);
+    it('should swallow the key without copying when the task is missing from the store', () => {
+      // The exact stub selectTaskByIdWithSubTaskData returns for an unknown id:
+      // no title, no id. In a production build devError only logs, so this
+      // shape really does reach the caller.
+      stubFocusedTaskData({ subTasks: [] });
       const event = createKeyboardEvent('c', 'KeyC', { ctrlKey: true });
 
       const result = service.handleTaskShortcuts(event);

--- a/src/app/features/tasks/task-shortcut.service.spec.ts
+++ b/src/app/features/tasks/task-shortcut.service.spec.ts
@@ -4,6 +4,8 @@ import { TaskFocusService } from './task-focus.service';
 import { TaskService } from './task.service';
 import { GlobalConfigService } from '../config/global-config.service';
 import { signal } from '@angular/core';
+import { of } from 'rxjs';
+import { Task, TaskWithSubTasks } from './task.model';
 
 describe('TaskShortcutService', () => {
   let service: TaskShortcutService;
@@ -76,6 +78,9 @@ describe('TaskShortcutService', () => {
       setCurrentId: jasmine.createSpy('setCurrentId'),
       toggleStartTask: jasmine.createSpy('toggleStartTask'),
       scheduleForTodayById: jasmine.createSpy('scheduleForTodayById'),
+      getByIdWithSubTaskData$: jasmine
+        .createSpy('getByIdWithSubTaskData$')
+        .and.returnValue(of(null)),
     } as any;
 
     mockConfigService = {
@@ -485,9 +490,15 @@ describe('TaskShortcutService', () => {
     });
   });
 
-  describe('copy focused task title shortcut', () => {
+  describe('copy focused task shortcut', () => {
     let originalClipboardDescriptor: PropertyDescriptor | undefined;
     let writeText: jasmine.Spy;
+
+    const stubFocusedTaskData = (task: Partial<TaskWithSubTasks> | null): void => {
+      mockTaskService.getByIdWithSubTaskData$.and.returnValue(
+        of(task as TaskWithSubTasks),
+      );
+    };
 
     beforeEach(() => {
       writeText = jasmine.createSpy('writeText').and.returnValue(Promise.resolve());
@@ -500,6 +511,12 @@ describe('TaskShortcutService', () => {
         value: { writeText },
       });
       setFocusedTask('focused-task-1');
+      stubFocusedTaskData({
+        id: 'focused-task-1',
+        title: 'Task title to copy',
+        isDone: false,
+        subTasks: [],
+      });
       mockTaskFocusService.lastFocusedTaskComponent.set({
         task: () => ({ id: 'focused-task-1', title: 'Task title to copy' }),
         taskContextMenu: () => undefined,
@@ -515,25 +532,25 @@ describe('TaskShortcutService', () => {
       originalClipboardDescriptor = undefined;
     });
 
-    it('should copy the focused task title on Ctrl+C', () => {
+    it('should copy the focused task as a markdown checklist on Ctrl+C', () => {
       const event = createKeyboardEvent('c', 'KeyC', { ctrlKey: true });
       spyOn(event, 'preventDefault');
 
       const result = service.handleTaskShortcuts(event);
 
       expect(result).toBe(true);
-      expect(writeText).toHaveBeenCalledWith('Task title to copy');
+      expect(writeText).toHaveBeenCalledWith('- [ ] Task title to copy');
       expect(event.preventDefault).toHaveBeenCalled();
     });
 
-    it('should copy the focused task title on Cmd+C', () => {
+    it('should copy the focused task as a markdown checklist on Cmd+C', () => {
       const event = createKeyboardEvent('c', 'KeyC', { metaKey: true });
       spyOn(event, 'preventDefault');
 
       const result = service.handleTaskShortcuts(event);
 
       expect(result).toBe(true);
-      expect(writeText).toHaveBeenCalledWith('Task title to copy');
+      expect(writeText).toHaveBeenCalledWith('- [ ] Task title to copy');
       expect(event.preventDefault).toHaveBeenCalled();
     });
 
@@ -547,8 +564,56 @@ describe('TaskShortcutService', () => {
       const result = service.handleTaskShortcuts(event);
 
       expect(result).toBe(true);
-      expect(writeText).toHaveBeenCalledWith('Task title to copy');
+      expect(writeText).toHaveBeenCalledWith('- [ ] Task title to copy');
       expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it('should copy sub tasks as an indented checklist', () => {
+      stubFocusedTaskData({
+        id: 'focused-task-1',
+        title: 'Parent',
+        isDone: false,
+        subTasks: [
+          { title: 'Sub done', isDone: true },
+          { title: 'Sub open', isDone: false },
+        ] as Task[],
+      });
+      const event = createKeyboardEvent('c', 'KeyC', { ctrlKey: true });
+
+      const result = service.handleTaskShortcuts(event);
+
+      expect(result).toBe(true);
+      expect(writeText).toHaveBeenCalledWith(
+        '- [ ] Parent\n  - [x] Sub done\n  - [ ] Sub open',
+      );
+    });
+
+    it('should copy the task under the focus border even when lastFocusedTaskComponent is stale', () => {
+      mockTaskFocusService.lastFocusedTaskComponent.set({
+        task: () => ({ id: 'some-other-task', title: 'Stale title' }),
+        taskContextMenu: () => undefined,
+      });
+      const event = createKeyboardEvent('c', 'KeyC', { ctrlKey: true });
+      spyOn(event, 'preventDefault');
+
+      const result = service.handleTaskShortcuts(event);
+
+      expect(result).toBe(true);
+      expect(mockTaskService.getByIdWithSubTaskData$).toHaveBeenCalledWith(
+        'focused-task-1',
+      );
+      expect(writeText).toHaveBeenCalledWith('- [ ] Task title to copy');
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it('should swallow the key without copying when the task has no store data', () => {
+      stubFocusedTaskData(null);
+      const event = createKeyboardEvent('c', 'KeyC', { ctrlKey: true });
+
+      const result = service.handleTaskShortcuts(event);
+
+      expect(result).toBe(true);
+      expect(writeText).not.toHaveBeenCalled();
     });
 
     it('should not override native copy when the event target is an input', () => {

--- a/src/app/features/tasks/task-shortcut.service.ts
+++ b/src/app/features/tasks/task-shortcut.service.ts
@@ -368,7 +368,10 @@ export class TaskShortcutService {
       // getByIdWithSubTaskData$ is a `take(1)` store select, so this resolves
       // synchronously — no cleanup needed.
       .subscribe((task) => {
-        if (!task) {
+        // For an unknown id the selector logs a devError and returns a
+        // `{ subTasks: [] }` stub with no id and no title — in a production
+        // build that stub really reaches us, so check for a real task.
+        if (!task?.id) {
           Log.warn('No task data to copy for focused task');
           return;
         }

--- a/src/app/features/tasks/task-shortcut.service.ts
+++ b/src/app/features/tasks/task-shortcut.service.ts
@@ -9,6 +9,7 @@ import { TaskContextMenuComponent } from './task-context-menu/task-context-menu.
 import { TaskContextMenuInnerComponent } from './task-context-menu/task-context-menu-inner/task-context-menu-inner.component';
 import { isInputElement } from '../../util/dom-element';
 import { getDomFocusedTaskId } from './get-dom-focused-task-id';
+import { taskToMarkdownChecklist } from './task-to-markdown-checklist';
 
 type TaskId = string;
 
@@ -105,9 +106,9 @@ export class TaskShortcutService {
       return false;
     }
 
-    // Ctrl+C / Cmd+C: copy focused task title. Match on `code` (physical
-    // position) so the shortcut still fires on non-Latin layouts, mirroring
-    // how the browser's native copy is bound.
+    // Ctrl+C / Cmd+C: copy the focused task and its sub tasks as a markdown
+    // checklist. Match on `code` (physical position) so the shortcut still
+    // fires on non-Latin layouts, mirroring how native copy is bound.
     if ((ev.ctrlKey || ev.metaKey) && !ev.altKey && !ev.shiftKey && ev.code === 'KeyC') {
       const target = ev.target;
       const hasTextSelected = !!window.getSelection()?.toString();
@@ -115,17 +116,12 @@ export class TaskShortcutService {
         !(target instanceof HTMLElement && isInputElement(target)) &&
         !hasTextSelected
       ) {
-        const taskComponent = this._taskFocusService.lastFocusedTaskComponent();
-        // getDomFocusedTaskId() can derive focusedTaskId from the DOM before
-        // lastFocusedTaskComponent has caught up — fall through to native copy
-        // rather than copying a stale title.
-        if (taskComponent?.task().id === focusedTaskId) {
-          void navigator.clipboard?.writeText(taskComponent.task().title).catch((err) => {
-            Log.warn('Failed to copy task title to clipboard:', err);
-          });
-          ev.preventDefault();
-          return true;
-        }
+        // Read from the store rather than lastFocusedTaskComponent, which can
+        // lag behind the DOM-derived focusedTaskId — the task under the focus
+        // border must always be the one that lands on the clipboard.
+        this._copyTaskAsMarkdownChecklist(focusedTaskId);
+        ev.preventDefault();
+        return true;
       }
     }
 
@@ -361,6 +357,27 @@ export class TaskShortcutService {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Writes the task and its sub tasks to the clipboard as a markdown checklist.
+   */
+  private _copyTaskAsMarkdownChecklist(taskId: TaskId): void {
+    this._taskService
+      .getByIdWithSubTaskData$(taskId)
+      // getByIdWithSubTaskData$ is a `take(1)` store select, so this resolves
+      // synchronously — no cleanup needed.
+      .subscribe((task) => {
+        if (!task) {
+          Log.warn('No task data to copy for focused task');
+          return;
+        }
+        void navigator.clipboard
+          ?.writeText(taskToMarkdownChecklist(task))
+          .catch((err) => {
+            Log.warn('Failed to copy task to clipboard:', err);
+          });
+      });
   }
 
   /**

--- a/src/app/features/tasks/task-to-markdown-checklist.spec.ts
+++ b/src/app/features/tasks/task-to-markdown-checklist.spec.ts
@@ -1,0 +1,33 @@
+import { taskToMarkdownChecklist } from './task-to-markdown-checklist';
+import { Task, TaskWithSubTasks } from './task.model';
+
+const task = (title: string, isDone = false): Task => ({ title, isDone }) as Task;
+
+const parent = (title: string, subTasks: Task[] = [], isDone = false): TaskWithSubTasks =>
+  ({ title, isDone, subTasks }) as TaskWithSubTasks;
+
+describe('taskToMarkdownChecklist', () => {
+  it('should render a task without sub tasks as a single checklist item', () => {
+    expect(taskToMarkdownChecklist(parent('Write docs'))).toBe('- [ ] Write docs');
+  });
+
+  it('should mark done tasks with [x]', () => {
+    expect(taskToMarkdownChecklist(parent('Write docs', [], true))).toBe(
+      '- [x] Write docs',
+    );
+  });
+
+  it('should indent sub tasks and keep their done state', () => {
+    const result = taskToMarkdownChecklist(
+      parent('Ship feature', [task('Implement', true), task('Test')]),
+    );
+
+    expect(result).toBe('- [ ] Ship feature\n  - [x] Implement\n  - [ ] Test');
+  });
+
+  it('should collapse whitespace so a title cannot break the checklist', () => {
+    expect(taskToMarkdownChecklist(parent(' Multi\nline   title '))).toBe(
+      '- [ ] Multi line title',
+    );
+  });
+});

--- a/src/app/features/tasks/task-to-markdown-checklist.ts
+++ b/src/app/features/tasks/task-to-markdown-checklist.ts
@@ -1,0 +1,22 @@
+import { Task, TaskWithSubTasks } from './task.model';
+
+const SUB_TASK_INDENT = '  ';
+
+// Titles are single-line in the UI, but short syntax and paste can smuggle in
+// newlines — collapsing keeps every task on exactly one checklist line.
+const toChecklistLine = (task: Task, indent: string): string =>
+  `${indent}- [${task.isDone ? 'x' : ' '}] ${task.title.replace(/\s+/g, ' ').trim()}`;
+
+/**
+ * Render a task and its sub tasks as a markdown checklist, e.g.
+ *
+ * ```
+ * - [ ] Parent
+ *   - [x] Sub task
+ * ```
+ */
+export const taskToMarkdownChecklist = (task: TaskWithSubTasks): string =>
+  [
+    toChecklistLine(task, ''),
+    ...task.subTasks.map((subTask) => toChecklistLine(subTask, SUB_TASK_INDENT)),
+  ].join('\n');

--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/dougcooper/sp-reporter",
     "author": "dougcooper",
     "authorUrl": "https://github.com/dougcooper",
-    "stars": 32
+    "stars": 58
   },
   {
     "name": "Archived Tasks Viewer",
@@ -13,7 +13,7 @@
     "url": "https://github.com/baiyina/Archived-Tasks-Viewer",
     "author": "baiyina",
     "authorUrl": "https://github.com/baiyina",
-    "stars": 31
+    "stars": 61
   },
   {
     "name": "QuestArc",
@@ -21,7 +21,7 @@
     "url": "https://codeberg.org/Nexumia/QuestArc",
     "author": "Nexumia",
     "authorUrl": "https://codeberg.org/Nexumia",
-    "stars": 4
+    "stars": 8
   },
   {
     "name": "AutoPlan",
@@ -29,7 +29,7 @@
     "url": "https://codeberg.org/00sapo/sp-autoplan",
     "author": "00sapo",
     "authorUrl": "https://codeberg.org/00sapo",
-    "stars": 28
+    "stars": 13
   },
   {
     "name": "Asana Integration",
@@ -37,7 +37,7 @@
     "url": "https://codeberg.org/sinenomine/sp-asana",
     "author": "sinenomine",
     "authorUrl": "https://codeberg.org/sinenomine",
-    "stars": 0
+    "stars": 2
   },
   {
     "name": "Obsidian Integration",
@@ -45,7 +45,7 @@
     "url": "https://codeberg.org/sinenomine/sp-obsidian/",
     "author": "sinenomine",
     "authorUrl": "https://codeberg.org/sinenomine",
-    "stars": 5
+    "stars": 10
   },
   {
     "name": "MCP",
@@ -53,7 +53,7 @@
     "url": "https://github.com/organicmoron/SP-MCP",
     "author": "organicmoron",
     "authorUrl": "https://github.com/organicmoron",
-    "stars": 68
+    "stars": 120
   },
   {
     "name": "Super Productivity MCP",
@@ -61,7 +61,7 @@
     "url": "https://github.com/b0x42/Super-Productivity-MCP",
     "author": "b0x42",
     "authorUrl": "https://github.com/b0x42",
-    "stars": 11
+    "stars": 81
   },
   {
     "name": "Dashboard",
@@ -69,7 +69,7 @@
     "url": "https://github.com/ahanel13/sp-dashboard",
     "author": "ahanel13",
     "authorUrl": "https://github.com/ahanel13",
-    "stars": 9
+    "stars": 19
   },
   {
     "name": "Invoicer",
@@ -77,7 +77,7 @@
     "url": "https://github.com/1jamesthompson1/sp-invoicer",
     "author": "1jamesthompson1",
     "authorUrl": "https://github.com/1jamesthompson1",
-    "stars": 11
+    "stars": 24
   },
   {
     "name": "StudyForge Leaderboard",
@@ -93,7 +93,7 @@
     "url": "https://codeberg.org/sinenomine/sp-task-print",
     "author": "sinenomine",
     "authorUrl": "https://codeberg.org/sinenomine/",
-    "stars": 1
+    "stars": 2
   },
   {
     "name": "AI Assistant",
@@ -101,7 +101,7 @@
     "url": "https://github.com/ai-eifying/ai-assistant-plugin",
     "author": "ai-eifying",
     "authorUrl": "https://github.com/ai-eifying",
-    "stars": 4
+    "stars": 33
   },
   {
     "name": "Memos Sync",
@@ -109,7 +109,7 @@
     "url": "https://github.com/giba0/memos-sync",
     "author": "giba0",
     "authorUrl": "https://github.com/giba0",
-    "stars": 2
+    "stars": 7
   },
   {
     "name": "YouTrack Importer for SuperProductivity",
@@ -117,7 +117,7 @@
     "url": "https://github.com/coissay/superProductivity-YoutrackPlugin",
     "author": "coissay",
     "authorUrl": "https://github.com/coissay",
-    "stars": 0
+    "stars": 2
   },
   {
     "name": "Home Assistant Bridge",
@@ -125,7 +125,7 @@
     "url": "https://github.com/jloops412/ha-super-productivity",
     "author": "jloops412",
     "authorUrl": "https://github.com/jloops412",
-    "stars": 0
+    "stars": 14
   },
   {
     "name": "Goals Vision Board",
@@ -133,7 +133,7 @@
     "url": "https://github.com/CuriousChipmunk/vision-board-super-productivity",
     "author": "CuriousChipmunk",
     "authorUrl": "https://github.com/CuriousChipmunk",
-    "stars": 0
+    "stars": 33
   },
   {
     "name": "sync.md Multi",
@@ -141,7 +141,7 @@
     "url": "https://codeberg.org/fpindado/sync-md-multi",
     "author": "Fernando Pindado",
     "authorUrl": "https://codeberg.org/fpindado",
-    "stars": 0
+    "stars": 2
   },
   {
     "name": "JSON to Tasks",
@@ -157,6 +157,6 @@
     "url": "https://github.com/BigWebstas/SuperProd-Joplin-Sync",
     "author": "BigWebstas",
     "authorUrl": "https://github.com/BigWebstas",
-    "stars": 0
+    "stars": 3
   }
 ]


### PR DESCRIPTION
## What

`Ctrl`+`C` / `Cmd`+`C` on a task row that has the primary-colored focus border now copies the task **and its sub tasks** as a markdown checklist, instead of just the title:

```
- [ ] Parent task
  - [x] Sub one
  - [ ] Sub two
```

## Why

The shortcut already existed but copied the bare title, and it could silently copy nothing: it read the task from `lastFocusedTaskComponent`, which lags behind the DOM-derived focused task id, and fell through to native copy when the two disagreed. The task is now resolved from the store via `getByIdWithSubTaskData$`, so the row under the focus border is always the one that lands on the clipboard.

## Commits

- `2745374c15` — the feature: new pure `taskToMarkdownChecklist` util + store-based lookup
- `4e2e1a9a1e` — a crash found while auditing: `selectTaskByIdWithSubTaskData` returns a `{ subTasks: [] }` stub with no `id`/`title` for an unknown id, and `devError` only *logs* in a production build. That stub reached the formatter and threw an uncaught `TypeError` on a keystroke already `preventDefault`ed. Reproduced first (it disconnected the Karma browser), then fixed.
- `2d900491f8` — E2E covering the shortcut end to end

## Behavior kept as-is

Two native-copy deferrals are unchanged, both with existing tests: focus inside an input/textarea/contenteditable (title editing), and a non-empty text selection. The first is outside the ask — with focus in the title input the row has no focus border. The second means drag-selecting text inside a task still copies the selection rather than the checklist.

## Tests

- `task-to-markdown-checklist.spec.ts` — 4 cases (plain, done, indented sub tasks, whitespace collapse)
- `task-shortcut.service.spec.ts` — 35 passing, incl. the stale-component regression and the missing-entity stub
- `e2e/tests/keyboard/copy-task-as-checklist.spec.ts` — 1 passing (26s); asserts the exact string handed to `navigator.clipboard`

Docs: `docs/wiki/3.03-Keyboard-Shortcuts.md` updated.

https://claude.ai/code/session_01TB6bFVzC64SMGWiLCfYf14