### PR TITLE
feat/sync alert health check failed 54198e

### DIFF
--- a/packages/super-sync-server/scripts/MONITORING-README.md
+++ b/packages/super-sync-server/scripts/MONITORING-README.md
@@ -505,6 +505,12 @@ read and nothing else, where `adm` also opens `/var/log` broadly. Running the
 cron as root works too but grants far more than this one read needs. The marker
 clears itself on the next run once the log is readable.
 
+If the group is already there and `journalctl -k` still prints nothing, the
+host is a container (OpenVZ/Virtuozzo, LXC) that does not expose a kernel log
+to guests at all — verified on the hosted server 2026-09-09, cron user in
+`systemd-journal`, journal empty. No group fixes that; the marker is permanent
+there and `docker inspect -f '{{.State.OOMKilled}}'` is the only OOM signal.
+
 ### "PostgreSQL canceled this query because it exceeded statement_timeout"
 
 The reports no longer inherit the deployment's `statement_timeout`. `monitoring-db.ts`


### PR DESCRIPTION
- **fix(e2e): make the schedule touch spec independent of the time of day (#9813)**
- **chore(deps): unpin @capacitor/keyboard, bump safe-area to 5.0.1**
- **ci(android): verify 16 KB native page alignment before release upload**
- **docs(agents): slim AGENTS.md by moving narrative to docs**
- **18.21.2**
- **ci(windows): reduce code-signing volume safely**
- **fix(schedule): anchor the day panel to the displayed day #9758 (#9835)**
- **feat(tasks): add duplicate task shortcut (#9834)**
- **fix(supersync): keep the causal full-state lookup off a generic plan (#9847)**
- **build(deps): bump the npm_and_yarn group across 7 directories with 1 update (#9854)**
- **chore(deps)(deps): bump the github-actions-minor group with 4 updates (#9825)**
- **chore(deps): bump fast-uri from 3.1.5 to 3.1.7 (#9867)**
- **chore(deps): bump @xmldom/xmldom (#9860)**
- **chore(deps): bump browserslist from 4.28.2 to 4.28.8 (#9855)**
- **chore(deps): bump postcss-selector-parser from 7.1.1 to 7.1.6 (#9876)**
- **fix(electron): keep macOS tray icon at 16pt so it stops jumping on play**
- **fix(tasks): align sub-task checkbox with title in detail panel**
- **feat(plugin-api): add deleteProject (#9525)**
- **chore(deps)(deps): bump actions/setup-java from 5.7.0 to 6.0.0 (#9826)**
- **fix(theme): stop transformed background image from leaving body scrolled (#9874)**
- **feat(user-profile): remove the User Profiles feature (#9884)**
- **feat(automations): add keyboard shortcut trigger (#9883)**
- **feat(tracking-presence): tell desktop clients apart by OS and device name (#9879)**
- **test(e2e): wait out the mat-menu enter animation before clicking items**
- **fix(supersync): stop crash-killed pg_dump from leaving a valid-looking truncated backup (#9889)**
- **fix(work-view): show started or tracked appointments in the main list, not "Later Today" (#9880)**
- **test(e2e): assert legacy late joiner adopts server data on Use Server Data (#9887)**
- **test(e2e): stop recurring dueDay assertions failing at midnight**
- **chore(deps): bump fastify from 5.8.5 to 5.12.1 (#9859)**
- **fix(notes): remove close button from mobile notes panel (#9894)**
- **fix(tasks): drop the misleading (0) from the empty Subtasks panel header (#9501)**
- **fix(e2e): pin test timezone away from midnight (#9896)**
- **fix(tasks): open notes section directly from the task notes icon (#9864)**
- **fix(schedule): render the schedule day panel in the mobile bottom sheet (#9895)**
- **fix(schedule): clarify date-only task heading #9870 (#9901)**
- **fix(electron): bump electron to 43.5.0 to restore the Linux tray icon (#9902)**
- **test(sync): pin local-win compensation survives a failed resolution apply (#8761) (#9915)**
- **fix(tasks): emit a real op when starting a done task re-opens it #9904 (#9916)**
- **test(op-log): end-to-end boot coverage for mid-batch archive failure (#8305) (#9918)**
- **fix(sync): surface the conflict dialog for never-synced genesis clients #9863 (#9919)**
- **fix(supersync): stop orphaned healthcheck probes from crash-restarting postgres (#9695) (#9917)**
- **test(sync): add reproduction specs for #8764 strict wire-enum parsing (#9922)**
- **test(op-log): dual-backend reproductions for the SQLite shared-connection gate #8746 (#9920)**
- **fix(ios): keep the keyboard off <html> and wait for the web view resize (#9779) (#9926)**
- **fix(android): keep add-task bar above keyboard on old WebViews, validated on an API 34 emulator (#9923)**
- **docs(wiki): document the GPU-acceleration escape hatch for Linux launch failures (#9937)**
- **fix(sync): genesis-op handling at join time follow-ups #9921 (#9930)**
- **fix: six review fixes (issue-provider sync direction, shortcuts, CalDAV, finishDay hook) (#9900)**
- **fix(ui): clip route wrapper overflow to stop enter-animation scroll nudge (#9908)**
- **test(perf): add the #9779 root custom-property measurement harness (#9961)**
- **build(android): drop the unused service worker from the APK #4155 (#9935)**
- **fix(notes): open x-devonthink-item links and schemeless markdown links (#9976)**
- **chore(deps): patch reported security advisories in both lockfiles (#9974)**
- **ci(triage): add AI issue triage for newly opened issues (#9973)**
- **ci(repro): reproduce labeled bugs as failing E2E tests via Claude Code (#9983)**
- **ci(e2e): add a run_webdav input to skip the WebDAV job (#9984)**
- **chore(deps)(deps): bump the github-actions-minor group with 3 updates (#9955)**
- **chore(deps): bump @simplewebauthn/server from 13.3.0 to 13.3.2 (#9933)**
- **fix(sync): refuse a destructive server overwrite from a device with no data (#9256) (#9931)**
- **fix(sync): skip already-applied ops re-delivered by forced downloads (#9975)**
- **docs(supersync): note that container hosts never expose a kernel log to the OOM check**
