### PR TITLE
test(sync): add e2e coverage for recent sync regressions

### DIFF
--- a/e2e/sync-coverage-2026-09-10.md
+++ b/e2e/sync-coverage-2026-09-10.md
@@ -1,0 +1,91 @@
+# Sync regression coverage: September 3–10, 2026
+
+Audited the current branch's history through `f6cf7cd79e`, using commit dates
+from September 3 onward. This includes device sync, persistence/recovery,
+tracking presence, and issue-provider sync. Existing reproductions are reused;
+an additional browser test is useful where it exercises a missing user flow or
+a boundary that the existing unit/integration tests do not cover.
+
+## Added coverage
+
+| Change                                                                              | Browser reproduction                                                                                                                                                                                                                                                                                                     |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `b1b39f9c60` #9916 / #9904: starting a completed task must emit a persistent reopen | [Task reopening](tests/sync/supersync-reopen-started-task-9904.spec.ts): start a done task with `Y`, sync to another device, verify `isDone` and `doneOn`, then reload. Also start a parent whose only subtask is done and verify that the child reopens remotely.                                                       |
+| `5bde0aa362` #9922 / #8764: unknown wire vocabulary must block per operation        | [Mid-batch errors](tests/sync/supersync-error-scenarios.spec.ts): extend the existing schema-version scenario with unknown `opType` and `syncImportReason`. Intercept real encrypted operations, require the valid prefix, preserve the cursor, and recover the blocked suffix after removing the incompatible metadata. |
+| `50db311cdd` #9900: issue refresh must respect field sync directions                | [GitHub refresh](tests/issue-provider-panel/github-sync-direction-9900.spec.ts): import through the bundled provider with title sync off; refresh a changed issue and require the status update while preserving the mapped title. Only GitHub HTTP responses are stubbed.                                               |
+| `50db311cdd` #9900: calendar connection errors must reach the setup dialog          | [Calendar connection error](tests/issue-provider-panel/calendar-connection-error-9900.spec.ts): a real HTTP 401 failure reaches the toast without exposing the private calendar URL.                                                                                                                                     |
+
+## Existing browser reproductions retained
+
+| Change                                                                       | Existing coverage                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `2827f4cf49` #10002: local recovery points                                   | [Local recovery point](tests/sync/supersync-local-recovery-point.spec.ts) exercises remote replacement, shrink banner, browsing/restoring backups, propagation to the other client, and the pristine-device skip. [Forced download](tests/sync/supersync-forced-download-pruned-import.spec.ts) also asserts that duplicate imports do not rotate the ring. Ring rotation, quota failure, and undo identity have store/integration tests. |
+| `188cbc1450` #9943 / #9932: archive-only legacy joins and migration outcomes | [Legacy migration](tests/sync/supersync-legacy-migration-sync.spec.ts), archive-only join: conflict dialog, Keep local, genesis acknowledgement, and archived task arrival on the other device. Seeding outcomes and interrupted writes have service/integration tests.                                                                                                                                                                   |
+| `ee455beef0` #9975: ignore already-applied operations on forced download     | [Forced download after compaction](tests/sync/supersync-forced-download-pruned-import.spec.ts) checks the real rejection/re-download path and watches for unexpected conflict dialogs independently of helpers that auto-dismiss them.                                                                                                                                                                                                    |
+| `323f454c61` #9931 / #9256: empty device cannot overwrite the server         | [Final-page decrypt failure](tests/sync/supersync-final-page-decrypt-failure-9256.spec.ts) has both the blocked decrypt reproduction and refusal of a destructive overwrite, with server-copy preservation.                                                                                                                                                                                                                               |
+| `5289cd1961` #9930 / #9921 and `eaad99dad6` #9919 / #9863: genesis-only join | [Legacy migration](tests/sync/supersync-legacy-migration-sync.spec.ts) seeds credentials before boot, verifies ordinary server operations without a full-state import, requires the conflict dialog, and verifies local data reaches the other device. Other cases cover Keep remote and first-client migration.                                                                                                                          |
+| `51edc77a6b` #9887: legacy late joiner adopts server data                    | The existing Keep remote case in [legacy migration](tests/sync/supersync-legacy-migration-sync.spec.ts) is the reproduction added by this commit.                                                                                                                                                                                                                                                                                         |
+| `e35e82317a` #9879: tracking-presence device labels                          | [Tracking presence](tests/sync/supersync-tracking-presence.spec.ts) covers remote tracking and labels; native OS/device-name construction is covered by platform/unit tests.                                                                                                                                                                                                                                                              |
+| `2182ec335c` #9884: remove profiles and migrate persistence                  | [Profiles-era migration](tests/migration/user-profiles-removal-v11.spec.ts) boots seeded old IndexedDB data and checks retained active drafts. Backup/export compatibility has corresponding unit tests.                                                                                                                                                                                                                                  |
+| `b973ac9747` #9982 and `f6cf7cd79e` #10011: privacy in exportable logs       | [Decrypt failure](tests/sync/supersync-final-page-decrypt-failure-9256.spec.ts) checks diagnostic exports. Individual log call sites, lint-rule holes, and Electron spellchecking are covered more directly by lint/unit/native tests.                                                                                                                                                                                                    |
+
+## Changes where an additional browser test would not help
+
+| Change                                                                                                                 | Reason / appropriate coverage                                                                                                                                                                                      |
+| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `992c81d1cb` #9920 / #8746: shared SQLite connection gate                                                              | `sqlite-shared-connection.integration.spec.ts` exercises both adapters and native connection scheduling. Chromium uses IndexedDB and cannot reproduce the native SQLite race.                                      |
+| `cfa858661c` #9918 / #8305: mid-batch archive failure at boot                                                          | `operation-log-hydrator.failed-op-boot.integration.spec.ts` and `.retry.integration.spec.ts` already exercise boot/retry boundaries. A browser equivalent needs an artificial internal archive-write failure hook. |
+| `d25707d26e` #9915 / #8761: compensation survives failed resolution apply                                              | `conflict-resolution-persistence.integration.spec.ts` controls the failed apply at the persistence boundary. A browser cannot naturally force that specific internal failure.                                      |
+| `a95e148aa4` #9847: causal full-state SQL lookup plan                                                                  | SQL integration and PGlite plan tests verify query semantics and planner behavior. Browser task convergence cannot distinguish a generic from a custom PostgreSQL plan.                                            |
+| `df16412c8b` #9889: crash-killed backup must not look valid                                                            | `packages/super-sync-server/tests/backup-script.spec.ts` exercises the shell script and failed backup publication; this does not run in the browser.                                                               |
+| `78b31bdbc6` #9917 / #9695: orphaned PostgreSQL health probes                                                          | Docker process adoption / postmaster restart behavior, not a browser behavior.                                                                                                                                     |
+| `6872e7678b` #9995: isolate and clean up test containers                                                               | Test harness lifecycle. Verify container startup/teardown, not another app E2E.                                                                                                                                    |
+| `b9bf872bf2` #9859: Fastify security update                                                                            | Server security tests directly cover the changed HTTP behavior. Existing sync E2Es exercise the server's normal requests.                                                                                          |
+| #9998 nodemailer, #9933 WebAuthn, #9860 XML parser, #9974 security lockfile updates, and other dependency-only changes | No new sync workflow; exercise existing tests instead of duplicating them per dependency bump.                                                                                                                     |
+| #9984, #9983, #9955 and other CI changes; #9994 docs; #9896 and the timezone/menu E2E fixes                            | Automation, documentation, or existing-test reliability, not new sync behavior.                                                                                                                                    |
+
+Adjacent task/UI/API changes (#9880 appointment placement, #9525 plugin project
+deletion, #9834 duplicate shortcut, #9883 automation keyboard triggers, and #9986
+copy-as-checklist) do not change the device-sync protocol or replay behavior.
+They use the existing task/project actions or change local presentation; their
+own feature tests and existing sync/cascade tests remain the appropriate coverage.
+The other #9900 fixes (shortcut handling, GitLab worklog day, and finish-day hook)
+have focused feature/effect tests and do not introduce a device-sync path.
+
+## Validation
+
+Final focused run: **7 passed in 5.6 minutes, with retries disabled** (six new
+cases plus the existing mid-batch schema-version control).
+
+Verified with Chromium, the checked-out SuperSync server, and a disposable
+PostgreSQL 15 database. `E2E_REQUIRE_SUPERSYNC=true` prevents an unavailable
+backend from silently skipping the sync tests.
+
+Each of the six new cases was also verified against the old behavior:
+
+- Reopening: temporarily used the task reducer and internal effects from
+  `b1b39f9c60^`; both remote tasks remained completed.
+- Vocabulary: used the converter from `5bde0aa362^` and removed the later
+  unknown-vocabulary gate; an unknown type lost the valid prefix, and an unknown
+  import reason incorrectly completed sync instead of blocking.
+- Calendar/GitHub: used the respective service implementations from
+  `50db311cdd^`; the calendar toast lost the HTTP detail and GitHub replaced the
+  protected title. These controls were rerun after compilation settled to
+  exclude dev-server startup failures.
+
+All temporary production edits were restored byte for byte. `npm run checkFile`
+passed for all four changed TypeScript test files and the restored source files.
+Existing tests listed above were inspected for coverage; the full SuperSync and
+WebDAV suites were not rerun as part of this audit.
+
+To run the focused cases using the repository's Docker-backed runner:
+
+```sh
+npm run e2e:supersync:file -- \
+  e2e/tests/sync/supersync-reopen-started-task-9904.spec.ts \
+  e2e/tests/sync/supersync-error-scenarios.spec.ts \
+  e2e/tests/issue-provider-panel/github-sync-direction-9900.spec.ts \
+  e2e/tests/issue-provider-panel/calendar-connection-error-9900.spec.ts \
+  --grep 'reopening|Mid-batch|GitHub refresh|calendar connection failure' \
+  --workers=1 --retries=0
+```

--- a/e2e/tests/issue-provider-panel/calendar-connection-error-9900.spec.ts
+++ b/e2e/tests/issue-provider-panel/calendar-connection-error-9900.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '../../fixtures/test.fixture';
+
+// #9900: CalendarIntegrationService swallowed the HttpErrorResponse, so the
+// setup dialog could only say "Connection failed". Preserve the reason but
+// redact the URL, which commonly embeds a private calendar access token.
+test('calendar connection failure shows the HTTP status without exposing its URL', async ({
+  page,
+  workViewPage,
+}) => {
+  await workViewPage.waitForTaskList();
+  const calendarUrl = 'https://calendar.example/private-secret-9900/events.ics';
+  let requests = 0;
+  await page.route(calendarUrl, async (route) => {
+    requests++;
+    await route.fulfill({ status: 401, body: 'Unauthorized' });
+  });
+
+  await page.locator('.e2e-toggle-issue-provider-panel').click();
+  await page.locator('mat-tab-group .mat-mdc-tab:last-child').click();
+  await page.getByRole('button', { name: 'Other (iCal)' }).click();
+  const dialog = page.locator('dialog-edit-issue-provider');
+  await dialog.locator('input[id*="icalUrl"]').fill(calendarUrl);
+  await dialog.getByRole('button', { name: 'Test connection' }).click();
+
+  const snack = page.locator('mat-snack-bar-container');
+  await expect(snack).toContainText('Connection failed:');
+  await expect(snack).toContainText('401');
+  await expect(snack).not.toContainText('private-secret-9900');
+  await expect(snack).not.toContainText(calendarUrl);
+  expect(requests).toBeGreaterThan(0);
+  await expect(dialog).toBeVisible();
+});

--- a/e2e/tests/issue-provider-panel/github-sync-direction-9900.spec.ts
+++ b/e2e/tests/issue-provider-panel/github-sync-direction-9900.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '../../fixtures/test.fixture';
+
+// #9900: refreshing a plugin issue used the import mapping and then raw issue
+// fields, overwriting task fields even when their sync direction was off.
+test('GitHub refresh respects disabled title sync while still pulling status', async ({
+  page,
+  workViewPage,
+  taskPage,
+}) => {
+  await workViewPage.waitForTaskList();
+  let refreshed = false;
+  let refreshRequests = 0;
+  await page.route('https://api.github.com/**', async (route) => {
+    const issue = {
+      id: 9900,
+      number: 9900,
+      title: refreshed ? 'Remote replacement' : 'Original issue',
+      body: 'Issue body',
+      state: refreshed ? 'closed' : 'open',
+      html_url: 'https://github.com/e2e/repro/issues/9900',
+      created_at: '2026-09-01T12:00:00Z',
+      updated_at: refreshed ? '2026-09-02T12:00:00Z' : '2026-09-01T12:00:00Z',
+      comments: 0,
+      labels: [],
+    };
+    if (refreshed && route.request().url().includes('/issues/9900')) {
+      refreshRequests++;
+    }
+    await route.fulfill({
+      json: route.request().url().includes('/search/issues') ? { items: [issue] } : issue,
+    });
+  });
+
+  await page.locator('.e2e-toggle-issue-provider-panel').click();
+  await page.locator('mat-tab-group .mat-mdc-tab:last-child').click();
+  await page.getByRole('button', { name: 'GitHub Issues', exact: true }).click();
+  const dialog = page.locator('dialog-edit-issue-provider');
+  await dialog.locator('input[id*="repo"]').fill('e2e/repro');
+  await dialog.getByRole('button', { name: /Two-Way Sync/i }).click();
+  await dialog.locator('mat-select[id*="twoWaySync.title"]').click();
+  await page.getByRole('option', { name: 'Off', exact: true }).click();
+  await dialog.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(dialog).toBeHidden();
+
+  await page.locator('mat-tab-group .mat-mdc-tab').first().click();
+  await page.locator('issue-provider-tab input[name="search"]').fill('Original issue');
+  await page
+    .locator('issue-preview-item', { hasText: 'Original issue' })
+    .getByRole('button')
+    .first()
+    .click();
+  await page.locator('.e2e-toggle-issue-provider-panel').click();
+  const task = taskPage.getTaskByText('#9900 Original issue');
+  await expect(task).toBeVisible();
+  await expect(task).not.toHaveClass(/isDone/);
+  const taskId = await task.getAttribute('data-task-id');
+
+  refreshed = true;
+  await task.click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Update issue data' }).click();
+
+  // A pulled status change proves the refresh completed. The same response's
+  // title must not overwrite the imported, mapped title (#9900 prefix included).
+  const updatedTask = page.locator(`task[data-task-id="${taskId}"]`).first();
+  await expect(updatedTask).toHaveClass(/isDone/);
+  await expect(updatedTask.locator('task-title')).toHaveText('#9900 Original issue');
+  expect(refreshRequests).toBeGreaterThan(0);
+});

--- a/e2e/tests/sync/supersync-error-scenarios.spec.ts
+++ b/e2e/tests/sync/supersync-error-scenarios.spec.ts
@@ -16,6 +16,8 @@ interface MutableServerOperation {
   op?: {
     id?: string;
     schemaVersion?: number;
+    opType?: string;
+    syncImportReason?: string;
   };
 }
 
@@ -83,7 +85,7 @@ const areLocalOperationsSynced = (page: Page, operationIds: string[]): Promise<b
  * - B.4: Payload too large shows alert dialog
  * - G.5: Duplicate operation silently marked as synced
  * - G.7: Schema version mismatch returns handled error
- * - G.8: Failed operation migration skips op
+ * - G.8: Schema/vocabulary blockers preserve the valid prefix and retry the suffix
  *
  * Run with: npm run e2e:supersync:file e2e/tests/sync/supersync-error-scenarios.spec.ts
  */
@@ -483,101 +485,113 @@ test.describe('@supersync Error Scenarios', () => {
   });
 
   /**
-   * Scenario G.8: A mid-batch schema blocker applies only the valid prefix and keeps
+   * Scenario G.8: A mid-batch compatibility blocker applies only the valid prefix and keeps
    * the cursor before the blocker so the suffix can be retried after recovery.
    */
-  test('Mid-batch schema blocker applies prefix and retries suffix from prior cursor', async ({
-    browser,
-    baseURL,
-    testRunId,
-  }) => {
-    test.setTimeout(120000);
-    let clientA: SimulatedE2EClient | null = null;
-    let clientB: SimulatedE2EClient | null = null;
-    let injectedResponses = 0;
+  // #8764 / #9922: vocabulary can grow without a schema bump. The valid
+  // prefix must still apply; neither the blocker nor its suffix may be lost.
+  for (const field of ['schemaVersion', 'opType', 'syncImportReason'] as const) {
+    test(`Mid-batch ${field} blocker applies prefix and retries suffix from prior cursor`, async ({
+      browser,
+      baseURL,
+      testRunId,
+    }) => {
+      test.setTimeout(120000);
+      let clientA: SimulatedE2EClient | null = null;
+      let clientB: SimulatedE2EClient | null = null;
+      let injectedResponses = 0;
 
-    try {
-      const user = await createTestUser(testRunId);
-      const syncConfig = getSuperSyncConfig(user);
+      try {
+        const user = await createTestUser(testRunId);
+        const syncConfig = getSuperSyncConfig(user);
 
-      clientA = await createSimulatedClient(browser, baseURL!, 'A', testRunId);
-      await clientA.sync.setupSuperSync(syncConfig);
+        clientA = await createSimulatedClient(browser, baseURL!, 'A', testRunId);
+        await clientA.sync.setupSuperSync(syncConfig);
 
-      clientB = await createSimulatedClient(browser, baseURL!, 'B', testRunId);
-      await clientB.sync.setupSuperSync(syncConfig);
-      const cursorBeforeBlock = await getSuperSyncCursor(clientB.page);
-      expect(cursorBeforeBlock).not.toBeNull();
+        clientB = await createSimulatedClient(browser, baseURL!, 'B', testRunId);
+        await clientB.sync.setupSuperSync(syncConfig);
+        const cursorBeforeBlock = await getSuperSyncCursor(clientB.page);
+        expect(cursorBeforeBlock).not.toBeNull();
 
-      const taskNames = [
-        `MigrationPrefix-${testRunId}`,
-        `MigrationBlocker-${testRunId}`,
-        `MigrationSuffix-${testRunId}`,
-      ];
-      const uploadedOpIds: string[] = [];
-      await routeSuperSyncOps(clientA.page, async (route) => {
-        if (route.request().method() === 'POST') {
-          const upload = parseSuperSyncRequestBody<OperationUploadBody>(route.request());
-          uploadedOpIds.push(...upload.ops.map((operation) => operation.id));
-        }
-        await route.continue();
-      });
-      for (const taskName of taskNames) {
-        await clientA.workView.addTask(taskName);
-      }
-      await clientA.sync.syncAndWait();
-      await unrouteSuperSyncOps(clientA.page);
-      expect(uploadedOpIds).toHaveLength(3);
-      const blockerOpId = uploadedOpIds[1];
-
-      await routeSuperSyncOps(clientB.page, async (route) => {
-        if (route.request().method() === 'GET') {
-          const response = await route.fetch();
-          const body = (await response.json()) as OperationDownloadBody;
-          const blocker = body.ops?.find(({ op }) => op?.id === blockerOpId);
-          if (blocker?.op) {
-            // Use a real encrypted operation and change only its schema metadata,
-            // preserving real server sequences on both sides of the blocker.
-            blocker.op.schemaVersion = 99;
-            injectedResponses++;
+        const taskNames = [
+          `MigrationPrefix-${testRunId}`,
+          `MigrationBlocker-${testRunId}`,
+          `MigrationSuffix-${testRunId}`,
+        ];
+        const uploadedOpIds: string[] = [];
+        await routeSuperSyncOps(clientA.page, async (route) => {
+          if (route.request().method() === 'POST') {
+            const upload = parseSuperSyncRequestBody<OperationUploadBody>(
+              route.request(),
+            );
+            uploadedOpIds.push(...upload.ops.map((operation) => operation.id));
           }
-          await route.fulfill({
-            response,
-            body: JSON.stringify(body),
-          });
-          return;
+          await route.continue();
+        });
+        for (const taskName of taskNames) {
+          await clientA.workView.addTask(taskName);
         }
-        await route.continue();
-      });
+        await clientA.sync.syncAndWait();
+        await unrouteSuperSyncOps(clientA.page);
+        expect(uploadedOpIds).toHaveLength(3);
+        const blockerOpId = uploadedOpIds[1];
 
-      await clientB.sync.syncBtn.click();
-      await expect.poll(() => clientB!.sync.hasSyncError()).toBe(true);
+        await routeSuperSyncOps(clientB.page, async (route) => {
+          if (route.request().method() === 'GET') {
+            const response = await route.fetch();
+            const body = (await response.json()) as OperationDownloadBody;
+            const blocker = body.ops?.find(({ op }) => op?.id === blockerOpId);
+            if (blocker?.op) {
+              // Preserve the real encrypted payload and server sequences.
+              // These fields are plaintext metadata from a newer client.
+              if (field === 'schemaVersion') {
+                blocker.op.schemaVersion = 99;
+              } else if (field === 'opType') {
+                blocker.op.opType = 'FUTURE_OP_TYPE';
+              } else {
+                blocker.op.syncImportReason = 'FUTURE_IMPORT_REASON';
+              }
+              injectedResponses++;
+            }
+            await route.fulfill({
+              response,
+              body: JSON.stringify(body),
+            });
+            return;
+          }
+          await route.continue();
+        });
 
-      expect(injectedResponses).toBeGreaterThan(0);
-      expect(await getSuperSyncCursor(clientB.page)).toBe(cursorBeforeBlock);
-      await waitForTask(clientB.page, taskNames[0]);
-      await expect(
-        clientB.page.locator(`task:has-text("${taskNames[1]}")`),
-      ).not.toBeVisible();
-      await expect(
-        clientB.page.locator(`task:has-text("${taskNames[2]}")`),
-      ).not.toBeVisible();
+        await clientB.sync.syncBtn.click();
+        await expect.poll(() => clientB!.sync.hasSyncError()).toBe(true);
 
-      await unrouteSuperSyncOps(clientB.page);
-      await clientB.sync.syncAndWait();
-      for (const taskName of taskNames) {
-        await waitForTask(clientB.page, taskName);
+        expect(injectedResponses).toBeGreaterThan(0);
+        expect(await getSuperSyncCursor(clientB.page)).toBe(cursorBeforeBlock);
+        await waitForTask(clientB.page, taskNames[0]);
+        await expect(
+          clientB.page.locator(`task:has-text("${taskNames[1]}")`),
+        ).not.toBeVisible();
+        await expect(
+          clientB.page.locator(`task:has-text("${taskNames[2]}")`),
+        ).not.toBeVisible();
+
+        await unrouteSuperSyncOps(clientB.page);
+        await clientB.sync.syncAndWait();
+        for (const taskName of taskNames) {
+          await waitForTask(clientB.page, taskName);
+        }
+        expect(await clientB.sync.hasSyncError()).toBe(false);
+        expect(await getSuperSyncCursor(clientB.page)).not.toBe(cursorBeforeBlock);
+      } finally {
+        if (clientA) {
+          await unrouteSuperSyncOps(clientA.page).catch(() => {});
+          await closeClient(clientA);
+        }
+        if (clientB) {
+          await unrouteSuperSyncOps(clientB.page).catch(() => {});
+          await closeClient(clientB);
+        }
       }
-      expect(await clientB.sync.hasSyncError()).toBe(false);
-      expect(await getSuperSyncCursor(clientB.page)).not.toBe(cursorBeforeBlock);
-    } finally {
-      if (clientA) {
-        await unrouteSuperSyncOps(clientA.page).catch(() => {});
-        await closeClient(clientA);
-      }
-      if (clientB) {
-        await unrouteSuperSyncOps(clientB.page).catch(() => {});
-        await closeClient(clientB);
-      }
-    }
-  });
+    });
+  }
 });

--- a/e2e/tests/sync/supersync-reopen-started-task-9904.spec.ts
+++ b/e2e/tests/sync/supersync-reopen-started-task-9904.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from '../../fixtures/supersync.fixture';
+import {
+  closeClient,
+  createSimulatedClient,
+  createTestUser,
+  getSubtaskElement,
+  getSuperSyncConfig,
+  getTaskElement,
+  type SimulatedE2EClient,
+} from '../../utils/supersync-helpers';
+import type { Page } from '@playwright/test';
+import { waitForAppReady } from '../../utils/waits';
+
+type Completion = { isDone: boolean; doneOn?: number };
+const readCompletion = (page: Page, taskId: string): Promise<Completion> =>
+  page.evaluate(async (id) => {
+    const { store } = (
+      window as unknown as {
+        __e2eTestHelpers: {
+          store: {
+            subscribe: (
+              cb: (state: { tasks: { entities: Record<string, Completion> } }) => void,
+            ) => { unsubscribe: () => void };
+          };
+        };
+      }
+    ).__e2eTestHelpers;
+    return new Promise<Completion>((resolve) => {
+      const subscription = store.subscribe((state) => {
+        window.setTimeout(() => subscription.unsubscribe());
+        const task = state.tasks.entities[id];
+        resolve({ isDone: task.isDone, doneOn: task.doneOn });
+      });
+    });
+  }, taskId);
+
+// #9904 / #9916: setCurrentTask used to reopen the task only in local state.
+// The second device must receive a persistent update, including clearing doneOn.
+test.describe('@supersync Starting a completed task (#9904)', () => {
+  for (const withSubtask of [false, true]) {
+    test(`reopening ${withSubtask ? 'a completed subtask by starting its parent' : 'a completed task'} syncs and survives reload`, async ({
+      browser,
+      baseURL,
+      testRunId,
+    }) => {
+      let clientA: SimulatedE2EClient | undefined;
+      let clientB: SimulatedE2EClient | undefined;
+      try {
+        const config = getSuperSyncConfig(await createTestUser(testRunId));
+        clientA = await createSimulatedClient(browser, baseURL!, 'A', testRunId);
+        await clientA.sync.setupSuperSync(config);
+        clientB = await createSimulatedClient(browser, baseURL!, 'B', testRunId);
+        await clientB.sync.setupSuperSync(config);
+
+        await clientA.workView.waitForTaskList();
+        const parentName = `Parent-${testRunId}`;
+        const taskName = withSubtask ? `Child-${testRunId}` : parentName;
+        await clientA.workView.addTask(parentName);
+        if (withSubtask) {
+          await clientA.workView.addSubTask(
+            getTaskElement(clientA, parentName),
+            taskName,
+          );
+        }
+        const taskId = await getSubtaskElement(clientA, taskName).getAttribute(
+          'data-task-id',
+        );
+        expect(taskId).toBeTruthy();
+        const parent = getTaskElement(clientA, parentName).first();
+        const leaf = getSubtaskElement(clientA, taskName).first();
+        await leaf.focus();
+        await leaf.press('d');
+        await expect(getSubtaskElement(clientA, taskName).first()).toHaveClass(/isDone/);
+        await clientA.sync.syncAndWait();
+        await clientB.sync.syncAndWait();
+
+        // Control: B really received the completion before A starts tracking.
+        await clientB.page.reload();
+        await waitForAppReady(clientB.page);
+        const completed = await readCompletion(clientB.page, taskId!);
+        expect(completed).toMatchObject({ isDone: true, doneOn: expect.any(Number) });
+
+        // Completed rows have no play button; the supported Y shortcut starts
+        // them directly without first toggling completion by hand.
+        await parent.focus();
+        await parent.press('y');
+        const startedTask = getSubtaskElement(clientA, taskName).first();
+        await expect(startedTask).toHaveClass(/isCurrent/);
+        await expect(startedTask).not.toHaveClass(/isDone/);
+        await startedTask.focus();
+        await startedTask.press('y');
+        await expect(startedTask).not.toHaveClass(/isCurrent/);
+        await clientA.sync.syncAndWait();
+        await clientB.sync.syncAndWait();
+
+        // The old reducer-only change left B done forever, even though sync
+        // reported success. Tracking itself must remain local to A.
+        const remoteTask = getSubtaskElement(clientB, taskName).first();
+        await expect(remoteTask).toBeVisible();
+        await expect(remoteTask).not.toHaveClass(/isDone/);
+        await expect(clientB.page.locator('task.isCurrent')).toHaveCount(0);
+        await clientB.page.reload();
+        await waitForAppReady(clientB.page);
+        await expect(remoteTask).not.toHaveClass(/isDone/);
+        const reopened = await readCompletion(clientB.page, taskId!);
+        expect(reopened.isDone).toBe(false);
+        expect(reopened.doneOn).toBeUndefined();
+      } finally {
+        if (clientA) await closeClient(clientA);
+        if (clientB) await closeClient(clientB);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Problem

Several sync-related fixes from September 3–10 lacked browser reproductions for their user-visible behavior. Regressions could leave reopened tasks completed on another device, mishandle unknown operation vocabulary, overwrite GitHub fields with sync disabled, or hide calendar connection failure details.

## Solution

Add six E2E regression cases:

- Reopen a completed task, or a completed subtask by starting its parent, and verify completion state propagates and survives reload (#9904 / #9916).
- Extend the existing mid-batch schema blocker test to unknown operation types and import reasons, verifying valid-prefix application, cursor preservation, and suffix recovery (#8764 / #9922).
- Refresh a GitHub issue with title sync off, preserving its mapped title while pulling status (#9900).
- Show the HTTP status for a failed calendar connection without exposing its private URL (#9900).

The coverage audit in `e2e/sync-coverage-2026-09-10.md` maps the week's changes to new or existing tests and explains exclusions. Changes are limited to tests and documentation.

## Type of Change

- [x] Documentation
- [x] Other: E2E regression coverage

## Validation

- Seven targeted Chromium E2E cases passed in 5.6 minutes with retries disabled, using the checked-out SuperSync server and disposable PostgreSQL database.
- Each of the six new cases failed at the intended assertion against the previous behavior; all temporary production edits were restored.
- `npm run checkFile` passed for all four changed TypeScript files; formatting and diff checks passed.
- Independent subagent review found no actionable issues. The reviewer inspected source and red/green evidence without rerunning browsers.
- Full SuperSync and WebDAV suites were not rerun.

## Checklist

- [x] I have included relevant documentation (coverage audit; no user-facing behavior change).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files.
- [x] I have added tests for my changes.
- [ ] Existing tests still pass (focused existing control passed; full suites not run).
- [x] My commit messages follow the Angular format (`type(scope): description`).
