### PR TITLE
fix(build): unbreak the snap by bumping electron-builder to 26.16.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,34 @@ jobs:
           release: false
           args: '--publish never'
 
+      # electron-builder 26.15.0-26.15.6 only 7z-decompressed the snap template's
+      # .tar.7z and shipped the inner .tar verbatim at the snap root, so the
+      # desktop-integration scripts command.sh sources were missing and every
+      # edge revision failed to start (#9992, electron-builder#10002). The build
+      # itself stayed green, so assert on the packaged payload instead.
+      - name: Verify snap template was unpacked
+        run: |
+          set -euo pipefail
+          SNAP_FILE=$(find ./.tmp/app-builds -type f -name '*.snap' -print -quit)
+          if [ -z "$SNAP_FILE" ]; then
+            echo "::error::no .snap produced in .tmp/app-builds"
+            exit 1
+          fi
+          # squashfs-tools is not guaranteed on the runner image, and installing without
+          # refreshing apt lists first fails with "Unable to locate package".
+          if ! command -v unsquashfs > /dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends squashfs-tools
+          fi
+          unsquashfs -l "$SNAP_FILE" > "$RUNNER_TEMP/snap-listing.txt"
+          for script in desktop-init.sh desktop-common.sh desktop-gnome-specific.sh; do
+            grep -qx "squashfs-root/$script" "$RUNNER_TEMP/snap-listing.txt" || {
+              echo "::error::$script missing from the snap root -- the template archive was not unpacked"
+              grep -E '^squashfs-root/[^/]+$' "$RUNNER_TEMP/snap-listing.txt"
+              exit 1
+            }
+          done
+
       - name: Normalize snap file name
         if: false == startsWith(github.ref, 'refs/tags/v')
         run: find ./.tmp/app-builds -type f -name '*.snap' -exec sh -c 'x="{}"; mv "$x" ".tmp/app-builds/sp.snap"' \;

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "detect-it": "^4.0.1",
         "dotenv": "^17.4.2",
         "electron": "43.5.0",
-        "electron-builder": "^26.15.3",
+        "electron-builder": "^26.16.1",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": "^2.32.0",
@@ -3728,9 +3728,9 @@
       }
     },
     "node_modules/@electron/rebuild": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.4.tgz",
-      "integrity": "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.2.0.tgz",
+      "integrity": "sha512-RKL/O+jGoXJMxrx/5771y1n0xTKmFuOYGO3gMmwypBM6rsH0kou0mswwdXA2JrhIkE4xyC7v9vGk0n6NPzgOxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10095,9 +10095,9 @@
       }
     },
     "node_modules/app-builder-lib": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.3.tgz",
-      "integrity": "sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==",
+      "version": "26.16.1",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.16.1.tgz",
+      "integrity": "sha512-FhaO6YOup01ZfQW0Z6gt3AyukJjv1gW4uFK47jTgwcHZKqyN/fSlK2LqPf9tAeZYLP2bRJLDzeOkRImsw2X4Pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10109,13 +10109,13 @@
         "@electron/rebuild": "^4.0.4",
         "@electron/universal": "2.0.3",
         "@malept/flatpak-bundler": "^0.4.0",
-        "@noble/hashes": "^2.2.0",
+        "@noble/hashes": "^1.8.0",
         "@peculiar/webcrypto": "^1.7.1",
         "@types/fs-extra": "9.0.13",
         "ajv": "^8.18.0",
         "asn1js": "^3.0.10",
         "async-exit-hook": "^2.0.1",
-        "builder-util": "26.15.3",
+        "builder-util": "26.16.0",
         "builder-util-runtime": "9.7.0",
         "chromium-pickle-js": "^0.2.0",
         "ci-info": "4.3.1",
@@ -10123,7 +10123,7 @@
         "dotenv": "^16.4.5",
         "dotenv-expand": "^11.0.6",
         "ejs": "^3.1.8",
-        "electron-publish": "26.15.3",
+        "electron-publish": "26.16.0",
         "fs-extra": "^10.1.0",
         "hosted-git-info": "^4.1.0",
         "isbinaryfile": "^5.0.0",
@@ -10147,8 +10147,8 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "dmg-builder": "26.15.3",
-        "electron-builder-squirrel-windows": "26.15.3"
+        "dmg-builder": "26.16.1",
+        "electron-builder-squirrel-windows": "26.16.1"
       }
     },
     "node_modules/app-builder-lib/node_modules/@electron/get": {
@@ -10250,19 +10250,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/@noble/hashes": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
-      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/app-builder-lib/node_modules/@types/fs-extra": {
@@ -11190,9 +11177,9 @@
       "license": "MIT"
     },
     "node_modules/builder-util": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.15.3.tgz",
-      "integrity": "sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==",
+      "version": "26.16.0",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.16.0.tgz",
+      "integrity": "sha512-RLyJhB7Si3YkzKR9ubQslWuXW3Vhs3CGe1i+SeixBZ0qTd1mk3XBmssvY22TlB6CS5blyko8Gu1JzpYk8UkYAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12836,14 +12823,14 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.3.tgz",
-      "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
+      "version": "26.16.1",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.16.1.tgz",
+      "integrity": "sha512-pnI/3Qb24Uk+rMTgIUrsVUKosVgwmBUdF8Zeb8TexOSbpq8MWc7v6l+n+FrEqVkjNZwzBN+XpDS9ENgZ/rkWAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.15.3",
-        "builder-util": "26.15.3",
+        "app-builder-lib": "26.16.1",
+        "builder-util": "26.16.0",
         "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0"
       }
@@ -13135,18 +13122,18 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz",
-      "integrity": "sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==",
+      "version": "26.16.1",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.16.1.tgz",
+      "integrity": "sha512-LrLK65QX5PUYYODXqp23FKrV7CILTtVY7mrJckNknO9jLNSMiqFkKbSMiDRw4CjOADMPVDdWLxY4mezOZWswxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.15.3",
-        "builder-util": "26.15.3",
+        "app-builder-lib": "26.16.1",
+        "builder-util": "26.16.0",
         "builder-util-runtime": "9.7.0",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
-        "dmg-builder": "26.15.3",
+        "dmg-builder": "26.16.1",
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "simple-update-notifier": "2.0.0",
@@ -13161,15 +13148,15 @@
       }
     },
     "node_modules/electron-builder-squirrel-windows": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.3.tgz",
-      "integrity": "sha512-Jc19XPV9y9+2bAdZPkXuVNGNIEFBq9poHC61l8Kv6FdK7DRG3+Ic0rerC0DXOaeHNz8yW0fg/JnF8GQROOF5MA==",
+      "version": "26.16.1",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.16.1.tgz",
+      "integrity": "sha512-w0y44wSaT1l6R7CAGmeHn4nHPfvzDyCAU1xJyi1w9SbPYJpYn76SmHDzqHf8Y7l91cPWTdPYBpGQtB2T5mJ08A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "app-builder-lib": "26.15.3",
-        "builder-util": "26.15.3",
+        "app-builder-lib": "26.16.1",
+        "builder-util": "26.16.0",
         "electron-winstaller": "5.4.0"
       }
     },
@@ -13308,15 +13295,15 @@
       }
     },
     "node_modules/electron-publish": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.3.tgz",
-      "integrity": "sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==",
+      "version": "26.16.0",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.16.0.tgz",
+      "integrity": "sha512-Vt3KzQIiw9BImvNOYtndg9Mjki+tl4+1sQiC/+G5j8khWaENOJFWodiB+sUl6yyHwtd37avehskdtPw7f8y/+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
         "aws4": "^1.13.2",
-        "builder-util": "26.15.3",
+        "builder-util": "26.16.0",
         "builder-util-runtime": "9.7.0",
         "chalk": "^4.1.2",
         "form-data": "^4.0.5",
@@ -20153,9 +20140,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.31.0.tgz",
-      "integrity": "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.35.0.tgz",
+      "integrity": "sha512-ymk4aIzxdPopw2giv8Fs1Ec6vybGkjmyxUwVqhkI4MCy2tVfXdkOGGWieWVjL0THgH+7a8lRdevyupoYj3Js/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
     "detect-it": "^4.0.1",
     "dotenv": "^17.4.2",
     "electron": "43.5.0",
-    "electron-builder": "^26.15.3",
+    "electron-builder": "^26.16.1",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",


### PR DESCRIPTION
Fixes #9992 — snap edge revisions since 4611 fail to start with:

```
/snap/superproductivity/4611/command.sh: line 2: /snap/superproductivity/4611/desktop-init.sh: No such file or directory
```

## Root cause

#9974 moved `app-builder-lib` 26.8.1 → 26.15.3, which replaced the Go `app-builder` binary with an in-tree JS snap target. Its `extractArchive()` has a correct two-step branch for `.tar.xz` (7za, then untar) but the `.7z` branch runs 7za once and stops — and the snap template asset is `snap-template-electron-4.0-2-amd64.**tar.7z**`.

So the template dir held a single `.tar`, `buildWithTemplate()` passed that straight to `mksquashfs`, and the snap root got the tarball instead of the three desktop-integration scripts `command.sh` sources. Independently confirmed by @masterjaguar in the issue, who repaired a local snap by extracting that exact tarball into the snap root.

## Fix

Upstream fixed it in electron-userland/electron-builder#10003 (v26 backport #10004), released in **26.15.7**: `.tar.7z` now shares the two-step `.tar.xz` branch, placed ahead of the plain `.7z` one, and the extract-dir name changed so caches poisoned by the broken extraction bust themselves.

This bumps to **26.16.1** (head of the `v26` tag; npm's `latest` dist-tag is stale at the broken 26.15.3). `builder-util-runtime` stays 9.7.0, so #9974's CVE-2026-54672 / CVE-2026-54673 fixes are retained — reverting to 26.8.1 was not an option for that reason.

## Scope

- **Snap only.** The other `.7z` toolsets (appimage, fpm) are plain 7z archives, so AppImage / deb / rpm / Windows / macOS were never affected.
- **Stable is unaffected** — `git tag --contains` puts #9974 in no release. Only `latest/edge`, which auto-publishes from every master push.
- Checked the minor bump against what this config leans on: `NsisTarget.finishBuild` is byte-identical between 26.15.3 and 26.16.1, so the no-`${arch}` `artifactName` behaviour the signing-quota comment in `electron-builder.yaml` depends on is unchanged. The bump also picks up electron-builder#9983, where the NSIS install-time extractor silently dropped the main exe.
- Lockfile diff adds and removes no packages — only the electron-builder family plus transitive `@electron/rebuild` 4.2.0 and `node-abi` 4.35.0.

## CI guard

The build stayed green through all of this and shipped a non-starting snap to edge, so this also asserts on the packaged payload: after the electron-builder step, verify the three `desktop-*.sh` scripts are present at the snap root. It runs **before** the edge upload, so a broken template fails the build instead of publishing.

Verified against a real squashfs image that the assertion passes on a good listing and fails on a missing script; the shell body passes `bash -n` and the file-discovery form was exercised on a nested path and on an empty directory.

## What is not verified

No snap has actually been built with 26.16.1 — the branch push doesn't trigger `build.yml` (feature branches aren't in its trigger list). The root cause and fix rest on reading the published 26.15.3 and 26.16.1 tarballs. Merging this is what produces the proof: a green snap job plus an edge revision that starts.

https://claude.ai/code/session_01DwZ68WeqhLA3CFcjpAsMgS