### PR TITLE
fix(note): keep the phone note toolbar's overflow reachable (#10015)

### DIFF
--- a/e2e/tests/notes/note-toolbar-touch-scroll.spec.ts
+++ b/e2e/tests/notes/note-toolbar-touch-scroll.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '../../fixtures/test.fixture';
+
+// MatTooltip only takes its touch code path when `Platform.ANDROID`/`IOS` is
+// true, and that check is UA-sniffed — a touch-enabled context alone is not
+// enough to reproduce #10015. The fixture appends `PLAYWRIGHT-WORKER-n`, so
+// onboarding is still skipped with this UA in place.
+const ANDROID_UA =
+  'Mozilla/5.0 (Linux; Android 15; Nothing Phone 1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Mobile Safari/537.36';
+
+test.use({
+  userAgent: ANDROID_UA,
+  // The custom isolated-context fixture consumes contextOptions, so keep the
+  // mobile/touch descriptor nested here (same reason as the mobile-webkit
+  // project in playwright.config.ts).
+  contextOptions: {
+    viewport: { width: 393, height: 851 },
+    deviceScaleFactor: 2.75,
+    isMobile: true,
+    hasTouch: true,
+  },
+});
+
+test.describe('Fullscreen note editor toolbar on a phone', () => {
+  test('keeps the overflowing formatting controls reachable by touch', async ({
+    page,
+    workViewPage,
+  }) => {
+    await workViewPage.waitForTaskList();
+
+    // The notes page object drives the desktop side panel; on the phone layout
+    // Project Notes is only reachable through the side panel menu.
+    await page.locator('button[aria-label="Side Panel Menu"]').first().tap();
+    await page.locator('.mat-mdc-menu-item', { hasText: 'Project Notes' }).first().tap();
+    await page.locator('#add-note-btn, button:has-text("Add new Note")').first().tap();
+
+    const toolbar = page.locator('dialog-fullscreen-markdown .formatting-toolbar');
+    await expect(toolbar).toBeVisible();
+
+    // Precondition: the toolbar really is wider than the screen here. Without
+    // this the rest of the test would pass vacuously on a wider viewport.
+    const overflowPx = await toolbar.evaluate((el) => el.scrollWidth - el.clientWidth);
+    expect(overflowPx).toBeGreaterThan(0);
+
+    // The regression itself: MatTooltip's long-press gesture writes an inline
+    // `touch-action: none` onto every tooltip host, and the buttons tile the
+    // whole toolbar — so a swipe never becomes a pan and the overflow is
+    // unreachable. Headless Chromium cannot synthesize a real compositor pan,
+    // so assert on the property that gates one.
+    const blockedButtonCount = await toolbar.evaluate(
+      (el) =>
+        Array.from(el.querySelectorAll('button')).filter(
+          (btn) => getComputedStyle(btn).touchAction === 'none',
+        ).length,
+    );
+    expect(blockedButtonCount).toBe(0);
+
+    // …and scrolling actually brings the hidden controls into view.
+    const lastButton = toolbar.locator('button').last();
+    await expect(lastButton).not.toBeInViewport();
+    await toolbar.evaluate((el) => {
+      el.scrollLeft = el.scrollWidth;
+    });
+    await expect(lastButton).toBeInViewport();
+  });
+});

--- a/e2e/tests/notes/note-toolbar-touch-scroll.spec.ts
+++ b/e2e/tests/notes/note-toolbar-touch-scroll.spec.ts
@@ -24,6 +24,7 @@ test.describe('Fullscreen note editor toolbar on a phone', () => {
   test('keeps the overflowing formatting controls reachable by touch', async ({
     page,
     workViewPage,
+    testPrefix,
   }) => {
     await workViewPage.waitForTaskList();
 
@@ -31,7 +32,18 @@ test.describe('Fullscreen note editor toolbar on a phone', () => {
     // Project Notes is only reachable through the side panel menu.
     await page.locator('button[aria-label="Side Panel Menu"]').first().tap();
     await page.locator('.mat-mdc-menu-item', { hasText: 'Project Notes' }).first().tap();
+
+    const noteText = `${testPrefix}-toolbar-note`;
     await page.locator('#add-note-btn, button:has-text("Add new Note")').first().tap();
+    await page.locator('dialog-fullscreen-markdown textarea').fill(noteText);
+    await page.locator('#T-save-note').tap();
+    await expect(page.locator('dialog-fullscreen-markdown')).toBeHidden();
+
+    // Reopen the saved note. #10015 is about editing an existing Project Note,
+    // which is DialogFullscreenMarkdownComponent itself — the add-note flow
+    // above is the DialogAddNoteComponent subclass, and the two only share this
+    // template by path, so assert against the one the issue actually names.
+    await page.locator('note', { hasText: noteText }).locator('.markdown-preview').tap();
 
     const toolbar = page.locator('dialog-fullscreen-markdown .formatting-toolbar');
     await expect(toolbar).toBeVisible();

--- a/e2e/tests/notes/note-toolbar-touch-scroll.spec.ts
+++ b/e2e/tests/notes/note-toolbar-touch-scroll.spec.ts
@@ -42,8 +42,15 @@ test.describe('Fullscreen note editor toolbar on a phone', () => {
     // Reopen the saved note. #10015 is about editing an existing Project Note,
     // which is DialogFullscreenMarkdownComponent itself — the add-note flow
     // above is the DialogAddNoteComponent subclass, and the two only share this
-    // template by path, so assert against the one the issue actually names.
+    // template by path.
     await page.locator('note', { hasText: noteText }).locator('.markdown-preview').tap();
+
+    // Both components declare `selector: 'dialog-fullscreen-markdown'`, so the
+    // element alone cannot tell them apart. Prefilled content can: the add-note
+    // dialog always opens empty.
+    await expect(page.locator('dialog-fullscreen-markdown textarea')).toHaveValue(
+      noteText,
+    );
 
     const toolbar = page.locator('dialog-fullscreen-markdown .formatting-toolbar');
     await expect(toolbar).toBeVisible();

--- a/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.html
+++ b/src/app/ui/dialog-fullscreen-markdown/dialog-fullscreen-markdown.component.html
@@ -4,9 +4,20 @@
 >
   @if (viewMode === 'TEXT_ONLY' || viewMode === 'SPLIT') {
     <div class="editor-section">
+      <!--
+        The toolbar is wider than a phone (~565px vs 393px on a Nothing Phone 1)
+        and relies on its own `overflow-x: auto` to reach the last controls.
+        `matTooltipTouchGestures="off"` is load-bearing for that: on a touch
+        platform MatTooltip writes an inline `touch-action: none` onto every
+        tooltip host to claim the long-press, and the buttons tile the whole
+        toolbar — so a swipe never becomes a pan and the overflowing controls
+        are unreachable (#10015). Long-press tooltips are a desktop affordance
+        anyway; hover tooltips are unaffected.
+      -->
       <div class="formatting-toolbar">
         <button
           mat-icon-button
+          matTooltipTouchGestures="off"
           (mousedown)="$event.preventDefault()"
           (click)="onApplyHeading(1)"
           [matTooltip]="T.F.NOTE.D_FULLSCREEN.TOOLBAR.HEADING_1 | translate"
@@ -16,6 +27,7 @@
         </button>
         <button
           mat-icon-button
+          matTooltipTouchGestures="off"
           (mousedown)="$event.preventDefault()"
           (click)="onApplyHeading(2)"
           [matTooltip]="T.F.NOTE.D_FULLSCREEN.TOOLBAR.HEADING_2 | translate"
@@ -25,6 +37,7 @@
         </button>
         <button
           mat-icon-button
+          matTooltipTouchGestures="off"
           (mousedown)="$event.preventDefault()"
           (click)="onApplyHeading(3)"
           [matTooltip]="T.F.NOTE.D_FULLSCREEN.TOOLBAR.HEADING_3 | translate"
@@ -37,6 +50,7 @@
 
         <button
           mat-icon-button
+          matTooltipTouchGestures="off"
           (mousedown)="$event.preventDefault()"
           (click)="onApplyBold()"
           [matTooltip]="
@@ -49,6 +63,7 @@
         </button>
         <button
           mat-icon-button
+          matTooltipTouchGestures="off"
           (mousedown)="$event.preventDefault()"
           (click)="onApplyItalic()"
           [matTooltip]="
@@ -61,6 +76,7 @@
         </button>
         <button
           mat-icon-button
+          matTooltipTouchGestures="off"
           (mousedown)="$event.preventDefault()"
           (click)="onApplyStrikethrough()"
           [matTooltip]="
@@ -76,6 +92,7 @@
 
         <button
           mat-icon-button
+          matTooltipTouchGestures="off"
           (mousedown)="$event.preventDefault()"
           (click)="onApplyBulletList()"
           [matTooltip]="
@@ -88,6 +105,7 @@
         </button>
         <button
           mat-icon-button
+          matTooltipTouchGestures="off"
           (mousedown)="$event.preventDefault()"
           (click)="onApplyNumberedList()"
           [matTooltip]="
@@ -100,6 +118,7 @@
         </button>
         <button
           mat-icon-button
+          matTooltipTouchGestures="off"
           (mousedown)="$event.preventDefault()"
           (click)="onApplyTaskList()"
           [matTooltip]="T.F.NOTE.D_FULLSCREEN.TOOLBAR.TASK_LIST | translate"
@@ -112,6 +131,7 @@
 
         <button
           mat-icon-button
+          matTooltipTouchGestures="off"
           (mousedown)="$event.preventDefault()"
           (click)="onApplyQuote()"
           [matTooltip]="
@@ -124,6 +144,7 @@
         </button>
         <button
           mat-icon-button
+          matTooltipTouchGestures="off"
           (mousedown)="$event.preventDefault()"
           (click)="onApplyInlineCode()"
           [matTooltip]="
@@ -136,6 +157,7 @@
         </button>
         <button
           mat-icon-button
+          matTooltipTouchGestures="off"
           (mousedown)="$event.preventDefault()"
           (click)="onApplyCodeBlock()"
           [matTooltip]="T.F.NOTE.D_FULLSCREEN.TOOLBAR.CODE_BLOCK | translate"
@@ -148,6 +170,7 @@
 
         <button
           mat-icon-button
+          matTooltipTouchGestures="off"
           (mousedown)="$event.preventDefault()"
           (click)="onInsertLink()"
           [matTooltip]="
@@ -160,6 +183,7 @@
         </button>
         <button
           mat-icon-button
+          matTooltipTouchGestures="off"
           (mousedown)="$event.preventDefault()"
           (click)="onInsertImage()"
           [matTooltip]="T.F.NOTE.D_FULLSCREEN.TOOLBAR.INSERT_IMAGE | translate"
@@ -169,6 +193,7 @@
         </button>
         <button
           mat-icon-button
+          matTooltipTouchGestures="off"
           (mousedown)="$event.preventDefault()"
           (click)="onInsertTable()"
           [matTooltip]="T.F.NOTE.D_FULLSCREEN.TOOLBAR.INSERT_TABLE | translate"
@@ -181,6 +206,7 @@
 
         <button
           mat-icon-button
+          matTooltipTouchGestures="off"
           (mousedown)="$event.preventDefault()"
           (click)="openShortcutsHelp()"
           [matTooltip]="T.F.NOTE.D_FULLSCREEN.TOOLBAR.KEYBOARD_SHORTCUTS | translate"


### PR DESCRIPTION
Fixes #10015.

## The bug

The fullscreen markdown toolbar (Project Notes editor) is ~565px wide against a 393px phone screen, so five controls sit off-screen — code block, link, image, table, keyboard shortcuts. The SCSS already anticipates this with `overflow-x: auto`, and that scroll container works.

It was just unreachable by touch. Every toolbar button carries `[matTooltip]`, and on a touch platform `MatTooltip._disableNativeGesturesIfNecessary()` writes an inline `touch-action: none` onto its host to claim the long-press gesture. Measured in the running app: 16 of 16 buttons blocked, covering 448px of the toolbar's 393px visible surface. Only the 2px gaps and 1px dividers were pannable, so a swipe essentially never became a pan and the overflow could not be reached at all.

## The fix

`matTooltipTouchGestures="off"` on the toolbar buttons. Long-press tooltips are a desktop-oriented affordance; hover tooltips are on the other code path (`_isTouchPlatform()` false → `mouseenter`, which never consults `touchGestures`) and are unaffected.

A component-scoped `MAT_TOOLTIP_DEFAULT_OPTIONS` provider would have been one line instead of 16 attributes, but `DialogAddNoteComponent` subclasses this component with its own `@Component` decorator and shares only the template by path, so Angular would not inherit the provider. The attribute lives in the shared template, so both dialogs get it from one edit.

## Test

`e2e/tests/notes/note-toolbar-touch-scroll.spec.ts` — creates a note, reopens it, and asserts the toolbar genuinely overflows at 393px (so it cannot pass vacuously on a wider viewport), that no button computes `touch-action: none`, and that scrolling brings the last button into the viewport.

Two things the test needs to be honest:

- It sets an **Android UA**, not just a touch context. `MatTooltip._isTouchPlatform()` UA-sniffs `Platform.ANDROID`, so a merely touch-enabled Chromium never reproduces the bug.
- Both dialogs declare `selector: 'dialog-fullscreen-markdown'`, so the element cannot tell them apart. The reopened note's content is asserted prefilled — the add-note dialog always opens empty — to prove the guard runs on the component this issue names.

It asserts on `touch-action` rather than performing a real swipe because headless Chromium cannot synthesize a compositor pan; I confirmed that limitation with controls (a plain injected scroll container and the textarea both refused to pan under a synthesized gesture), so a swipe-based test would fail for the wrong reason.

Verified it can fail: reverting the 16 attributes gives `Expected: 0, Received: 16`. Green: this spec 3×, all 12 `tests/notes/` specs, and `tests/note/detail-fullscreen-note-resize.spec.ts`.

## Not covered

The issue's second symptom — "the editor does not scroll when its content exceeds the visible area" — **did not reproduce** and is not addressed here. The textarea measured `scrollHeight` 2296 vs `clientHeight` 739 and scrolled fine. The one lead I had (the app's own `touch-action: none` in `note.component.scss`) came back negative — it's on a corner drag handle, not the card body. @BobakTech, once this ships, could you confirm the toolbar swipes now, and describe what you were trying to scroll for the second issue?

Two known trade-offs: `_isTouchPlatform()` is true for any Android/iOS UA regardless of pointer, so an Android tablet with a mouse loses tooltips on these buttons; and no scroll affordance was added, since the clipped partial button at the right edge already signals more content.

https://claude.ai/code/session_018dVgq6fGJYnmmc1gnnHt8G