### PR TITLE
fix(supersync): prune aged prefixes behind recent checkpoints

### DIFF
--- a/packages/super-sync-server/docs/architecture.md
+++ b/packages/super-sync-server/docs/architecture.md
@@ -121,9 +121,18 @@ This serialization mechanism is a load-bearing decision; see
   snapshot BLOB exists, the boundary additionally never passes that row's
   cursor (protects the cached base's replay tail for restore); a cursor left
   behind without its blob does not cap. A user's aged prefix is pruned whole
-  or not at all, so the lowest surviving op stays a full-state op. Quota
+  or not at all, so the lowest surviving op stays a full-state op. When recent
+  operations block the newest boundary, cleanup falls back to the newest causal
+  boundary at or before the lowest recent sequence (#9962). This preserves every
+  operation inside retention without letting frequent checkpoints block an older
+  complete prefix. Quota
   recovery uses a
   separate bounded cleanup policy.
+- Routine incremental sync does not create periodic full-state boundaries.
+  Adding a client cadence requires a compatibility design (#9962): released
+  v18.14.0 clients accept schema-4 operations but treat `REPAIR` as a reset and
+  discard concurrent edits. Reusing current repair semantics alone cannot safely
+  enable automatic checkpoints for accounts with those clients.
 - Server-generated restore is unavailable when the required replay range
   contains encrypted operations.
 

--- a/packages/super-sync-server/scripts/old-ops-sweep-plan.ts
+++ b/packages/super-sync-server/scripts/old-ops-sweep-plan.ts
@@ -65,7 +65,9 @@ export const affectedUsers = (rows: PerUserRow[]): PerUserRow[] =>
  * Boundary resolution mirrors production (storage-quota.service.ts): the newest
  * causal full-state op with server_seq > 1 authorizes pruning; while a cached
  * snapshot blob exists the boundary may not pass last_snapshot_seq and drops to
- * the newest causal full-state op at or below that cursor. The
+ * the newest causal full-state op at or below that cursor. If its prefix has
+ * recent operations, use the newest causal boundary at or before the lowest
+ * recent sequence instead (#9962); a boundary itself may still be recent. The
  * latest_full_state_seq marker is not consulted (stale for ~90% of users, no
  * backfill in #8973).
  */
@@ -79,6 +81,7 @@ export const fetchOldOpsSweepPlan = (
         o.user_id,
         count(*) AS op_count,
         max(o.received_at) AS last_received_at,
+        min(o.server_seq) FILTER (WHERE o.received_at >= ${cutoff}) AS first_fresh_seq,
         max(o.server_seq) FILTER (
           WHERE o.server_seq > 1 AND ${causalFullStateSql('o')}
         ) AS causal_boundary_seq,
@@ -114,10 +117,8 @@ export const fetchOldOpsSweepPlan = (
         ) AS was_capped
       FROM joined j
     ),
-    -- MATERIALIZED is already the default here (two CTE references below), so
-    -- this only pins it: an edit that leaves a single reference must not let
-    -- Postgres inline the correlated cap aggregate and re-run it per row.
-    resolved AS MATERIALIZED (
+    -- Resolve the cached-blob cap once before the retention fallback.
+    snapshot_resolved AS MATERIALIZED (
       SELECT
         c.*,
         CASE WHEN c.was_capped THEN (
@@ -127,6 +128,17 @@ export const fetchOldOpsSweepPlan = (
             AND ${causalFullStateSql('o')}
         ) ELSE c.causal_boundary_seq END AS protected_from_seq
       FROM capped c
+    ),
+    resolved AS MATERIALIZED (
+      SELECT s.*,
+        CASE WHEN s.first_fresh_seq < s.protected_from_seq THEN COALESCE((
+          SELECT max(o.server_seq) FROM operations o
+          WHERE o.user_id = s.user_id
+            AND o.server_seq > 1
+            AND o.server_seq <= s.first_fresh_seq
+            AND ${causalFullStateSql('o')}
+        ), s.protected_from_seq) ELSE s.protected_from_seq END AS aged_boundary_seq
+      FROM snapshot_resolved s
     ),
     -- Only the prefix ranges are joined, so retained_from_boundary can be
     -- derived from op_count and the largest of the three ranges is never
@@ -141,8 +153,8 @@ export const fetchOldOpsSweepPlan = (
       FROM operations o
       JOIN resolved r
         ON r.user_id = o.user_id
-        AND r.protected_from_seq > 1
-        AND o.server_seq < r.protected_from_seq
+        AND r.aged_boundary_seq > 1
+        AND o.server_seq < r.aged_boundary_seq
       GROUP BY r.user_id
     )
     SELECT
@@ -155,13 +167,13 @@ export const fetchOldOpsSweepPlan = (
       r.has_legacy_repair,
       r.has_plaintext_rows,
       r.was_capped,
-      r.protected_from_seq,
+      r.aged_boundary_seq AS protected_from_seq,
       -- No CASE needed: the counts join filters protected_from_seq > 1, so a
       -- non-prunable user has no row there and COALESCE already yields 0.
       COALESCE(ct.would_delete, 0) AS would_delete,
       COALESCE(ct.fresh_prefix, 0) AS fresh_prefix,
       -- This one DOES need the CASE — op_count - 0 - 0 is op_count, not 0.
-      CASE WHEN r.protected_from_seq > 1
+      CASE WHEN r.aged_boundary_seq > 1
         THEN r.op_count - COALESCE(ct.would_delete, 0) - COALESCE(ct.fresh_prefix, 0)
         ELSE 0 END AS retained_from_boundary
     FROM resolved r

--- a/packages/super-sync-server/src/sync/services/storage-quota.service.ts
+++ b/packages/super-sync-server/src/sync/services/storage-quota.service.ts
@@ -12,7 +12,10 @@ import { prisma } from '../../db';
 import { Logger } from '../../logger';
 import { parsePositiveIntegerEnv } from '../../util/env';
 import { APPROX_BYTES_PER_OP } from '../sync.const';
-import { CAUSAL_FULL_STATE_OPERATION_WHERE } from '../sync.types';
+import {
+  agedPrefixCausalFullStateSql,
+  CAUSAL_FULL_STATE_OPERATION_WHERE,
+} from '../sync.types';
 
 /**
  * Default storage quota per user in bytes (100MB).
@@ -482,9 +485,8 @@ export class StorageQuotaService {
     // Every reason the sweep declines a candidate is counted and reported.
     // #9688 was exactly a fleet-wide exemption from retention that nobody
     // could see; a silent skip re-creates that blind spot in narrower form.
-    // `skippedFreshPrefix` in particular can pin a user forever: anyone
-    // emitting a causal full-state op more often than once per retention
-    // window is skipped on every single run while their log grows unbounded.
+    // A fresh prefix is skipped only when no older causal checkpoint can
+    // protect a wholly aged prefix either.
     let skippedFreshPrefix = 0;
     let skippedBoundaryAtOne = 0;
     let drainFailures = 0;
@@ -555,8 +557,9 @@ export class StorageQuotaService {
         // `_resolveExpectedFirstSeq` (op-replay.ts) tolerates a leading gap ONLY
         // when the lowest surviving op is a causal full-state op that resets
         // state — otherwise it throws SNAPSHOT_REPLAY_INCOMPLETE, which the
-        // restore route surfaces as a 500. Skipping the user keeps the whole
-        // prefix intact until it ages out, so this sweep never NEWLY breaks the
+        // restore route surfaces as a 500. Try an older causal boundary before
+        // skipping the user (#9962), so frequent checkpoints cannot strand an
+        // older complete prefix. This sweep never NEWLY breaks the
         // invariant that path documents ("the surviving lowest-seq op is
         // guaranteed to be a full-state op"). Costs retention lag, never
         // over-deletion. Note the invariant is not globally true: quota
@@ -613,8 +616,18 @@ export class StorageQuotaService {
           select: { serverSeq: true },
         });
         if (freshOpBelowBoundary) {
-          skippedFreshPrefix++;
-          continue;
+          const [olderBoundary] = await prisma.$queryRaw<{ server_seq: number }[]>(
+            agedPrefixCausalFullStateSql(
+              candidate.userId,
+              protectedFromSeq,
+              BigInt(cutoffTime),
+            ),
+          );
+          if (!olderBoundary) {
+            skippedFreshPrefix++;
+            continue;
+          }
+          protectedFromSeq = olderBoundary.server_seq;
         }
 
         // Drain this user to completion. The budget gates which users we

--- a/packages/super-sync-server/src/sync/sync.types.ts
+++ b/packages/super-sync-server/src/sync/sync.types.ts
@@ -87,6 +87,36 @@ export const latestCausalFullStateSql = (
 export type LatestCausalFullStateRow = { server_seq: number; client_id: string };
 
 /**
+ * Fall back from a recent checkpoint to one whose entire prefix has aged out.
+ * Materialize the receipt-time range before MIN: a direct MIN(server_seq) can
+ * walk the whole historical sequence index to find the first recent row.
+ * Literal op types keep the causal partial index usable with generic plans.
+ */
+export const agedPrefixCausalFullStateSql = (
+  userId: number,
+  maxServerSeq: number,
+  cutoffTime: bigint,
+): Prisma.Sql => Prisma.sql`
+  WITH fresh_prefix AS MATERIALIZED (
+    SELECT server_seq FROM operations
+    WHERE user_id = ${userId}
+      AND received_at >= ${cutoffTime}
+      AND server_seq < ${maxServerSeq}
+    ORDER BY received_at
+  )
+  SELECT server_seq FROM operations
+  WHERE user_id = ${userId}
+    AND server_seq > 1
+    AND server_seq <= (SELECT min(server_seq) FROM fresh_prefix)
+    AND (
+      op_type IN ('SYNC_IMPORT', 'BACKUP_IMPORT')
+      OR (op_type = 'REPAIR' AND repair_base_server_seq IS NOT NULL)
+    )
+  ORDER BY server_seq DESC
+  LIMIT 1
+`;
+
+/**
  * True when `opType` carries the user's full state (SYNC_IMPORT, BACKUP_IMPORT,
  * REPAIR). Whether it is a proven causal boundary additionally depends on the
  * REPAIR base cursor; use {@link isCausalFullStateOperation} for that decision.

--- a/packages/super-sync-server/tests/integration/old-ops-probe-plan.integration.spec.ts
+++ b/packages/super-sync-server/tests/integration/old-ops-probe-plan.integration.spec.ts
@@ -70,6 +70,7 @@
  */
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { Prisma, PrismaClient } from '@prisma/client';
+import { agedPrefixCausalFullStateSql } from '../../src/sync/sync.types';
 import {
   explainGeneric,
   type ExplainRunner,
@@ -429,6 +430,29 @@ describeWithDb('Old-ops fresh-prefix probe plan (PostgreSQL)', () => {
       'TRUNCATE "operations", "users" RESTART IDENTITY CASCADE',
     );
     await prisma.$disconnect();
+  });
+
+  it('finds an older checkpoint without scanning the aged prefix (#9962)', async () => {
+    const query = agedPrefixCausalFullStateSql(
+      deepUserId,
+      BOUNDARY_SEQ + WINDOW_OPS,
+      BigInt(CUTOFF),
+    );
+    const plan = await measureUnderDdl(
+      [
+        `UPDATE operations SET op_type = 'REPAIR', repair_base_server_seq = server_seq - 1
+         WHERE user_id = ${deepUserId} AND server_seq = ${BOUNDARY_SEQ}`,
+        `CREATE INDEX IF NOT EXISTS operations_user_id_causal_full_state_server_seq_idx
+         ON operations (user_id, server_seq)
+         WHERE op_type IN ('SYNC_IMPORT', 'BACKUP_IMPORT')
+           OR (op_type = 'REPAIR' AND repair_base_server_seq IS NOT NULL)`,
+      ],
+      query.text,
+      query.values,
+    );
+    expect(plan.nodes).toContain(COVERING_IDX);
+    expect(plan.nodes).toContain('operations_user_id_causal_full_state_server_seq_idx');
+    expect(plan.examined).toBeLessThan(WINDOW_OPS * 5);
   });
 
   it('CANARY: the prefix-bound candidate is catastrophic on this seed', async () => {

--- a/packages/super-sync-server/tests/integration/old-ops-sweep.integration.spec.ts
+++ b/packages/super-sync-server/tests/integration/old-ops-sweep.integration.spec.ts
@@ -366,6 +366,53 @@ describeWithDb('Old-ops sweep (PostgreSQL)', () => {
     expect(affectedUserIds).not.toContain(SNAPSHOTLESS_IMPORT_USER_ID);
   });
 
+  it.each([
+    { name: 'recent checkpoint', freshSeq: 4, snapshotCap: 0, boundary: 3 },
+    { name: 'fresh checkpoint itself', freshSeq: 3, snapshotCap: 0, boundary: 3 },
+    { name: 'out-of-order receipt times', freshSeq: 2, snapshotCap: 0, boundary: 1 },
+    { name: 'cached snapshot cap', freshSeq: 6, snapshotCap: 3, boundary: 3 },
+  ])(
+    'uses the newest wholly aged prefix: $name',
+    async ({ freshSeq, snapshotCap, boundary }) => {
+      // Two older full-state bases and a recent one. A recent checkpoint must
+      // not strand an older, complete prefix; receipt times need not follow seq.
+      for (let seq = 1; seq <= 7; seq++) {
+        const receivedAt =
+          seq === freshSeq || seq === 7 ? BigInt(cutoffTime) : oldReceivedAt;
+        if ([1, 3, 5, 7].includes(seq)) {
+          await seedImportOp(ENCRYPTED_USER_ID, seq, {
+            opType: 'REPAIR',
+            repairBaseServerSeq: seq - 1,
+            isPayloadEncrypted: true,
+            receivedAt,
+          });
+        } else {
+          await seedOp(ENCRYPTED_USER_ID, seq, { isPayloadEncrypted: true, receivedAt });
+        }
+      }
+      if (snapshotCap) {
+        await prisma.userSyncState.create({
+          data: {
+            userId: ENCRYPTED_USER_ID,
+            lastSeq: 7,
+            lastSnapshotSeq: snapshotCap,
+            snapshotData: Buffer.from('legacy-cached-snapshot'),
+          },
+        });
+      }
+      const plan = await fetchOldOpsSweepPlan(prisma, BigInt(cutoffTime));
+      const predicted = affectedUsers(plan).find(
+        (row) => row.user_id === ENCRYPTED_USER_ID,
+      );
+      const { totalDeleted } = await runSweep();
+      expect(totalDeleted).toBe(boundary - 1);
+      expect(predicted ? toNum(predicted.would_delete) : 0).toBe(boundary - 1);
+      expect(await survivingSeqs(ENCRYPTED_USER_ID)).toEqual(
+        Array.from({ length: 8 - boundary }, (_, index) => boundary + index),
+      );
+    },
+  );
+
   it('caps the boundary at lastSnapshotSeq while a cached snapshot blob exists', async () => {
     // Stuck-snapshot cohort (e.g. issue user 1515): cached snapshot frozen at
     // seq 1. While the blob exists, pruning must never pass its cursor — the

--- a/packages/super-sync-server/tests/sync.service.test-state.ts
+++ b/packages/super-sync-server/tests/sync.service.test-state.ts
@@ -72,10 +72,15 @@ export function isEntityArrayBranchQuery(strings: unknown): boolean {
 
 /**
  * The download path's newest-causal-full-state lookup (`latestCausalFullStateSql`).
- * Discriminates on the REPAIR base-cursor clause, which no other statement carries.
+ * The selected columns distinguish this from the old-ops aged-prefix fallback,
+ * which uses the same causal predicate but binds a retention cutoff as well.
  */
 export function isLatestCausalFullStateQuery(strings: unknown): boolean {
-  return rawQueryText(strings).includes('repair_base_server_seq IS NOT NULL');
+  const sql = rawQueryText(strings);
+  return (
+    sql.includes('SELECT server_seq, client_id') &&
+    sql.includes('repair_base_server_seq IS NOT NULL')
+  );
 }
 
 /**


### PR DESCRIPTION
## Problem

A recent operation below the newest causal checkpoint makes the daily retention sweep skip the user, even when an older checkpoint protects a fully aged prefix. Frequent checkpoints can therefore prevent that older history from being pruned.

Refs #9962. This addresses the server boundary-selection gap; the issue remains open for client checkpoint cadence and compatibility work.

## Solution

- After applying the cached-snapshot cap, fall back to the newest causal full-state checkpoint at or before the lowest sequence still inside retention.
- Preserve that checkpoint and its entire tail, including every recent operation. Leave history intact when no eligible older checkpoint exists.
- Mirror the adjusted boundary in the dry-run plan and cover both paths with PostgreSQL regression tests.
- Keep the fallback query bounded by the receipt-time window, with generic-plan coverage for the existing receipt-time and causal indexes.

Document why automatic client checkpoints need separate compatibility work: released v18.14.0 clients treat REPAIR as a reset and can discard concurrent edits.

## Validation

- 17 PostgreSQL retention integration tests passed; two regression cases failed before the fix.
- 9 PostgreSQL query-plan tests passed.
- Full server suite: 1,277 passed, 46 existing skipped. After the final mock-discriminator adjustment, all its consumers were rerun: 209 passed.
- Server TypeScript build and `checkFile` for every changed TypeScript file passed.

The production dry-run timed out, so reclaimable rows and storage savings have not been measured.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
