### PR TITLE
fix(privacy): close three log-rule holes, a surviving Task[] leak, and false claims in the hardening doc

### DIFF
--- a/docs/hardening-earns-its-place.md
+++ b/docs/hardening-earns-its-place.md
@@ -9,46 +9,40 @@ A privacy branch (#7870, #5314) removed user content — task titles, notes,
 calendar event titles — from the app's exportable log history, and disabled
 Chromium's spellchecker so the app stops contacting Google for dictionaries.
 
-The privacy fixes themselves were about 40 lines across five files. They were
-correct in the first commit and survived nine independent reviews, across four
-rounds, untouched.
+The privacy fixes ended up spanning 19 files (117 insertions, 45 deletions).
+They were _not_ right first time: the first commit covered five files, and
+review then found the iCal `SUMMARY` leak, nine more content-bearing sites and
+the Jira issue-picker response. Only one of the six files the first commit
+touched was still untouched at the end.
 
 Around them grew roughly 700 lines of enforcement machinery: a custom ESLint
 rule, a grandfathered exception list, a fail-closed Electron `webPreferences`
 assertion, and a source-scanning test. Every round of review found a way past
 the rule; every finding was closed by adding another branch; each addition was
-individually cheap and jointly unjustifiable.
+individually cheap and jointly unjustifiable. Note the past tense is not
+earned: the rule and its spec together are ~627 lines at the time of writing,
+larger than the pre-cut peak this paragraph describes.
 
 ## What the measurements showed
 
-Attributing every report the rule produced to the code path that produced it
-(measured 2026-09, over the 1,714 `*Log.<method>()` call sites in `src/app`
-outside specs):
+Seven additions to the rule had **zero instances** anywhere in the codebase.
+One (`ChainExpression` unwrapping) was provably dead code: its child node type
+can never be reportable, so unwrapping it could not change any verdict.
 
-| Code path                                                      | Reports produced |
-| -------------------------------------------------------------- | ---------------- |
-| The rule's first version (bare identifier, shorthand property) | 110 of 121 (91%) |
-| Everything added afterwards, in review                         | 11               |
-
-Four of those 11 were false positives. Two independent measurements disagreed
-on how to attribute the rest — the disagreement was over whether one shape
-counted as an "addition" — which is itself the point: a number nobody can
-reproduce is not evidence. The 110/121 split and the zero-instance count below
-were both reproduced independently.
-
-Seven of the additions had **zero instances** anywhere in the codebase. One
-(`ChainExpression` unwrapping) was provably dead code: its child node type can
-never be reportable, so unwrapping it could not change any verdict.
+An earlier version of this section attributed each report to the rule branch
+that produced it, and quoted that split as evidence. Two later measurements
+disagreed with it and with each other. The number is deliberately not restated
+here: coverage attribution measures the rule against itself, and it is the
+wrong metric — see below.
 
 ## What review found afterwards
 
 The measurement above attributes each report to the rule branch that produced
 it. It says nothing about whether a report is a _leak_, and that turned out to
-be the number that mattered: sampling the 121 showed roughly two thirds are
-scalars the naming heuristics could not classify (`dateStr`, `evName`,
-`handlerMap`, `initialSyncDone`, `date1`, `providerRaw`, `zoomFactor`). Framing
-that list as "debt to pay down" would have sent contributors renaming benign
-variables.
+be the number that mattered: roughly half the 121 were scalars the naming
+heuristics could not classify (`dateStr`, `evName`, `initialSyncDone`, `date1`,
+`providerRaw`, `zoomFactor`). Framing that list as "debt to pay down" would
+have sent contributors renaming benign variables.
 
 Two corrections followed. Widening the heuristics for the largest benign
 cluster — timestamps, durations and `err*` strings, each with an observed
@@ -57,26 +51,29 @@ instance — removed 27 reports. Fixing the sites that were _actually_ leaking
 `undo-task-delete.meta-reducer.ts`, a notification event, an issue search
 result, the Jira issue-picker response, and the `task-context-menu-inner`
 copy of the very block this branch had already fixed in `task.component.ts`)
-removed 14 more hits and 10 files. The baseline settled at 80 hits across 40
+removed 14 more hits and 9 files. The baseline settled at 80 hits across 40
 files.
 
 The general lesson: **a precision number is the only one that justifies an
-allowlist.** Coverage attribution measures the rule against itself.
+allowlist.** Coverage attribution measures the rule against itself. Stated
+plainly, because it is the honest state of this branch: no precision number was
+ever produced, so the 40-file allowlist still rests on the rough sample above.
 
-The rule would not have caught the branch's own most severe leak. The iCal
-`SUMMARY` calls that exported private calendar event titles are
-`CallExpression`s — a shape the rule documents as a known gap.
+Two of the three iCal `SUMMARY` sites that exported private calendar event
+titles were `CallExpression`s — a shape the rule documents as a known gap, and
+so invisible to it. The third passed the title as a bare identifier and the
+rule's first version does report it.
 
 ## The three failure modes worth remembering
 
 **Findings are hypotheses, not work orders.** "You missed X" was treated as an
-instruction to close X, without asking whether X occurs in this repo. Three
-regressions came from acting on a reviewer's aside: dropping `use` from a
-boolean-name allowlist (immediate false positive on `useAlarmStyle`, the only
-logged `use*` in `src/app` and a genuine boolean); narrowing a key allowlist to
-quantities only (turned `{ error: scrubbedMessage }`, the canonical safe idiom,
-into a CI-failing error); and removing `??`/`||`/`?:` traversal (opened a
-cheaper bypass than the `!` it had just closed).
+instruction to close X, without asking whether X occurs in this repo. Two
+regressions came from acting on a reviewer's aside: narrowing a key allowlist
+to quantities only (which turned `{ error: errorMessage }`, the canonical safe
+idiom, into a CI-failing error), and removing `??`/`||`/`?:` traversal (which
+opened a cheaper bypass than the `!` it had just closed). A third suggestion —
+dropping `use` from the boolean-name allowlist — was tried, immediately
+false-positived on `useAlarmStyle`, and reverted before it was ever committed.
 
 **Automation can launder a defect into recorded debt.** The grandfathered
 offender list was regenerated from lint output, so a false positive introduced
@@ -124,6 +121,5 @@ registered after it and exits 333 — no app at all, over a dictionary fetch.
 ## Related
 
 - [`feature-review-guide.md`](feature-review-guide.md) — does it earn its place
-- [`sync-and-op-log/contributor-sync-model.md`](sync-and-op-log/contributor-sync-model.md)
-  — the sync section's "start from a reproducible problem" rule, which this
-  generalises
+- [`../AGENTS.md`](../AGENTS.md) — the sync section's "start from a reproducible
+  problem" rule, which this generalises

--- a/eslint-local-rules/rules/no-user-content-in-logs.js
+++ b/eslint-local-rules/rules/no-user-content-in-logs.js
@@ -110,16 +110,37 @@ const SAFE_SUFFIX_RE = suffixRe(SAFE_WORDS);
 // does. Whole-word and suffix are separate lists on purpose — a `Msg` suffix
 // would allow `snackMsg`, which routinely interpolates a task title.
 const SCALAR_WHOLE = new Set(['msg', 'seq', 'time', 'delay', 'duration']);
-const SCALAR_SUFFIX_RE = /(?:Seq|Time|Date|Day|At|Delay|Duration|Zoom|Factor)$/;
+// `Day`/`Date` are deliberately NOT suffixes: `*ForDay` / `*ByDay` is this
+// repo's convention for a collection of tasks (`flowTasksForDay`,
+// `deadlineTasksByDay`, `tasksDueByDay`), so a suffix match would wave whole
+// TaskCopy[] arrays through — and schedule/planner are error-scoped. The
+// observed scalar instances are listed by name instead.
+const SCALAR_SUFFIX_RE = /(?:Seq|Time|At|Delay|Duration|Zoom|Factor)$/;
+const SCALAR_DAY_DATE = new Set([
+  'dueday',
+  'deadlineday',
+  'plannedforday',
+  'targetdate',
+  'duedate',
+]);
 
 const ERROR_WHOLE = new Set(['e', 'ex', 'err', 'error', 'exception', 'reason']);
-const ERROR_SUFFIX_RE = /(?:Error|Errors|Err|Exception)$/;
+const ERROR_SUFFIX_RE = /(?:Error|Err|Exception)$/;
+// Value-only: ERROR_SUFFIX_RE is shared with isVouchingKey, and a plural
+// `*Errors` KEY must not vouch or `{ validationErrors: task }` reopens the
+// entity-label hole isVouchingKey exists to close.
+const ERROR_PLURAL_SUFFIX_RE = /Errors$/;
 // `errStr`, `errTxt`, `errorMsg`, `errorMessage` — the same allowance as the
 // conventional bare names, which `log.ts` narrows for a real `Error`. As with
 // ERROR_WHOLE this does not certify the value; see the HttpErrorResponse note
 // in the docstring. Value names only: an `err*` KEY must not vouch, or
 // `{ errorMsg: task }` reopens the entity-label hole isVouchingKey closes.
-const ERROR_PREFIX_RE = /^(?:err|error)[A-Z0-9]/;
+// A closed set of string-ish shapes, not a bare prefix. `/^err(or)?[A-Z]/`
+// also admitted `errorBody` — the raw provider response body in
+// handle-issue-provider-http-error.ts, which is exactly the un-narrowed
+// HttpErrorResponse payload the docstring above warns about — plus
+// `errorPayload`, `errorData`, `errTask`.
+const ERROR_PREFIX_RE = /^(?:err|error)(?:Str|Txt|Msg|Message|Text|Name|Code)$/;
 
 // A boolean says its own shape. `do`/`did`/`does` are absent — they would allow
 // `doNotDisturbList`. `use` is kept: it reads ambiguously in the abstract, but
@@ -158,6 +179,8 @@ const isSafeName = (name) => {
     SAFE_SUFFIX_RE.test(name) ||
     SCALAR_WHOLE.has(lower) ||
     SCALAR_SUFFIX_RE.test(name) ||
+    SCALAR_DAY_DATE.has(lower) ||
+    ERROR_PLURAL_SUFFIX_RE.test(name) ||
     ERROR_WHOLE.has(lower) ||
     ERROR_SUFFIX_RE.test(name) ||
     ERROR_PREFIX_RE.test(name) ||
@@ -168,7 +191,12 @@ const isSafeName = (name) => {
 
 // Wrappers that carry the value through unchanged. Without unwrapping, a `!` is
 // a one-keystroke way to silence this rule while still exporting the object.
-const UNWRAP = { TSNonNullExpression: 1, TSAsExpression: 1 };
+const UNWRAP = {
+  TSNonNullExpression: 1,
+  TSAsExpression: 1,
+  TSSatisfiesExpression: 1,
+  TSTypeAssertion: 1,
+};
 const unwrap = (node) => {
   let n = node;
   while (n && UNWRAP[n.type]) n = n.expression;

--- a/eslint-local-rules/rules/no-user-content-in-logs.spec.js
+++ b/eslint-local-rules/rules/no-user-content-in-logs.spec.js
@@ -94,6 +94,10 @@ ruleTester.run('no-user-content-in-logs', rule, {
     { code: `Log.err('x', errorMsg);` },
     { code: `Log.err('x', errorMessage);` },
     { code: `Log.err('x', rollbackErrors);` },
+    // The observed Day/Date scalars, allowed by name rather than by suffix.
+    { code: `Log.log('x', { dueDay, deadlineDay, targetDate, dueDate });` },
+    // Delay/Duration as suffixes, not just whole words.
+    { code: `Log.log('x', { retryDelay, sessionDuration });` },
     // Not a logger.
     { code: `analytics.log(task);` },
     { code: `console.log(task);` },
@@ -252,6 +256,36 @@ ruleTester.run('no-user-content-in-logs', rule, {
       code: `Log.log({ duration: taskWithSubTasks });`,
       errors: [{ messageId: 'bareValue', data: { name: 'taskWithSubTasks' } }],
     },
+    // `*ForDay` / `*ByDay` is this repo's convention for a COLLECTION of tasks,
+    // so Day/Date must not be a blanket suffix — schedule/planner are
+    // error-scoped and these hold TaskCopy[].
+    {
+      code: `Log.log({ flowTasksForDay });`,
+      errors: [{ messageId: 'bareValue', data: { name: 'flowTasksForDay' } }],
+    },
+    {
+      code: `Log.log('x', tasksDueByDay);`,
+      errors: [{ messageId: 'bareValue', data: { name: 'tasksDueByDay' } }],
+    },
+    // `err*` needs a shape: `errorBody` is the raw HttpErrorResponse body the
+    // docstring warns is not narrowed by log.ts.
+    {
+      code: `Log.err('x', errorBody);`,
+      errors: [{ messageId: 'bareValue', data: { name: 'errorBody' } }],
+    },
+    {
+      code: `Log.err('x', errorPayload);`,
+      errors: [{ messageId: 'bareValue', data: { name: 'errorPayload' } }],
+    },
+    // An err* name must not vouch as a KEY, or the entity-label hole reopens.
+    {
+      code: `Log.log({ errorMsg: task });`,
+      errors: [{ messageId: 'bareValue', data: { name: 'task' } }],
+    },
+    {
+      code: `Log.log({ validationErrors: taskWithSubTasks });`,
+      errors: [{ messageId: 'bareValue', data: { name: 'taskWithSubTasks' } }],
+    },
     // Every context logger is covered, not just `Log`.
     {
       code: `PluginLog.warn('plugin cfg', cfg);`,
@@ -283,6 +317,15 @@ tsRuleTester.run('no-user-content-in-logs (typescript)', rule, {
     },
     {
       code: `Log.log('x', task as any);`,
+      errors: [{ messageId: 'bareValue', data: { name: 'task' } }],
+    },
+    // `satisfies` and `<T>x` carry the value through exactly as `!` and `as` do.
+    {
+      code: `Log.log('x', task satisfies Task);`,
+      errors: [{ messageId: 'bareValue', data: { name: 'task' } }],
+    },
+    {
+      code: `Log.log('x', <Task>task);`,
       errors: [{ messageId: 'bareValue', data: { name: 'task' } }],
     },
     // The spread path unwraps too, or `!` reopens the same evasion there.

--- a/src/app/features/issue/issue.service.ts
+++ b/src/app/features/issue/issue.service.ts
@@ -394,10 +394,10 @@ export class IssueService {
 
     for (const pKey of Object.keys(tasksIssueIdsByIssueProviderKey)) {
       const providerKey = pKey as IssueProviderKey;
-      IssueLog.log(
-        'POLLING CHANGES FOR ' + providerKey,
-        tasksIssueIdsByIssueProviderKey[providerKey],
-      );
+      IssueLog.log('POLLING CHANGES FOR ' + providerKey, {
+        taskCount: tasksIssueIdsByIssueProviderKey[providerKey].length,
+        taskIds: tasksIssueIdsByIssueProviderKey[providerKey].map((t) => t.id),
+      });
       const pollingLabelParams = {
         issueProviderName: this._getProviderName(providerKey),
         issuesStr: this._translateService.instant(


### PR DESCRIPTION
## Problem

Follow-up to #9982. Reviewing that work after it merged turned up one live leak the pass missed, three latent holes in the lint rule's name allowlists, and about ten false or unreproducible claims in the doc it added.

**A `Record<string, Task[]>` was still being logged whole.** `issue.service.ts` logs it on every issue-provider poll (`refreshIssueTasks`, reached from `poll-issue-updates.effects.ts`), so full Task objects — titles, notes, attachments — reach the exportable history for anyone with Jira, GitHub or CalDAV enabled. The rule could not see it: the argument is a computed `MemberExpression`, which falls through `checkValue`'s `default` — the same shape the docstring declines to guard. #9982 edited this file 140 lines below the leak.

**`err*` needed a shape, not just a prefix.** `/^(?:err|error)[A-Z0-9]/` also admitted `errorBody` — the raw provider response body in `handle-issue-provider-http-error.ts`, which is precisely the un-narrowed `HttpErrorResponse` payload the rule's own docstring warns about, and which the same name holds in `jira-api.service.ts` for the parsed Jira failure body. `errorPayload`, `errorData` and `errTask` passed too.

**`Day` / `Date` are the wrong shape claim for this codebase.** `*ForDay` / `*ByDay` is the local convention for a *collection of tasks*, so the suffix waved through `flowTasksForDay` (`ScheduleFlowTask[]`), `tasksDueByDay` and `deadlineTasksByDay` (`Record<string, TaskCopy[]>`). `schedule/` and `planner/` are error-scoped, so those modules had no protection at all — and it was a rename-to-silence path: `{ tasks }` reported, `{ tasksForDay }` did not.

**`Errors` widened the key path.** It went into `ERROR_SUFFIX_RE`, which `isVouchingKey` shares, so `{ validationErrors: task }` stopped being reported — the entity-label hole that check exists to close.

## Solution

The leak becomes a count and ids. `err*` narrows to the observed string-ish shapes (`Str|Txt|Msg|Message|Text|Name|Code`), which covers every instance that motivated the widening. `Day`/`Date` stop being blanket suffixes and the observed scalars are allowed by name. `Errors` moves to a value-only constant. `TSSatisfiesExpression` and `TSTypeAssertion` join `UNWRAP` — they carry a value through unchanged exactly as `!` and `as` do, and `satisfies` appears 183× in `src/app`.

**Baseline is unchanged at 80 hits / 40 files, zero errors, no newly reported file.** These were latent holes rather than current leaks — except the `issue.service.ts` one, which the rule never saw. Each fix is mutation-pinned: reopening any of the three fails the spec.

## The doc corrections

`docs/hardening-earns-its-place.md` argues that unverified numbers should not ship, so its own being wrong matters more than it otherwise would. Two worth calling out:

- *"Correct in the first commit and survived nine independent reviews untouched"* — false, and load-bearing. One of six files was untouched. It is also self-refuting three paragraphs later, where the doc calls the iCal `SUMMARY` leak "the branch's own most severe leak" — found in review, not in the first commit.
- The doc listed dropping `use` from the boolean allowlist as one of three regressions. `use` is present in **every committed revision**. It was tried in the working tree, immediately false-positived on `useAlarmStyle`, and reverted before commit — a declined suggestion narrated as a shipped regression.

Also corrected: `{ error: scrubbedMessage }` (no such identifier; it is `errorMessage`), "1,714 call sites" (counted commented-out code; AST count ≈1,682), "10 files" (9 — the doc's own arithmetic disproved it: 61 − 12 − 10 = 39, not 40), "roughly two thirds are scalars" (about half), and a pointer sending readers to `contributor-sync-model.md` for a rule that lives in `AGENTS.md`.

The coverage-attribution table is **removed** rather than corrected a fourth time — its numbers could not be reproduced, and coverage attribution is the metric that section exists to warn against.

Two things are now stated that the doc previously implied otherwise: the machinery is not smaller than the peak it calls unjustifiable (rule plus spec are larger), and no precision number was ever produced, so the 40-file allowlist still rests on a rough sample — by the standard that same section sets.

## Not done here — needs your call

The `AGENTS.md` rule added in #9982 says *"zero occurrences → record a known gap instead"*. Under it, two of this repo's load-bearing guards would not have been built:

| guard | observed instances |
|---|---|
| `assertSecureWebPreferences` | **zero** — no `nodeIntegration: true`, `contextIsolation: false`, `webSecurity: false` anywhere; its docstring calls it "a tripwire against accidental drift" |
| `MAX_VECTOR_CLOCK_SIZE` | **zero** — it is DoS protection, which by definition has no in-repo instance of the attack |

`eslint.config.js:437-441` also states the opposite epistemology directly: the `packages/` fences "are lint-enforced and **hold at zero violations**" — cited as the argument *for* copying that fence inward.

A carve-out sentence for fences whose purpose is holding a boundary at zero would settle it. That is an agent-control file, so I have not touched it.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

Verification: `npm run lint` 0 errors, `npm test` **14,900/14,900**, `npx tsc -p src/tsconfig.app.json --noEmit` clean, `test:lint-rules` green. Each of the three rule fixes was mutation-tested — reverting it makes the spec fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UifewQtVFHoMvQEnbiDAjE

---
_Generated by [Claude Code](https://claude.ai/code/session_01UifewQtVFHoMvQEnbiDAjE)_