### PR TITLE
fix(plugins): keep OAuth tokens through transient refresh failures

### DIFF
--- a/src/app/plugins/oauth/plugin-oauth-bridge.service.spec.ts
+++ b/src/app/plugins/oauth/plugin-oauth-bridge.service.spec.ts
@@ -2,7 +2,11 @@ import { TestBed } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 import type { OAuthFlowConfig } from '@super-productivity/plugin-api';
 import { PluginOAuthBridgeService } from './plugin-oauth-bridge.service';
-import { deleteOAuthTokens, loadOAuthTokens } from './plugin-oauth-token-store';
+import {
+  deleteOAuthTokens,
+  loadOAuthTokens,
+  saveOAuthTokens,
+} from './plugin-oauth-token-store';
 import { PluginOAuthService } from './plugin-oauth.service';
 import { PluginLog } from '../../core/log';
 
@@ -36,7 +40,10 @@ describe('PluginOAuthBridgeService', () => {
         'restoreTokens',
         'getValidToken',
       ],
-      { tokenInvalidated$: new Subject<string>() },
+      {
+        tokenInvalidated$: new Subject<string>(),
+        tokensRefreshed$: new Subject<string>(),
+      },
     );
 
     TestBed.configureTestingModule({
@@ -100,6 +107,38 @@ describe('PluginOAuthBridgeService', () => {
         redirectUri: webCallback,
       }),
     );
+  });
+
+  // The token-store writes triggered by tokenInvalidated$/tokensRefreshed$ are
+  // fire-and-forget, so poll instead of awaiting a promise the bridge does not expose.
+  const waitForStoredTokens = async (expected: string | null): Promise<string | null> => {
+    let stored: string | null = null;
+    for (let i = 0; i < 50; i++) {
+      stored = await loadOAuthTokens('test-plugin__oauth');
+      if (stored === expected) {
+        return stored;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    return stored;
+  };
+
+  it('persists the rotated access token after a successful refresh', async () => {
+    await saveOAuthTokens('test-plugin__oauth', 'stale-tokens');
+    oauthService.serializeTokens.and.returnValue('refreshed-tokens');
+
+    oauthService.tokensRefreshed$.next('test-plugin');
+
+    expect(await waitForStoredTokens('refreshed-tokens')).toBe('refreshed-tokens');
+    await deleteOAuthTokens('test-plugin__oauth');
+  });
+
+  it('deletes persisted tokens once the grant is invalidated', async () => {
+    await saveOAuthTokens('test-plugin__oauth', 'stale-tokens');
+
+    oauthService.tokenInvalidated$.next('test-plugin');
+
+    expect(await waitForStoredTokens(null)).toBeNull();
   });
 
   it('persists oauth tokens in the local token store after a successful flow', async () => {

--- a/src/app/plugins/oauth/plugin-oauth-bridge.service.ts
+++ b/src/app/plugins/oauth/plugin-oauth-bridge.service.ts
@@ -29,11 +29,18 @@ export class PluginOAuthBridgeService {
   private _pluginOAuthService = inject(PluginOAuthService);
 
   constructor() {
-    // Clear persisted OAuth tokens when a refresh fails
+    // Clear persisted OAuth tokens once the authorization server rejects the grant
     this._pluginOAuthService.tokenInvalidated$
       .pipe(takeUntilDestroyed())
       .subscribe((pluginId) => {
         this._clearPersistedOAuthTokens(pluginId);
+      });
+
+    // Persist the rotated access token, so a restart does not immediately refresh again
+    this._pluginOAuthService.tokensRefreshed$
+      .pipe(takeUntilDestroyed())
+      .subscribe((pluginId) => {
+        this._persistOAuthTokens(pluginId);
       });
   }
 

--- a/src/app/plugins/oauth/plugin-oauth.service.spec.ts
+++ b/src/app/plugins/oauth/plugin-oauth.service.spec.ts
@@ -282,7 +282,9 @@ describe('PluginOAuthService', () => {
       expect(token).toBe('refreshed-token');
     });
 
-    it('should return null if refresh fails', async () => {
+    it('should keep tokens when client authentication fails', async () => {
+      // invalid_client faults the app's own credentials, not the user's grant —
+      // deleting their refresh token cannot fix it and re-consent would fail too.
       const tokenUrl = 'https://oauth2.googleapis.com/token';
       service.storeTokens('plugin-1', {
         accessToken: 'old-token',
@@ -295,11 +297,155 @@ describe('PluginOAuthService', () => {
       const promise = service.getValidToken('plugin-1');
 
       const req = httpMock.expectOne(tokenUrl);
-      req.flush('Unauthorized', { status: 401, statusText: 'Unauthorized' });
+      req.flush({ error: 'invalid_client' }, { status: 401, statusText: 'Unauthorized' });
 
       const token = await promise;
       expect(token).toBeNull();
+      expect(service.hasTokens('plugin-1')).toBe(true);
+    });
+
+    const REFRESH_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+
+    const storeNearExpiryTokens = (): void =>
+      service.storeTokens('plugin-1', {
+        accessToken: 'old-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 60000, // within the 5-min refresh buffer
+        tokenUrl: REFRESH_TOKEN_URL,
+        clientId: 'cid',
+      });
+
+    it('should keep tokens when the refresh fails with a network error', async () => {
+      const invalidated: string[] = [];
+      service.tokenInvalidated$.subscribe((id) => invalidated.push(id));
+      storeNearExpiryTokens();
+
+      const promise = service.getValidToken('plugin-1');
+      httpMock
+        .expectOne(REFRESH_TOKEN_URL)
+        .error(new ProgressEvent('error'), { status: 0, statusText: 'Unknown Error' });
+
+      expect(await promise).toBeNull();
+      expect(service.hasTokens('plugin-1')).toBe(true);
+      expect(invalidated).toEqual([]);
+    });
+
+    it('should keep tokens when the refresh fails with a server error', async () => {
+      storeNearExpiryTokens();
+
+      const promise = service.getValidToken('plugin-1');
+      httpMock
+        .expectOne(REFRESH_TOKEN_URL)
+        .flush('Service Unavailable', { status: 503, statusText: 'Service Unavailable' });
+
+      expect(await promise).toBeNull();
+      expect(service.hasTokens('plugin-1')).toBe(true);
+    });
+
+    it('should keep tokens when the refresh is rate limited', async () => {
+      storeNearExpiryTokens();
+
+      const promise = service.getValidToken('plugin-1');
+      httpMock
+        .expectOne(REFRESH_TOKEN_URL)
+        .flush('Too Many Requests', { status: 429, statusText: 'Too Many Requests' });
+
+      expect(await promise).toBeNull();
+      expect(service.hasTokens('plugin-1')).toBe(true);
+    });
+
+    it('should refresh successfully after a transient failure', async () => {
+      storeNearExpiryTokens();
+
+      const failing = service.getValidToken('plugin-1');
+      httpMock
+        .expectOne(REFRESH_TOKEN_URL)
+        .error(new ProgressEvent('error'), { status: 0, statusText: 'Unknown Error' });
+      expect(await failing).toBeNull();
+
+      const retried = service.getValidToken('plugin-1');
+      httpMock
+        .expectOne(REFRESH_TOKEN_URL)
+        .flush({ access_token: 'refreshed-token', expires_in: 3600 });
+
+      expect(await retried).toBe('refreshed-token');
+    });
+
+    it('should clear tokens when the refresh token is rejected', async () => {
+      const invalidated: string[] = [];
+      service.tokenInvalidated$.subscribe((id) => invalidated.push(id));
+      storeNearExpiryTokens();
+
+      const promise = service.getValidToken('plugin-1');
+      httpMock
+        .expectOne(REFRESH_TOKEN_URL)
+        .flush({ error: 'invalid_grant' }, { status: 400, statusText: 'Bad Request' });
+
+      expect(await promise).toBeNull();
       expect(service.hasTokens('plugin-1')).toBe(false);
+      expect(invalidated).toEqual(['plugin-1']);
+    });
+
+    it('should keep tokens when a 4xx carries no OAuth error code', async () => {
+      // A corporate proxy answering on the token endpoint's behalf must not be
+      // mistaken for the authorization server rejecting the grant.
+      storeNearExpiryTokens();
+
+      const promise = service.getValidToken('plugin-1');
+      httpMock
+        .expectOne(REFRESH_TOKEN_URL)
+        .flush('<html>Proxy Authentication Required</html>', {
+          status: 407,
+          statusText: 'Proxy Authentication Required',
+        });
+
+      expect(await promise).toBeNull();
+      expect(service.hasTokens('plugin-1')).toBe(true);
+    });
+
+    it('should keep tokens when a recoverable OAuth error is returned', async () => {
+      storeNearExpiryTokens();
+
+      const promise = service.getValidToken('plugin-1');
+      httpMock.expectOne(REFRESH_TOKEN_URL).flush(
+        { error: 'temporarily_unavailable' },
+        {
+          status: 400,
+          statusText: 'Bad Request',
+        },
+      );
+
+      expect(await promise).toBeNull();
+      expect(service.hasTokens('plugin-1')).toBe(true);
+    });
+
+    it('should keep tokens when the refresh throws a non-HTTP error', async () => {
+      // A stored non-HTTPS tokenUrl makes _postTokenRequest throw before any request
+      // goes out — an unknown failure shape, so credentials must survive it.
+      service.storeTokens('plugin-1', {
+        accessToken: 'old-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 60000,
+        tokenUrl: 'http://insecure.example/token',
+        clientId: 'cid',
+      });
+
+      expect(await service.getValidToken('plugin-1')).toBeNull();
+      expect(service.hasTokens('plugin-1')).toBe(true);
+    });
+
+    it('should announce a successful refresh so the new token can be persisted', async () => {
+      const refreshed: string[] = [];
+      service.tokensRefreshed$.subscribe((id) => refreshed.push(id));
+      storeNearExpiryTokens();
+
+      const promise = service.getValidToken('plugin-1');
+      httpMock
+        .expectOne(REFRESH_TOKEN_URL)
+        .flush({ access_token: 'refreshed-token', expires_in: 3600 });
+
+      await promise;
+      expect(refreshed).toEqual(['plugin-1']);
     });
   });
 

--- a/src/app/plugins/oauth/plugin-oauth.service.ts
+++ b/src/app/plugins/oauth/plugin-oauth.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { firstValueFrom, Subject } from 'rxjs';
 import { OAuthFlowConfig, OAuthTokenResult } from '@super-productivity/plugin-api';
 import { generateCodeChallenge, generateCodeVerifier } from '@sp/sync-providers/pkce';
@@ -25,6 +25,35 @@ const RESERVED_OAUTH_PARAMS = new Set([
   'state',
 ]);
 
+/** The one RFC 6749 §5.2 code that proves the stored grant is dead — re-consent is the only fix. */
+const TERMINAL_OAUTH_ERROR_CODE = 'invalid_grant';
+
+/** Reads the `error` code out of an RFC 6749 §5.2 error body, if there is one. */
+const readOAuthErrorCode = (body: unknown): string | null => {
+  if (typeof body !== 'object' || body === null) {
+    return null;
+  }
+  const code = (body as { error?: unknown }).error;
+  return typeof code === 'string' ? code : null;
+};
+
+/**
+ * True only when the authorization server rejected the stored grant itself, i.e.
+ * Google's `400 {"error":"invalid_grant"}` for a revoked or expired refresh token.
+ *
+ * Deliberately keyed on the error body rather than the status code: a corporate proxy
+ * can answer 4xx on our behalf, and misreading that as a rejection destroys a perfectly
+ * good refresh token. `invalid_client` is not terminal either — it says the app's own
+ * credentials are wrong, which deleting the user's token cannot fix.
+ *
+ * The two outcomes are not symmetric: deleting live credentials is unrecoverable
+ * without full re-consent, while keeping dead ones only costs a stale "connected"
+ * state, so anything unrecognised preserves the token.
+ */
+const isTerminalOAuthRefreshError = (err: unknown): boolean =>
+  err instanceof HttpErrorResponse &&
+  readOAuthErrorCode(err.error) === TERMINAL_OAUTH_ERROR_CODE;
+
 interface PendingRedirect {
   resolve: (code: string) => void;
   reject: (error: Error) => void;
@@ -40,6 +69,9 @@ export class PluginOAuthService {
 
   /** Emits the pluginId when a token refresh fails and in-memory tokens are cleared. */
   tokenInvalidated$ = new Subject<string>();
+
+  /** Emits the pluginId after a successful refresh, so the new token can be re-persisted. */
+  tokensRefreshed$ = new Subject<string>();
 
   async prepareRedirectUri(redirectUri?: string): Promise<string> {
     if (redirectUri) {
@@ -286,11 +318,17 @@ export class PluginOAuthService {
         accessToken: refreshed.accessToken,
         expiresAt: refreshed.expiresAt,
       });
+      this.tokensRefreshed$.next(pluginId);
       return refreshed.accessToken;
     } catch (err) {
       PluginLog.err(`Failed to refresh token for plugin ${pluginId}`, err);
-      this._tokenStore.delete(pluginId);
-      this.tokenInvalidated$.next(pluginId);
+      // Only a real rejection by the authorization server means the refresh token is
+      // dead. Dropping credentials on a transient failure (offline, 5xx, proxy error)
+      // silently deletes them from disk and forces a full re-consent — see #9939.
+      if (isTerminalOAuthRefreshError(err)) {
+        this._tokenStore.delete(pluginId);
+        this.tokenInvalidated$.next(pluginId);
+      }
       return null;
     }
   }


### PR DESCRIPTION
Closes #9939.

## The bug

A token refresh attempted while offline throws `HttpErrorResponse` with `status: 0`. `PluginOAuthService._doRefresh()` caught **any** error and treated it as a rejected grant:

```ts
} catch (err) {
  this._tokenStore.delete(pluginId);
  this.tokenInvalidated$.next(pluginId);
```

`PluginOAuthBridgeService` subscribes to `tokenInvalidated$` and deletes the persisted entry from the `sup-plugin-oauth` IndexedDB store. So a momentary network drop — laptop resume, flaky wifi — destroyed the refresh token on disk and forced a full Google Calendar re-consent. Unrecoverable for the user, and silent until a task fails to sync days later. Two reporters; shipped in v18.21.2 (`git tag --contains`).

## The fix

Invalidate only on an RFC 6749 §5.2 `invalid_grant` body — the one response that proves the *stored grant* is dead:

```ts
const isTerminalOAuthRefreshError = (err: unknown): boolean =>
  err instanceof HttpErrorResponse &&
  readOAuthErrorCode(err.error) === TERMINAL_OAUTH_ERROR_CODE;
```

Two deliberate choices:

- **Keyed on the error body, not the status code.** A corporate proxy can answer 4xx on the token endpoint's behalf, and misreading that as a rejection destroys a good refresh token just the same.
- **`invalid_client` is not terminal.** It faults the app's own credentials, which deleting the user's token cannot fix — re-consent would hit the same wall.

The outcomes aren't symmetric: deleting live credentials is unrecoverable without full re-consent, while keeping dead ones only costs a stale "connected" state. So every unrecognised failure — `status: 0`, timeouts, 429, 5xx, non-HTTP throws — preserves the token and returns `null`, and the next attempt succeeds once connectivity is back.

**Also fixed:** a successful refresh only updated the in-memory map, so the persisted blob kept the stale `accessToken`/`expiresAt` and every cold start opened with an immediate refresh — widening the window for the bug above. A new `tokensRefreshed$` signal re-persists after refresh.

## Verification

- 8 new specs (45 in the service file, 653 across `src/app/plugins/`, all green). Each new test was confirmed *failing* against the behavior it pins rather than trusted for being green: 2 fail under a status-range predicate, the non-HTTP throw test fails with the branch forced on, the `invalid_client` test fails if that code is re-added, and the bridge persist test fails with its subscription stubbed out.
- Angular's XHR backend `JSON.parse`s error bodies for `responseType: 'json'` regardless of content-type (`@angular/common` `_module-chunk.mjs:1124-1128`; fetch path `:909-923`), so `invalid_grant` reaches `err.error` as an object and the terminal path is genuinely reachable — read from source, not assumed. An unparseable body stays a string and falls through to "keep the token."
- `npm run checkFile` clean on all changed files.

## Known gaps

- **No runtime repro.** Tests drive `HttpTestingController`; I never ran a real offline refresh in Electron. The `status: 0` shape comes from the reporter's log.
- **No backoff on repeated failures.** Tokens now survive, so each `getHeaders()` retries the refresh instead of short-circuiting on a cleared store — a few extra token POSTs per poll cycle during an outage. Left alone deliberately: no observed rate-limit trouble to justify the added state.
- The plugin's "Not authenticated. Please connect your Google account first." message still fires on a transient failure. It's the correct instruction for the one case that can now linger (a rejection with no parseable body), so it's unchanged.

https://claude.ai/code/session_01CidkKhRdNgvKBaAPrn4NnX