### PR TITLE
fix(sync): keep the pre-loss recovery point through restores

### DIFF
--- a/docs/sync-and-op-log/local-recovery-points.md
+++ b/docs/sync-and-op-log/local-recovery-points.md
@@ -32,15 +32,18 @@ lets the user browse and restore every backup the device has.
   `skipRecoveryPoint` so the post-snapshot replay cannot move the pointer they
   are about to verify
   (`testing/integration/force-download-recovery-point.integration.spec.ts`).
-- A `QuotaExceededError` on capture prunes the ring to its newest snapshot and
-  retries once, so a full device degrades to a ring of two instead of never
-  applying another full-state op. The newest snapshot is never evicted, and
-  any other error aborts the apply without touching the ring.
+- A `QuotaExceededError` on capture prunes the ring to its newest `REMOTE_IMPORT`
+  / `FORCE_DOWNLOAD` snapshot (or newest snapshot if neither exists) and retries
+  once, so a full device degrades to a ring of two instead of never
+  applying another full-state op. One snapshot always survives, and any other
+  error aborts the apply without touching the ring.
 - The pristine-device skip uses `hasRecoverableData` (tasks incl. archive,
   projects, tags, notes, recurring configs, counters, issue providers, metrics,
   plugin data). Settings alone never trigger a capture.
-- Shortcut: plain FIFO of 3 with no notion of value. Upgrade path if evictions
-  bite: pin the newest `REMOTE_IMPORT` entry.
+- The newest `REMOTE_IMPORT` / `FORCE_DOWNLOAD` entry is never rotated out by
+  restores, so three wrong restores in a row cannot evict the pre-loss snapshot
+  (#10003). Only the next pre-replacement capture replaces it — including a
+  "Use Server Data" done _after_ the wipe, which is the accepted limit.
 - Legacy single-slot rows (state stored under `current`) keep working for Undo
   and are replaced by the pointer on the next capture.
 

--- a/src/app/op-log/backup/backup.service.ts
+++ b/src/app/op-log/backup/backup.service.ts
@@ -267,11 +267,11 @@ export class BackupService {
 
   /**
    * On storage quota the ring (up to three full snapshots) is the likeliest
-   * culprit: evict all but the newest existing snapshot and retry once, so a
-   * full device degrades to a ring of two instead of never applying another
-   * full-state op. The newest snapshot is always kept — a failed capture must
-   * never leave the device with fewer recovery points than it had. Any other
-   * error propagates untouched.
+   * culprit: keep the newest REMOTE_IMPORT / FORCE_DOWNLOAD snapshot (or the
+   * newest snapshot if neither exists) and retry once, so a full device degrades
+   * to a ring of two instead of never applying another full-state op. One
+   * snapshot is always kept (#10003) — a failed capture must never leave the
+   * device with no recovery point. Any other error propagates untouched.
    */
   private async _saveRecoveryPoint(
     state: unknown,

--- a/src/app/op-log/persistence/import-backup-ring.util.ts
+++ b/src/app/op-log/persistence/import-backup-ring.util.ts
@@ -60,6 +60,23 @@ const readRingMeta = async (tx: OpLogTx): Promise<ImportBackupMeta[]> => {
 };
 
 /**
+ * Newest-first entries that survive a rotation to `size`. The newest
+ * pre-replacement capture (REMOTE_IMPORT / FORCE_DOWNLOAD) survives when size > 0 so
+ * restores cannot rotate the pre-loss snapshot out (#10003); the other slots go
+ * to the newest remaining entries.
+ */
+const keepNewest = (entries: ImportBackupMeta[], size: number): ImportBackupMeta[] => {
+  if (size === 0) {
+    return [];
+  }
+  const guarded = entries.find((e) => e.reason !== 'LOCAL_IMPORT');
+  const others = entries
+    .filter((e) => e !== guarded)
+    .slice(0, Math.max(0, guarded ? size - 1 : size));
+  return entries.filter((e) => e === guarded || others.includes(e));
+};
+
+/**
  * Writes a new snapshot, points the undo slot at it, and rotates the ring.
  * The evicted snapshots are deleted in this same transaction.
  */
@@ -77,8 +94,8 @@ export const saveImportBackupTx = async (
     taskCount: meta.taskCount ?? 0,
   };
   const entries = [entry, ...(await readRingMeta(tx))];
-  const kept = entries.slice(0, IMPORT_BACKUP_RING_SIZE);
-  for (const evicted of entries.slice(IMPORT_BACKUP_RING_SIZE)) {
+  const kept = keepNewest(entries, IMPORT_BACKUP_RING_SIZE);
+  for (const evicted of entries.filter((e) => !kept.includes(e))) {
     await tx.delete(STORE_NAMES.IMPORT_BACKUP, evicted.backupId);
   }
   await tx.put(STORE_NAMES.IMPORT_BACKUP, {
@@ -133,16 +150,18 @@ export const listImportBackupsTx = (tx: OpLogTx): Promise<ImportBackupMeta[]> =>
   readRingMeta(tx);
 
 /**
- * Drops all but the newest `keep` snapshots to make room when a capture fails
- * (typically storage quota). The undo pointer is retired if its snapshot goes.
- * Returns how many snapshots were evicted.
+ * Drops all but the newest `keep` snapshots (the protected capture first) to
+ * make room when a capture fails (typically storage quota). Zero clears all
+ * snapshots, including the protected capture. The undo pointer is
+ * retired if its snapshot goes. Returns how many snapshots were evicted.
  */
 export const pruneImportBackupRingTx = async (
   tx: OpLogTx,
   keep: number,
 ): Promise<number> => {
   const entries = await readRingMeta(tx);
-  const evicted = entries.slice(keep);
+  const kept = keepNewest(entries, keep);
+  const evicted = entries.filter((e) => !kept.includes(e));
   if (evicted.length === 0) {
     return 0;
   }
@@ -151,7 +170,7 @@ export const pruneImportBackupRingTx = async (
   }
   await tx.put(STORE_NAMES.IMPORT_BACKUP, {
     id: RING_META_KEY,
-    entries: entries.slice(0, keep),
+    entries: kept,
   } satisfies RingMetaRow);
   const pointer = await tx.get<PointerRow>(STORE_NAMES.IMPORT_BACKUP, SINGLETON_KEY);
   if (pointer?.backupId && evicted.some((e) => e.backupId === pointer.backupId)) {

--- a/src/app/op-log/persistence/operation-log-store.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.spec.ts
@@ -3016,17 +3016,20 @@ describe('OperationLogStoreService', () => {
         expect(await service.pruneImportBackups(1)).toBe(0);
       });
 
-      it('should retire the undo pointer when pruning evicts its snapshot', async () => {
-        await service.saveImportBackup(
-          { v: 1 },
-          { reason: 'LOCAL_IMPORT', taskCount: 1 },
-        );
+      for (const reason of ['LOCAL_IMPORT', 'REMOTE_IMPORT', 'FORCE_DOWNLOAD'] as const) {
+        it(`should clear the ${reason} snapshot and undo pointer when pruning to zero`, async () => {
+          const backup = await service.saveImportBackup(
+            { v: 1 },
+            { reason, taskCount: 1 },
+          );
 
-        expect(await service.pruneImportBackups(0)).toBe(1);
+          expect(await service.pruneImportBackups(0)).toBe(1);
 
-        expect(await service.listImportBackups()).toEqual([]);
-        expect(await service.loadImportBackup()).toBeNull();
-      });
+          expect(await service.listImportBackups()).toEqual([]);
+          expect(await service.loadImportBackup()).toBeNull();
+          expect(await service.loadImportBackupById(backup.backupId)).toBeNull();
+        });
+      }
 
       it('should list captures newest first with reason and task count', async () => {
         await service.saveImportBackup(
@@ -3070,6 +3073,45 @@ describe('OperationLogStoreService', () => {
         expect((await service.loadImportBackupById(refs[2].backupId))?.state).toEqual({
           v: 2,
         });
+      });
+
+      it('should never rotate the pre-loss capture out (#10003)', async () => {
+        const preLoss = await service.saveImportBackup(
+          { v: 'pre-loss' },
+          { reason: 'REMOTE_IMPORT', taskCount: 40 },
+        );
+        const restores: ImportBackupRef[] = [];
+        for (let i = 0; i < IMPORT_BACKUP_RING_SIZE; i++) {
+          restores.push(await service.saveImportBackup({ v: i }));
+        }
+
+        expect((await service.listImportBackups()).map((e) => e.backupId)).toEqual([
+          ...restores
+            .slice(1)
+            .reverse()
+            .map((r) => r.backupId),
+          preLoss.backupId,
+        ]);
+        expect((await service.loadImportBackupById(preLoss.backupId))?.state).toEqual({
+          v: 'pre-loss',
+        });
+        expect(await service.loadImportBackupById(restores[0].backupId)).toBeNull();
+      });
+
+      it('should keep the pre-loss capture over newer restores when pruning', async () => {
+        const preLoss = await service.saveImportBackup(
+          { v: 'pre-loss' },
+          { reason: 'REMOTE_IMPORT', taskCount: 40 },
+        );
+        await service.saveImportBackup({ v: 1 });
+        await service.saveImportBackup({ v: 2 });
+
+        expect(await service.pruneImportBackups(1)).toBe(2);
+
+        expect((await service.listImportBackups()).map((e) => e.backupId)).toEqual([
+          preLoss.backupId,
+        ]);
+        expect(await service.loadImportBackup()).toBeNull();
       });
 
       it('should keep an older snapshot browsable after the undo slot is cleared', async () => {

--- a/src/app/op-log/persistence/operation-log-store.service.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.ts
@@ -2420,7 +2420,7 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
     return this._importBackupTx('readonly', listImportBackupsTx);
   }
 
-  /** Evicts all but the newest `keep` snapshots; see `pruneImportBackupRingTx`. */
+  /** Keeps `keep` snapshots, prioritizing the newest pre-replacement capture. */
   async pruneImportBackups(keep: number): Promise<number> {
     return this._importBackupTx('readwrite', (tx) => pruneImportBackupRingTx(tx, keep));
   }


### PR DESCRIPTION
## Problem

Three consecutive local restores could evict the pre-loss recovery snapshot from the three-slot FIFO ring, removing the backup needed to recover data after a remote full-state replacement.

Closes #10003.

## Solution

Reserve a ring slot for the newest `REMOTE_IMPORT` or `FORCE_DOWNLOAD` snapshot and fill the remaining slots with the newest captures. Quota pruning prioritizes the same snapshot; explicit pruning to zero still clears all snapshots and the Undo pointer. Update the retention documentation and regression tests.

Protection passes to the next remote or force-download capture. Ring size, persisted schema, and sync protocol remain unchanged.

## Validation

- All 257 persistence tests passed, including regression tests confirmed to fail before the fix.
- `npm run checkFile` passed for every changed TypeScript file.
- Independent sub-agent review found no actionable issues.
- Full sync E2E was not run.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass (targeted persistence suite; full suite not run)
- [x] My commit messages follow the Angular format (`type(scope): description`)
