### PR TITLE
fix(links): allow mid: protocol for email message-id links

### DIFF
--- a/electron/shared-with-frontend/is-external-url-allowed.ts
+++ b/electron/shared-with-frontend/is-external-url-allowed.ts
@@ -31,6 +31,7 @@ export const ALLOWED_EXTERNAL_URL_SCHEMES = [
   'http:',
   'https:',
   'mailto:',
+  'mid:', // RFC 2392 message-id links (mid:<id>@host) — Thunderbird registers this scheme
   'file:',
   'tel:',
   'sms:',

--- a/src/app/ui/is-external-url-allowed.spec.ts
+++ b/src/app/ui/is-external-url-allowed.spec.ts
@@ -13,6 +13,7 @@ describe('isExternalUrlSchemeAllowed', () => {
       'https://example.com/path?q=1#frag',
       'HTTPS://EXAMPLE.COM', // scheme is case-insensitive
       'mailto:someone@example.com',
+      'mid:message-id',
       'file:///home/user/notes.txt',
       '  https://example.com  ', // surrounding whitespace tolerated
       'tel:+123456789',
@@ -47,6 +48,7 @@ describe('isExternalUrlSchemeAllowed', () => {
         'http:',
         'https:',
         'mailto:',
+        'mid:',
         'file:',
         'tel:',
         'sms:',

--- a/src/app/ui/link-href.util.spec.ts
+++ b/src/app/ui/link-href.util.spec.ts
@@ -6,6 +6,7 @@ describe('toRenderableHref', () => {
       'http://example.com',
       'https://example.com/path?q=1#frag',
       'mailto:user@example.com',
+      'mid:message-id',
       'tel:+1234567890',
       'file:///home/user/notes.txt',
       'obsidian://open?vault=Notes',

--- a/src/app/ui/marked-options-factory.spec.ts
+++ b/src/app/ui/marked-options-factory.spec.ts
@@ -385,6 +385,7 @@ describe('markedOptionsFactory', () => {
         const linkRenderer = options.renderer!.link.bind({ parser: mockParser });
         [
           'mailto:a@b.com',
+          'mid:message-id',
           'file:///tmp/x',
           'https://example.com',
           // #8429: app deep-links must stay clickable

--- a/src/app/ui/pipes/render-links.pipe.spec.ts
+++ b/src/app/ui/pipes/render-links.pipe.spec.ts
@@ -225,6 +225,16 @@ describe('RenderLinksPipe', () => {
       expect(result).toContain('>Email</a>');
     });
 
+    it('should render mid: URLs in markdown links (shared allowlist)', () => {
+      const result = html(
+        pipe.transform(
+          '[Email-Message](mid:C64456A5-3E51-42D7-AB0B-B47B7DAFFEF3@example.com)',
+        ),
+      );
+      expect(result).toContain('Email-Message');
+      expect(result).toContain('<a ');
+    });
+
     // #8429: app deep-links must behave the same here as in markdown notes.
     it('should render app deep-link schemes (obsidian:, vscode:) verbatim as links', () => {
       const result = html(


### PR DESCRIPTION
Allow the RFC 2392 message-ID scheme mid:

## Problem

The protocol handler mid: as originally mentioned in https://github.com/super-productivity/super-productivity/issues/2775 was no longer on the allowlist.

## Solution

add the mid: handler to ALLOWED_EXTERNAL_URL_SCHEMES and extended tests

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)
