### PR TITLE
fix(supersync): make health alerts self-diagnosing

### DIFF
--- a/packages/super-sync-server/scripts/MONITORING-README.md
+++ b/packages/super-sync-server/scripts/MONITORING-README.md
@@ -417,6 +417,18 @@ Repeat alerts for the same problem are suppressed by a content hash, so counts,
 durations and the probe's exit status are normalised out — you get one mail per
 distinct problem, plus a recovery mail when it clears.
 
+When the database probe fails, its **stderr** is appended to the mail body under
+`Database probe stderr (URLs redacted):` — body only, never `PROBLEMS`, because
+that string is the dedupe key and error text that shifts run to run would re-mail
+every five minutes. Each URL is stripped through the end of its line before sending:
+Compose can print malformed datasource URLs with whitespace inside credentials.
+An empty capture is reported as `no stderr captured`; it does not establish why
+the probe failed. This exists because `exit 1` — the one probe failure
+that _does_ carry a cause — used to send that cause to `/dev/null`, leaving a status
+code that cannot distinguish "Prisma threw" from "the exec never started". Measured
+2026-09: four such alerts in ten hours, and reaching "the database was healthy all
+along" needed five rounds of manual `ssh` forensics that the mail could have carried.
+
 On top of that, two rules bound how loud a single incident can get. They exist
 because one incident is routinely reported as several different problems: a long
 query saturates the pool, the health probe then times out behind it, and the
@@ -486,9 +498,30 @@ You can set up cron jobs for regular monitoring:
 ### `deploy.sh` warns "OOM detection is BLIND"
 
 The OOM check reads `journalctl -k`. A cron user outside `adm`/`systemd-journal`
-— or any host without systemd — gets no output and **exit 0**, so before
+can get no output and **exit 0**, so before
 2026-08-25 the check silently could never fire and the absence of an OOM alert
 was not evidence of no OOM. It now probes readability first.
+
+The marker's second line distinguishes these observations:
+
+| Reason          | Observation                                                       | Advice                                                 |
+| --------------- | ----------------------------------------------------------------- | ------------------------------------------------------ |
+| `no-journalctl` | journalctl is not installed                                       | The journal-based check is unavailable                 |
+| `journal-error` | journalctl failed or timed out, even if it printed partial output | Check `journalctl -k` and journal configuration        |
+| `unreadable`    | Successful empty read without root or a recognized journal group  | Check the cron user's journal permissions              |
+| `no-kernel-log` | Successful empty read as root or a member of a journal group      | Check journal configuration and host kernel-log access |
+
+Group names are matched exactly: `systemd-journal-remote` does not grant the
+access associated with `systemd-journal`. The check does not use journalctl's
+permissions hint, because `-q` suppresses it. Membership helps choose advice;
+it does not prove access or identify a container guest. Empty output can also
+reflect journal configuration such as `Storage=none` or `ReadKMsg=no`.
+
+Measured 2026-09 on the hosted OpenVZ VPS: the marker sat at `unreadable` for 16
+days while every alert advised joining a group the operator was already in. On
+that host the kernel log was unavailable; `docker inspect --format
+'{{.State.OOMKilled}}'` is the substitute, and checks 0–3 still catch the restart
+that follows.
 
 An unreadable kernel log is a broken capability, not an unhealthy service, so it
 is recorded in `.health-alert/oom-check-blind` and surfaced by `deploy.sh`
@@ -499,7 +532,7 @@ could never be sent again on a host that merely lacks a group. (Alerts
 themselves would keep arriving: the dedupe key is a content hash, so a new
 problem still changes the hash and still mails.)
 
-Fix it rather than ignoring it: `sudo usermod -aG systemd-journal "$USER"`
+For a missing journal group: `sudo usermod -aG systemd-journal "$USER"`
 (re-login required). Prefer `systemd-journal` over `adm` — it grants the journal
 read and nothing else, where `adm` also opens `/var/log` broadly. Running the
 cron as root works too but grants far more than this one read needs. The marker

--- a/packages/super-sync-server/scripts/deploy.sh
+++ b/packages/super-sync-server/scripts/deploy.sh
@@ -549,6 +549,12 @@ report_monitoring_status() {
             # Not the operator's to fix: no systemd, so no journal and no group to join.
             printf '    NOTE: no journalctl on this host, so the OOM check is unavailable (since %s).\n' "$oom_ts"
             echo "          Not a misconfiguration — every other check is unaffected."
+        elif [ "$oom_reason" = "journal-error" ]; then
+            printf '    WARNING: OOM detection is BLIND (journal read failed, since %s).\n' "$oom_ts"
+            echo "             Check journalctl -k and journal configuration."
+        elif [ "$oom_reason" = "no-kernel-log" ]; then
+            printf '    NOTE: no kernel log entries are available, so the OOM check is unavailable\n'
+            printf '          (since %s). Check journal configuration and host kernel-log access.\n' "$oom_ts"
         else
             printf '    WARNING: OOM detection is BLIND (kernel log unreadable, since %s).\n' "$oom_ts"
             echo "             Container OOM kills will not be alerted on. Add the cron user to"

--- a/packages/super-sync-server/scripts/health-alert.sh
+++ b/packages/super-sync-server/scripts/health-alert.sh
@@ -84,20 +84,35 @@ OOM_BLIND_FILE="$ALERT_STATE_DIR/oom-check-blind"
 # See the check itself for why.
 POOL_PENDING_FILE="$ALERT_STATE_DIR/pool-busy-pending"
 MAIL_ERR_MAX_BYTES=4096
+# The database probe's own stderr, carried into the alert BODY. Far shorter than the mail
+# limit above: this is diagnostic context appended to an alert, not the alert itself, and a
+# Prisma stack trace would otherwise bury the problem list it is attached to.
+DB_PROBE_ERR_MAX_BYTES=512
+
+# Strip terminal control sequences from text this script did not produce (a remote SMTP
+# relay, a Prisma error) and that is about to be echoed to a terminal or mailed. The sed
+# matches UTF-8-*encoded* C1 (\xc2 followed by \x80-\x9f, which encodes U+0080-U+009F and
+# nothing else) so CSI/OSC go but em-dash, NBSP and CJK survive; a plain 0x80-0x9F byte
+# range would instead eat UTF-8 continuation bytes and corrupt every non-ASCII message.
+# Both halves are pinned by the "strips UTF-8-encoded C1 controls" spec case. TAB (\011)
+# and newline (\012) are deliberately spared: a multi-line probe error stays readable. $1
+# caps the output length.
+# shortcut: `|| true` because `head -c` closing the pipe early makes the pipeline exit 141
+# under `set -o pipefail` on any input that truncates. Both call sites discard the status
+# today, so this only stops that from becoming a trap for a future `… || warn` caller.
+strip_control_chars() {
+  { LC_ALL=C tr -d '\000-\010\013-\037\177' |
+    LC_ALL=C sed 's/\xc2[\x80-\x9f]//g' | head -c "$1"; } || true
+}
 
 # Record why mail could not be delivered. Line 1 is always the timestamp, so readers that
 # want only that (deploy.sh) can take the first line; the reason follows. Reason text can
-# originate from a remote SMTP relay and deploy.sh echoes it to a terminal, so strip
-# control characters and cap the length at write time. The sed matches UTF-8-*encoded* C1
-# (\xc2 followed by \x80-\x9f, which encodes U+0080-U+009F and nothing else) so CSI/OSC go
-# but em-dash, NBSP and CJK survive; a plain 0x80-0x9F byte range would instead eat UTF-8
-# continuation bytes and corrupt every non-ASCII message. Both halves are pinned by the
-# "strips UTF-8-encoded C1 controls" spec case.
+# originate from a remote SMTP relay and deploy.sh echoes it to a terminal, so it is
+# sanitized and capped at write time.
 record_mail_failure() {
   {
     date -u +%Y-%m-%dT%H:%M:%SZ
-    printf '%s\n' "$1" | LC_ALL=C tr -d '\000-\010\013-\037\177' |
-      LC_ALL=C sed 's/\xc2[\x80-\x9f]//g' | head -c "$MAIL_ERR_MAX_BYTES"
+    printf '%s\n' "$1" | strip_control_chars "$MAIL_ERR_MAX_BYTES"
   } > "$MAIL_FAILED_FILE"
 }
 
@@ -132,6 +147,15 @@ if ! flock -n 9; then
   exit 0
 fi
 
+# The probe's stderr lands here UNREDACTED for the ~25s between the redirect and the read,
+# and a Prisma connection error can name the datasource URL. The normal path unlinks it,
+# but a SIGKILL or reboot inside that window would otherwise leave a credential on disk
+# until the next probe truncates the file. umask 077 keeps it 0600, which is the second
+# line of defence, not the first: the state dir is documented above as something an
+# operator may widen so a non-root deploy.sh can read the markers.
+DB_ERRFILE="$ALERT_STATE_DIR/.db-probe-err"
+trap 'rm -f "$DB_ERRFILE"' EXIT
+
 # A stock Debian/Ubuntu host has no `mail` binary, and without this check the first
 # discovery of that is the first real incident, months after setup. Record it in the marker
 # deploy.sh already surfaces — never in CONFIG_PROBLEMS, which is the alert body and the
@@ -165,6 +189,10 @@ fi
 
 PROBLEMS="$CONFIG_PROBLEMS"
 DOCKER_OK=true
+# Set only when the database probe fails, and only ever read into the mail body. Declared
+# here because the probe lives behind the Docker gate: under `set -u` a Docker-down run
+# would otherwise abort at the body-assembly line below.
+DB_PROBE_DETAIL=""
 
 # 0. Check Docker daemon is accessible
 if ! docker info >/dev/null 2>&1; then
@@ -400,9 +428,17 @@ NODE
     # SIGKILLs it and compose's buffered stdout dies with it — a healthy server then reports
     # every probe key missing. Measured live: 25s/exit 137 without it, 1s/exit 0 with.
     # Allow Prisma's 5s pool wait plus its 12s transaction bound to finish.
+    # stderr to a FILE, not 2>/dev/null and not a pipe. Discarding it is why an exit-1
+    # probe — the one failure mode where Prisma DID report a cause — arrived as a bare
+    # status with the only useful line already gone, and a database that was healthy every
+    # time anyone went and looked. A pipe would be worse than either: command substitution
+    # waits for EOF, so a child outliving `timeout` would hang the run while holding the
+    # flock, which is the same trap send_alert_mail documents above. $DB_ERRFILE is set
+    # next to the flock, with an EXIT trap; the redirect below truncates it every run, so a
+    # file left by a killed run can never be read as if it were this run's output.
     DB_OUTPUT=$(timeout -k 5 20 docker compose exec -T \
       -e "HEALTH_MAX_QUERY_SECONDS=$MAX_QUERY_SECONDS" \
-      supersync timeout 18 node -e "$DB_PROBE_JS" </dev/null 2>/dev/null)
+      supersync timeout 18 node -e "$DB_PROBE_JS" </dev/null 2>"$DB_ERRFILE")
     DB_STATUS=$?
 
     LONG_Q=""
@@ -439,8 +475,17 @@ NODE
       # The status separates a timeout or kill (124/137) from a broken exec (126/127), a
       # probe error (1) and incomplete output (0). Not the probe's stderr: PROBLEMS is the
       # dedupe hash input, so text that varies per run would re-alert every five minutes.
+      # The stderr goes into the mail BODY instead, below.
       PROBLEMS="${PROBLEMS}Database monitoring checks failed (exit ${DB_STATUS})\n"
+      # Read only on failure. Compose can print malformed datasource URLs containing
+      # whitespace in credentials, so redact from ANY scheme through the end of its line.
+      # Redact before truncating, so the byte limit cannot cut inside a credential.
+      DB_PROBE_DETAIL=$(LC_ALL=C sed -E 's#[a-zA-Z][a-zA-Z0-9+.-]*://.*#<redacted-url>#' \
+        "$DB_ERRFILE" 2>/dev/null | strip_control_chars "$DB_PROBE_ERR_MAX_BYTES")
+      # Empty stderr is possible after a timeout, silent failure or malformed output.
+      : "${DB_PROBE_DETAIL:=(no stderr captured)}"
     fi
+    rm -f "$DB_ERRFILE"
 
     if $DB_RESULTS_OK; then
       if [ "$LONG_Q" -gt 0 ]; then
@@ -513,8 +558,19 @@ fi
 OOM_BLIND_REASON=""
 if ! command -v "$JOURNAL_CMD" >/dev/null 2>&1; then
   OOM_BLIND_REASON="no-journalctl"
-elif [ -z "$(timeout 10 "$JOURNAL_CMD" -k -q -n 1 --no-pager 2>/dev/null)" ]; then
-  OOM_BLIND_REASON="unreadable"
+elif ! KERNEL_LOG=$(timeout 10 "$JOURNAL_CMD" -k -q -n 1 --no-pager 2>/dev/null); then
+  # A failed or timed-out read is inconclusive, even if it printed some entries.
+  OOM_BLIND_REASON="journal-error"
+elif [ -z "$KERNEL_LOG" ]; then
+  # -q suppresses journalctl's permissions hint. Check exact group names to avoid
+  # recommending membership the user already has, but do not infer the host type:
+  # empty output can also reflect journal configuration or host restrictions.
+  if [ "$(id -u 2>/dev/null)" = "0" ] ||
+    id -nG 2>/dev/null | grep -qE '(^|[[:space:]])(adm|systemd-journal|wheel)([[:space:]]|$)'; then
+    OOM_BLIND_REASON="no-kernel-log"
+  else
+    OOM_BLIND_REASON="unreadable"
+  fi
 fi
 if [ -n "$OOM_BLIND_REASON" ]; then
   PREVIOUS_REASON=""
@@ -524,6 +580,10 @@ if [ -n "$OOM_BLIND_REASON" ]; then
   if [ "$PREVIOUS_REASON" != "$OOM_BLIND_REASON" ]; then
     if [ "$OOM_BLIND_REASON" = "no-journalctl" ]; then
       echo "health-alert: no journalctl on this host — OOM detection is unavailable (not a misconfiguration)." >&2
+    elif [ "$OOM_BLIND_REASON" = "journal-error" ]; then
+      echo "health-alert: failed to read the kernel log — OOM detection is blind. Check journalctl -k and journal configuration." >&2
+    elif [ "$OOM_BLIND_REASON" = "no-kernel-log" ]; then
+      echo "health-alert: no kernel log entries are available — OOM detection is unavailable. Check journal configuration and host kernel-log access." >&2
     else
       echo "health-alert: cannot read the kernel log — OOM detection is blind. Add the cron user to group 'systemd-journal' (or 'adm')." >&2
     fi
@@ -623,8 +683,16 @@ if [ -n "$PROBLEMS" ]; then
     if [ -f "$OOM_BLIND_FILE" ]; then
       COVERAGE_NOTE=$'\nNote: the OOM check did not run (kernel log unavailable), so an OOM kill\nwould not appear above. See scripts/MONITORING-README.md.\n'
     fi
-    if printf 'SuperSync health check failed at %s\n\nProblems found:\n%b\n%sServer: %s\n' \
-        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROBLEMS" "$COVERAGE_NOTE" "$(hostname)" \
+    # Same reasoning as COVERAGE_NOTE: body only. It varies run to run by design — that is
+    # the point of it — and PROBLEMS is the dedupe key, so putting it there would re-mail
+    # the same incident on every flip of a Prisma error string.
+    PROBE_DETAIL_NOTE=""
+    if [ -n "$DB_PROBE_DETAIL" ]; then
+      PROBE_DETAIL_NOTE=$'\nDatabase probe stderr (URLs redacted):\n'"$DB_PROBE_DETAIL"$'\n'
+    fi
+    if printf 'SuperSync health check failed at %s\n\nProblems found:\n%b\n%s%sServer: %s\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROBLEMS" "$PROBE_DETAIL_NOTE" "$COVERAGE_NOTE" \
+        "$(hostname)" \
         | send_alert_mail "SuperSync Alert: Health Check Failed"; then
       # One line per distinct symptom, so growth is bounded by the check list, not by its
       # power set. Cleared on recovery and aged out above.

--- a/packages/super-sync-server/tests/health-alert-script.spec.ts
+++ b/packages/super-sync-server/tests/health-alert-script.spec.ts
@@ -107,6 +107,9 @@ fi
 if [ "\${1:-}" = "exec" ]; then
   # Real \`docker compose exec -T\` keeps stdin attached and does not exit until EOF.
   cat > /dev/null
+  # The probe's stderr: what Prisma writes when it throws, and what the script used to
+  # send to /dev/null. Emitted before the exit so a failing probe can carry both.
+  [ -z "\${FAKE_DB_STDERR:-}" ] || printf '%b\n' "\$FAKE_DB_STDERR" >&2
   [ "\${FAKE_DB_EXIT:-0}" = "0" ] || exit "$FAKE_DB_EXIT"
   if [ "\${FAKE_DB_MALFORMED:-0}" = "1" ]; then
     printf 'not monitor data\n'
@@ -131,14 +134,31 @@ printf '%s' "\${FAKE_HTTP_CODE-200}"
 exit "\${FAKE_CURL_EXIT:-0}"
 `;
 
-// A readable kernel log. FAKE_JOURNAL_BLIND=1 reproduces a cron user outside 'adm' /
-// 'systemd-journal': systemd prints its hint on stderr, emits no kernel line and exits 0.
+// A readable kernel log. FAKE_JOURNAL_BLIND=1 makes `journalctl -k` emit no kernel line
+// and exit 0 — which is what BOTH blind cases look like on stdout, deliberately: a cron
+// user outside the journal groups and a host with no recorded kernel entries are
+// indistinguishable here. FAKE_ID_GROUPS helps choose advice without assuming a cause;
+// journalctl's own hint is suppressed by the -q the script passes.
 const FAKE_JOURNALCTL = `#!/bin/sh
+if [ "\${FAKE_JOURNAL_EXIT:-0}" != "0" ]; then
+  printf '%b' "\${FAKE_KERNEL_LOG:-}"
+  exit "$FAKE_JOURNAL_EXIT"
+fi
 if [ "\${FAKE_JOURNAL_BLIND:-0}" = "1" ]; then
-  printf '%s\n' 'Hint: You are currently not seeing messages from other users and the system.' >&2
   exit 0
 fi
 printf '%b\n' "\${FAKE_KERNEL_LOG:-Aug 25 09:00:00 host kernel: Linux version 6.0.0}"
+`;
+
+// The discriminator between "unreadable" and "no-kernel-log". Defaults to a user with no
+// journal access, so a test that does not opt in gets the branch carrying the actionable
+// advice — the safe direction if the script's default ever regresses.
+const FAKE_ID = `#!/bin/sh
+if [ "\${1:-}" = "-u" ]; then
+  printf '%s\n' "\${FAKE_ID_UID:-1000}"
+  exit 0
+fi
+printf '%s\n' "\${FAKE_ID_GROUPS:-nogroup users}"
 `;
 
 const FAKE_DF = `#!/bin/sh
@@ -286,6 +306,7 @@ beforeEach(() => {
   writeExecutable('df', FAKE_DF);
   writeExecutable('mail', FAKE_MAIL);
   writeExecutable('journalctl', FAKE_JOURNALCTL);
+  writeExecutable('id', FAKE_ID);
   writeExecutable('mountpoint', '#!/bin/sh\nexit 1\n');
 });
 
@@ -538,6 +559,115 @@ describe('health-alert.sh service and database monitoring', () => {
     expect(result.mailLog).toContain('Database monitoring checks failed');
   });
 
+  it('carries the probe stderr into the alert body', () => {
+    // Measured 2026-09: four "Database monitoring checks failed" mails, one of them exit 1
+    // — the single mode where the probe DID catch a cause and print it — and `2>/dev/null`
+    // discarded it. The status alone cannot distinguish a Prisma error from a docker exec
+    // that never started, so the alert cost a full manual investigation to reach a
+    // database that was healthy the whole time.
+    const result = run({
+      FAKE_DB_EXIT: '1',
+      FAKE_DB_STDERR: 'Database probe failed: Timed out fetching a new connection',
+    });
+
+    expect(result.mailLog).toContain('Database monitoring checks failed (exit 1)');
+    expect(result.mailLog).toContain('Timed out fetching a new connection');
+  });
+
+  it('redacts a datasource URL from the probe stderr before mailing it', () => {
+    // Prisma names the datasource in several connection errors, and this text is emailed.
+    const result = run({
+      FAKE_DB_EXIT: '1',
+      FAKE_DB_STDERR:
+        'P1001: cannot reach postgresql://supersync:hunter2@db:5432/supersync?schema=public',
+    });
+
+    expect(result.mailLog).toContain('P1001: cannot reach');
+    expect(result.mailLog).not.toContain('hunter2');
+    expect(result.mailLog).not.toContain('db:5432');
+  });
+
+  it('keeps the probe stderr out of the dedupe key', () => {
+    // The whole reason the status is normalized: a body that varies run to run must not
+    // reopen the incident, or a Prisma error whose text shifts would mail every 5 minutes.
+    run({ FAKE_DB_EXIT: '1', FAKE_DB_STDERR: 'first failure text' });
+    const result = run({ FAKE_DB_EXIT: '1', FAKE_DB_STDERR: 'entirely different text' });
+
+    expect(countAlerts(result.mailLog)).toBe(1);
+  });
+
+  it('redacts a malformed datasource URL through the end of its line', () => {
+    // Actual Docker Compose interpolation error: the invalid URL includes a space in
+    // the password, so treating whitespace as its end leaks the remaining credential.
+    const result = run({
+      FAKE_DB_EXIT: '1',
+      FAKE_DB_STDERR:
+        'invalid interpolation format for services.supersync.environment.DATABASE_URL.\n' +
+        'postgresql://demo:before SECRET_SUFFIX${BROKEN@db:5432/test\n' +
+        'Check the Compose configuration.',
+    });
+
+    expect(result.mailLog).toContain('invalid interpolation format');
+    expect(result.mailLog).toContain('<redacted-url>');
+    expect(result.mailLog).not.toContain('SECRET_SUFFIX');
+    expect(result.mailLog).not.toContain('db:5432');
+    expect(result.mailLog).toContain('Check the Compose configuration.');
+  });
+
+  it('omits the probe stderr section on a healthy run', () => {
+    // A probe that warns on stdout-clean success must not append noise to an unrelated
+    // alert, so the capture is read only on the failing path.
+    const result = run({ ...FAILING_PROBE, FAKE_DB_STDERR: 'a harmless warning' });
+
+    expect(result.mailLog).toContain('SuperSync health check failed');
+    expect(result.mailLog).not.toContain('Database probe stderr');
+    expect(result.mailLog).not.toContain('a harmless warning');
+  });
+
+  it('leaves no probe stderr scratch file behind', () => {
+    run({ FAKE_DB_EXIT: '1', FAKE_DB_STDERR: 'boom' });
+
+    expect(existsSync(stateFile('.db-probe-err'))).toBe(false);
+  });
+
+  it.each(['0', '1', '124'])(
+    'reports empty stderr without inventing a cause for probe exit %s',
+    (exit) => {
+      const result = run({ FAKE_DB_EXIT: exit, FAKE_DB_MALFORMED: '1' });
+
+      expect(result.mailLog).toContain(
+        `Database monitoring checks failed (exit ${exit})`,
+      );
+      expect(result.mailLog).toContain('(no stderr captured)');
+      expect(result.mailLog).not.toContain('killed before it could report');
+    },
+  );
+
+  it('redacts any URL scheme, not just the two Prisma spellings we expect', () => {
+    // An allowlist of postgres:// and postgresql:// silently passes prisma:// (Accelerate,
+    // whose api_key IS the credential) and any future scheme. Over-redacting an unrelated
+    // URL costs one line of diagnostic text; under-redacting costs a credential.
+    const result = run({
+      FAKE_DB_EXIT: '1',
+      FAKE_DB_STDERR: 'P6008 prisma://accelerate.example.net/?api_key=SECRETKEY123',
+    });
+
+    expect(result.mailLog).toContain('P6008');
+    expect(result.mailLog).not.toContain('SECRETKEY123');
+  });
+
+  it('strips control characters from the probe stderr too', () => {
+    // strip_control_chars is shared with record_mail_failure precisely so the two cannot
+    // drift; only the mail-failure caller was pinned, so this half was free to regress.
+    const result = run({
+      FAKE_DB_EXIT: '1',
+      FAKE_DB_STDERR: 'before\\033[2J\\033[1;31mafter',
+    });
+
+    expect(result.mailLog).toContain('after');
+    expect(result.mailLog).not.toMatch(/[ --]/);
+  });
+
   it.each(['', 'not-a-number', '0'])(
     'alerts when the running DATABASE_URL connection_limit is %j',
     (poolLimit) => {
@@ -763,6 +893,81 @@ describe('health-alert.sh kernel log OOM check', () => {
     expect(result.output).toContain('no journalctl on this host');
     expect(result.output).not.toContain("group 'systemd-journal'");
     expect(readStateFile('oom-check-blind')).toContain('no-journalctl');
+  });
+
+  it('does not read a hint that the -q it passes suppresses', () => {
+    // journalctl(1) on -q: "Suppresses all informational messages ..., any warning messages
+    // regarding inaccessible system journals when run as a normal user" — i.e. the exact
+    // "you are currently not seeing messages" hint. An earlier cut of this fix grepped for
+    // it, so `unreadable` was unreachable and EVERY permission-blind host was told its
+    // problem was unfixable. Verified against systemd 255. The discriminator must be
+    // something -q cannot erase, so no journalctl stderr may appear in the decision.
+    const script = readFileSync(HEALTH_ALERT_SCRIPT, 'utf8');
+
+    expect(script).not.toContain('not seeing messages');
+  });
+
+  it.each([
+    ['adm', 'nogroup adm users'],
+    ['systemd-journal', 'nogroup systemd-journal'],
+    ['wheel', 'wheel users'],
+  ])('does not blame permissions when the user is already in %s', (_group, groups) => {
+    // Empty output can reflect host restrictions or journal configuration. Group
+    // membership alone cannot establish the cause, so keep the diagnosis neutral.
+    const result = run({ FAKE_JOURNAL_BLIND: '1', FAKE_ID_GROUPS: groups });
+
+    expect(result.output).toContain('no kernel log entries are available');
+    expect(result.output).not.toContain('not a misconfiguration');
+    expect(result.output).not.toContain("group 'systemd-journal'");
+    expect(readStateFile('oom-check-blind')).toContain('no-kernel-log');
+  });
+
+  it('does not blame permissions when running as root', () => {
+    // root is in none of those groups and reads the journal regardless, so a group-only
+    // check would send the one user who cannot have a permission problem after one.
+    const result = run({
+      FAKE_JOURNAL_BLIND: '1',
+      FAKE_ID_UID: '0',
+      FAKE_ID_GROUPS: 'root',
+    });
+
+    expect(result.output).toContain('no kernel log entries are available');
+    expect(result.output).not.toContain('not a misconfiguration');
+    expect(readStateFile('oom-check-blind')).toContain('no-kernel-log');
+  });
+
+  it.each([
+    'admin adminx journal',
+    'users systemd-journal-remote',
+    'users adm-readonly',
+    'users wheel-backup',
+  ])('keeps the actionable advice for a user in unrelated groups: %s', (groups) => {
+    // The direction that matters: this is the only branch the operator can act on, and the
+    // -q defect made it unreachable. A near-miss group name must not count as access.
+    const result = run({
+      FAKE_JOURNAL_BLIND: '1',
+      FAKE_ID_GROUPS: groups,
+    });
+
+    expect(result.output).toContain('OOM detection is blind');
+    expect(result.output).toContain("group 'systemd-journal'");
+    expect(readStateFile('oom-check-blind')).toContain('unreadable');
+  });
+
+  it.each([
+    ['1', ''],
+    ['124', ''],
+    ['1', 'kernel: Linux version 6.0.0'],
+  ])('reports journal exit %s as a failed read, even with output %j', (exit, output) => {
+    const result = run({
+      FAKE_ID_UID: '0',
+      FAKE_JOURNAL_EXIT: exit,
+      FAKE_KERNEL_LOG: output,
+    });
+
+    expect(result.output).toContain('failed to read the kernel log');
+    expect(result.output).not.toContain('not a misconfiguration');
+    expect(readStateFile('oom-check-blind')).toContain('journal-error');
   });
 
   it('tells the operator in the alert body that OOM coverage was missing', () => {
@@ -1157,6 +1362,31 @@ describe('health-alert.sh state handling', () => {
     expect(output).toContain('usermod -aG systemd-journal');
   });
 
+  it('reports missing kernel entries without assuming a container limitation', () => {
+    writeStateFile('oom-check-blind', '2026-09-10T03:05:00Z\nno-kernel-log\n');
+
+    const output = runDeployMonitoringStatus();
+
+    expect(output).toContain('no kernel log entries are available');
+    expect(output).toContain('journal configuration');
+    expect(output).toContain('since 2026-09-10T03:05:00Z');
+    expect(output).not.toContain('usermod');
+    expect(output).not.toContain('OOM detection is BLIND');
+    expect(output).not.toContain('not a misconfiguration');
+  });
+
+  it('reports failed journal reads as a capability that needs investigation', () => {
+    writeStateFile('oom-check-blind', '2026-09-10T03:05:00Z\njournal-error\n');
+
+    const output = runDeployMonitoringStatus();
+
+    expect(output).toContain('OOM detection is BLIND');
+    expect(output).toContain('journal read failed');
+    expect(output).toContain('journalctl -k');
+    expect(output).not.toContain('usermod');
+    expect(output).not.toContain('not a misconfiguration');
+  });
+
   it('does not tell a non-systemd host to join a group that cannot exist', () => {
     // Dockerfile:60 ships scripts/ to self-hosters, Alpine among them. A permanent
     // WARNING with unfollowable remediation on every deploy is how an operator learns to
@@ -1340,6 +1570,10 @@ describe('health-alert.sh replaying the night of 2026-08-25', () => {
             `${entry.at} ${mail
               .replace(/\s+/g, ' ')
               .replace(/.*Problems found: /, '')
+              // Body-only sections, in the order they appear. This assertion is about
+              // WHICH problems were reported and when; the diagnostic context appended
+              // after them is covered by its own tests.
+              .replace(/ Database probe stderr.*/, '')
               .replace(/ (Note|Server):.*/, '')}`,
           );
         }

--- a/src/assets/community-plugins.json
+++ b/src/assets/community-plugins.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/dougcooper/sp-reporter",
     "author": "dougcooper",
     "authorUrl": "https://github.com/dougcooper",
-    "stars": 32
+    "stars": 58
   },
   {
     "name": "Archived Tasks Viewer",
@@ -13,7 +13,7 @@
     "url": "https://github.com/baiyina/Archived-Tasks-Viewer",
     "author": "baiyina",
     "authorUrl": "https://github.com/baiyina",
-    "stars": 31
+    "stars": 61
   },
   {
     "name": "QuestArc",
@@ -21,7 +21,7 @@
     "url": "https://codeberg.org/Nexumia/QuestArc",
     "author": "Nexumia",
     "authorUrl": "https://codeberg.org/Nexumia",
-    "stars": 4
+    "stars": 8
   },
   {
     "name": "AutoPlan",
@@ -29,7 +29,7 @@
     "url": "https://codeberg.org/00sapo/sp-autoplan",
     "author": "00sapo",
     "authorUrl": "https://codeberg.org/00sapo",
-    "stars": 28
+    "stars": 13
   },
   {
     "name": "Asana Integration",
@@ -37,7 +37,7 @@
     "url": "https://codeberg.org/sinenomine/sp-asana",
     "author": "sinenomine",
     "authorUrl": "https://codeberg.org/sinenomine",
-    "stars": 0
+    "stars": 2
   },
   {
     "name": "Obsidian Integration",
@@ -45,7 +45,7 @@
     "url": "https://codeberg.org/sinenomine/sp-obsidian/",
     "author": "sinenomine",
     "authorUrl": "https://codeberg.org/sinenomine",
-    "stars": 5
+    "stars": 10
   },
   {
     "name": "MCP",
@@ -53,7 +53,7 @@
     "url": "https://github.com/organicmoron/SP-MCP",
     "author": "organicmoron",
     "authorUrl": "https://github.com/organicmoron",
-    "stars": 68
+    "stars": 120
   },
   {
     "name": "Super Productivity MCP",
@@ -61,7 +61,7 @@
     "url": "https://github.com/b0x42/Super-Productivity-MCP",
     "author": "b0x42",
     "authorUrl": "https://github.com/b0x42",
-    "stars": 11
+    "stars": 81
   },
   {
     "name": "Dashboard",
@@ -69,7 +69,7 @@
     "url": "https://github.com/ahanel13/sp-dashboard",
     "author": "ahanel13",
     "authorUrl": "https://github.com/ahanel13",
-    "stars": 9
+    "stars": 19
   },
   {
     "name": "Invoicer",
@@ -77,7 +77,7 @@
     "url": "https://github.com/1jamesthompson1/sp-invoicer",
     "author": "1jamesthompson1",
     "authorUrl": "https://github.com/1jamesthompson1",
-    "stars": 11
+    "stars": 24
   },
   {
     "name": "StudyForge Leaderboard",
@@ -93,7 +93,7 @@
     "url": "https://codeberg.org/sinenomine/sp-task-print",
     "author": "sinenomine",
     "authorUrl": "https://codeberg.org/sinenomine/",
-    "stars": 1
+    "stars": 2
   },
   {
     "name": "AI Assistant",
@@ -101,7 +101,7 @@
     "url": "https://github.com/ai-eifying/ai-assistant-plugin",
     "author": "ai-eifying",
     "authorUrl": "https://github.com/ai-eifying",
-    "stars": 4
+    "stars": 33
   },
   {
     "name": "Memos Sync",
@@ -109,7 +109,7 @@
     "url": "https://github.com/giba0/memos-sync",
     "author": "giba0",
     "authorUrl": "https://github.com/giba0",
-    "stars": 2
+    "stars": 7
   },
   {
     "name": "YouTrack Importer for SuperProductivity",
@@ -117,7 +117,7 @@
     "url": "https://github.com/coissay/superProductivity-YoutrackPlugin",
     "author": "coissay",
     "authorUrl": "https://github.com/coissay",
-    "stars": 0
+    "stars": 2
   },
   {
     "name": "Home Assistant Bridge",
@@ -125,7 +125,7 @@
     "url": "https://github.com/jloops412/ha-super-productivity",
     "author": "jloops412",
     "authorUrl": "https://github.com/jloops412",
-    "stars": 0
+    "stars": 14
   },
   {
     "name": "Goals Vision Board",
@@ -133,7 +133,7 @@
     "url": "https://github.com/CuriousChipmunk/vision-board-super-productivity",
     "author": "CuriousChipmunk",
     "authorUrl": "https://github.com/CuriousChipmunk",
-    "stars": 0
+    "stars": 33
   },
   {
     "name": "sync.md Multi",
@@ -141,7 +141,7 @@
     "url": "https://codeberg.org/fpindado/sync-md-multi",
     "author": "Fernando Pindado",
     "authorUrl": "https://codeberg.org/fpindado",
-    "stars": 0
+    "stars": 2
   },
   {
     "name": "JSON to Tasks",
@@ -157,6 +157,6 @@
     "url": "https://github.com/BigWebstas/SuperProd-Joplin-Sync",
     "author": "BigWebstas",
     "authorUrl": "https://github.com/BigWebstas",
-    "stars": 0
+    "stars": 3
   }
 ]


### PR DESCRIPTION
## Problem

Failed database monitoring probes discarded stderr, leaving alerts without the cause needed to investigate. Empty kernel-journal output could also produce incorrect permissions advice or be presented as an unfixable container limitation.

## Solution

- Include bounded, sanitized probe stderr in alert bodies without changing incident deduplication. Redact URL-bearing lines through their end to cover malformed datasource credentials, and report empty stderr without assuming the probe was killed.
- Distinguish failed journal reads from empty results, match complete journal group names, and use neutral guidance when the cause of missing kernel entries is unknown.
- Update deployment reporting, monitoring documentation, and regression coverage.
- This branch also includes the inherited community-plugin star-count refresh from `bd051874dd`.

## Validation

- All 113 health-alert script tests pass, including regression cases that failed before the fixes.
- Isolated reproductions using real Docker Compose and journalctl confirm credential redaction and correct journal-error reporting.
- `npm run checkFile packages/super-sync-server/tests/health-alert-script.spec.ts`, shell syntax checks for both scripts, and `git diff --check` pass.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [x] Other: inherited plugin catalog metadata update

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass (113 health-alert tests)
- [x] My commit messages follow the Angular format (`type(scope): description`)
