### PR TITLE
fix: use parseDbDateStr for date-only deadline sorting (fixes #10005)

### DIFF
--- a/src/app/features/task-view-customizer/task-view-customizer.service.ts
+++ b/src/app/features/task-view-customizer/task-view-customizer.service.ts
@@ -36,6 +36,7 @@ import { LS } from '../../core/persistence/storage-keys.const';
 import { LanguageService } from 'src/app/core/language/language.service';
 import { TranslateService } from '@ngx-translate/core';
 import { T } from '../../t.const';
+import { parseDbDateStr } from '../../util/parse-db-date-str';
 
 const GROUP_OPTIONS_NO_PROJECT = OPTIONS.group.list.filter(
   (opt) => opt.type !== GROUP_OPTION_TYPE.project,
@@ -645,8 +646,8 @@ export class TaskViewCustomizerService {
     return tasks.sort((a, b) => {
       const [dayA, withTimeA] = getFields(a);
       const [dayB, withTimeB] = getFields(b);
-      const dateA = dayA ? new Date(dayA) : withTimeA ? new Date(withTimeA) : null;
-      const dateB = dayB ? new Date(dayB) : withTimeB ? new Date(withTimeB) : null;
+      const dateA = dayA ? parseDbDateStr(dayA) : withTimeA ? new Date(withTimeA) : null;
+      const dateB = dayB ? parseDbDateStr(dayB) : withTimeB ? new Date(withTimeB) : null;
 
       if (dateA === null && dateB === null) return 0;
       if (dateA === null) return 1 * factor;


### PR DESCRIPTION
Fixes #10005

`_sortByDateFields` parsed a date-only `deadlineDay` (or `dueDay`) with `new Date('YYYY-MM-DD')`, which resolves to **UTC** midnight. In negative UTC offsets this placed date-only deadlines a full day early relative to timestamps parsed by `parseDbDateStr` (which resolves to local midnight).

Reproduced against the comparator in node with `TZ=America/Los_Angeles`:
- Task A: `deadlineDay = '2026-12-11'` → parsed as Dec 10 16:00 local (UTC midnight)
- Task B: `deadlineWithTime = Dec 10 20:00` local
- A sorted before B, though A is due a day later

Fix: route the date-only branch through `parseDbDateStr`, matching what the rest of the codebase already does. The `deadlineWithTime` branch still uses `new Date()` (millisecond timestamp → correct in any timezone).