### PR TITLE
feat(ios): capture shared links and text in inbox

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -115,6 +115,17 @@ jobs:
           fi
           echo "Bundle ID verification passed!"
 
+      - name: Install share extension provisioning profile
+        env:
+          IOS_SHARE_PROVISION_PROFILE: ${{ secrets.IOS_SHARE_PROVISION_PROFILE }}
+        run: |
+          PROFILE_PATH="$RUNNER_TEMP/ios-share.mobileprovision"
+          echo "$IOS_SHARE_PROVISION_PROFILE" | base64 --decode > "$PROFILE_PATH"
+          security cms -D -i "$PROFILE_PATH" > "$RUNNER_TEMP/ios-share-profile.plist"
+          PROFILE_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" "$RUNNER_TEMP/ios-share-profile.plist")
+          cp "$PROFILE_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles/${PROFILE_UUID}.mobileprovision"
+          echo "SHARE_PROVISIONING_PROFILE_UUID=$PROFILE_UUID" >> "$GITHUB_ENV"
+
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |
@@ -197,6 +208,8 @@ jobs:
               <dict>
                   <key>com.super-productivity.app</key>
                   <string>${{ env.PROVISIONING_PROFILE_UUID }}</string>
+                  <key>com.super-productivity.app.ShareExtension</key>
+                  <string>${{ env.SHARE_PROVISIONING_PROFILE_UUID }}</string>
               </dict>
           </dict>
           </plist>

--- a/docs/ios-share-extension.md
+++ b/docs/ios-share-extension.md
@@ -1,0 +1,54 @@
+# iOS share extension
+
+The ShareExtension target receives URLs and text using Apple's system compose
+sheet. It writes one immutable JSON file per capture into the App Group
+`group.com.super-productivity.app`. The app imports these files into Inbox on
+startup/resume using the existing task-create action. No shared database,
+new synced model fields, or operation semantics are introduced.
+
+The native queue is acknowledged only after operation writes finish without
+an unrecovered persistence failure. The capture UUID is the task ID, so replay
+after a crash before acknowledgement recognizes an existing task. Local
+ID-only receipts cover acknowledgement retries after a user archives/deletes
+an imported task. Pending captures are not part of the app's normal exports or
+sync until imported. Uninstalling the app removes them.
+
+## Signing setup
+
+Before release, register `com.super-productivity.app.ShareExtension` in Apple
+Developer and enable the App Group above for both app identifiers. Regenerate
+the app's distribution profile with the App Group entitlement and update
+`IOS_PROVISION_PROFILE`. Create a distribution profile for the extension and
+store its base64 representation in `IOS_SHARE_PROVISION_PROFILE`.
+
+For development, select the same signing team on both Xcode targets and enable
+automatic provisioning. The app target embeds the extension. Existing release
+versioning via `agvtool` updates both targets.
+
+The extension bundles `src/assets/i18n/en.json` for its custom strings. Its
+custom copy currently uses English; system controls follow the device language.
+
+## Verification on macOS and iOS
+
+1. Run `npm run dist:ios:prod`, then build the App scheme in Xcode. Check that
+   `App.app/PlugIns/ShareExtension.appex` is embedded and both targets have the
+   App Group entitlement.
+2. On an iPhone and iPad, share a Safari URL and plain text from another app.
+   Check supplied titles, query strings, multiline text, Unicode, and literal
+   `+project`, `#tag`, and `@date` text. Save and cancel separately.
+3. With the app terminated, save two different shares, then open the app.
+   Verify two Inbox tasks with complete notes, no due date or inherited tags.
+   Repeat with the app in the background and with airplane mode enabled.
+4. Reopen repeatedly: each capture should appear once. Test a write failure
+   and a crash before native acknowledgement; pending content must survive.
+5. Check empty and oversized input, and unsupported photo/file shares. Saving
+   must stay disabled for invalid content. Verify VoiceOver and large text.
+
+Native compilation, signing, and share-sheet behavior require macOS/Xcode and
+an iOS device or simulator; the Angular importer tests alone do not verify them.
+
+## Apple references
+
+- [Share extensions](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/Share.html)
+- [Shared-container file safety](https://developer.apple.com/library/archive/technotes/tn2408/_index.html)
+- [Extension lifecycle and containing app](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/ExtensionOverview.html)

--- a/docs/wiki/3.05-Web-App-vs-Desktop.md
+++ b/docs/wiki/3.05-Web-App-vs-Desktop.md
@@ -134,6 +134,19 @@ Certain UI elements tied to these features are hidden in the web build via platf
 
 ## Platform-Specific Availability
 
+### Receive Shared Links and Text on iOS
+
+In the native iOS app, choose **Super Productivity** from another app's share
+sheet, review the link or text, and tap **Save**. Each share creates one new
+Inbox task when you next open Super Productivity. The supplied title is used
+when available; otherwise the title comes from the shared text. The complete
+shared content is stored in the task's notes. Task titles are limited to 300
+characters and shared text to 100,000 characters.
+
+Capture works offline. Pending shares stay on the device until imported;
+they sync as ordinary tasks after import. Photos and file attachments are not
+supported. This share extension is part of the native iOS app, not the web app.
+
 ### Donation and Contribution Links
 
 The Support Us page and links that can lead to GitHub Sponsors are unavailable in native iOS and macOS desktop builds. They remain available in the web app, native Android, Windows desktop, and Linux desktop builds.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		994800000000000000000001 /* ShareInbox.swift in App */ = {isa = PBXBuildFile; fileRef = 994800000000000000000010; };
+		994800000000000000000002 /* ShareInbox.swift in Extension */ = {isa = PBXBuildFile; fileRef = 994800000000000000000010; };
+		994800000000000000000003 /* ShareInboxPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994800000000000000000011; };
+		994800000000000000000004 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994800000000000000000012; };
+		994800000000000000000005 /* en.json in Resources */ = {isa = PBXBuildFile; fileRef = 994800000000000000000013; };
+		994800000000000000000006 /* ShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 994800000000000000000014; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		2FAD9763203C412B000D30F8 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 2FAD9762203C412B000D30F8 /* config.xml */; };
 		50379B232058CBB4000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B222058CBB4000EE86E /* capacitor.config.json */; };
 		504EC3081FED79650016851F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3071FED79650016851F /* AppDelegate.swift */; };
@@ -22,7 +28,31 @@
 		B63E17A52C5F3D8A00A1B2C3 /* CustomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63E17A42C5F3D8A00A1B2C3 /* CustomViewController.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		994800000000000000000020 = {isa = PBXContainerItemProxy; containerPortal = 504EC2FC1FED79650016851F; proxyType = 1; remoteGlobalIDString = 994800000000000000000030; remoteInfo = ShareExtension; };
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		994800000000000000000021 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (994800000000000000000006, );
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		994800000000000000000010 /* ShareInbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shared/ShareInbox.swift; sourceTree = SOURCE_ROOT; };
+		994800000000000000000011 /* ShareInboxPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/ShareInboxPlugin.swift; sourceTree = SOURCE_ROOT; };
+		994800000000000000000012 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtension/ShareViewController.swift; sourceTree = SOURCE_ROOT; };
+		994800000000000000000013 /* en.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ../../src/assets/i18n/en.json; sourceTree = SOURCE_ROOT; };
+		994800000000000000000014 /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		994800000000000000000015 /* ShareExtension Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = ShareExtension/Info.plist; sourceTree = SOURCE_ROOT; };
+		994800000000000000000016 /* ShareExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ShareExtension/ShareExtension.entitlements; sourceTree = SOURCE_ROOT; };
+		994800000000000000000017 /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App/App.entitlements; sourceTree = SOURCE_ROOT; };
 		2FAD9762203C412B000D30F8 /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = config.xml; sourceTree = "<group>"; };
 		50379B222058CBB4000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		504EC3041FED79650016851F /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -65,6 +95,13 @@
 		504EC2FB1FED79650016851F = {
 			isa = PBXGroup;
 			children = (
+				994800000000000000000010 /* ShareInbox.swift */,
+				994800000000000000000011 /* ShareInboxPlugin.swift */,
+				994800000000000000000012 /* ShareViewController.swift */,
+				994800000000000000000013 /* en.json */,
+				994800000000000000000015 /* ShareExtension Info.plist */,
+				994800000000000000000016 /* ShareExtension.entitlements */,
+				994800000000000000000017 /* App.entitlements */,
 				504EC3061FED79650016851F /* App */,
 				504EC3051FED79650016851F /* Products */,
 				7F8756D8B27F46E3366F6CEA /* Pods */,
@@ -75,6 +112,7 @@
 		504EC3051FED79650016851F /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				994800000000000000000014 /* ShareExtension.appex */,
 				504EC3041FED79650016851F /* App.app */,
 			);
 			name = Products;
@@ -112,6 +150,17 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		994800000000000000000030 /* ShareExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 994800000000000000000043;
+			buildPhases = (994800000000000000000031, 994800000000000000000032, );
+			buildRules = ();
+			dependencies = ();
+			name = ShareExtension;
+			productName = ShareExtension;
+			productReference = 994800000000000000000014;
+			productType = "com.apple.product-type.app-extension";
+		};
 		504EC3031FED79650016851F /* App */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 504EC3161FED79650016851F /* Build configuration list for PBXNativeTarget "App" */;
@@ -121,10 +170,12 @@
 				504EC3011FED79650016851F /* Frameworks */,
 				504EC3021FED79650016851F /* Resources */,
 				9592DBEFFC6D2A0C8D5DEB22 /* [CP] Embed Pods Frameworks */,
+				994800000000000000000021 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				994800000000000000000022 /* ShareExtension */,
 			);
 			name = App;
 			productName = App;
@@ -162,12 +213,14 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				994800000000000000000030 /* ShareExtension */,
 				504EC3031FED79650016851F /* App */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		994800000000000000000032 /* Extension Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (994800000000000000000005, ); runOnlyForDeploymentPostprocessing = 0; };
 		504EC3021FED79650016851F /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -220,11 +273,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		994800000000000000000031 /* Extension Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (994800000000000000000002, 994800000000000000000004, ); runOnlyForDeploymentPostprocessing = 0; };
 		504EC3001FED79650016851F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				994800000000000000000001 /* ShareInbox.swift in App */,
+				994800000000000000000003 /* ShareInboxPlugin.swift in Sources */,
 				B63E17A52C5F3D8A00A1B2C3 /* CustomViewController.swift in Sources */,
 				B63E17A12C5F3D8A00A1B2C3 /* WebDavHttpPlugin.swift in Sources */,
 				B63E17A32C5F3D8A00A1B2C3 /* WebDavHttpPlugin.m in Sources */,
@@ -234,6 +290,10 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		994800000000000000000022 /* ShareExtension */ = {isa = PBXTargetDependency; target = 994800000000000000000030; targetProxy = 994800000000000000000020; };
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		504EC30B1FED79650016851F /* Main.storyboard */ = {
@@ -255,6 +315,42 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		994800000000000000000041 /* Extension Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.super-productivity.app.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		994800000000000000000042 /* Extension Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.super-productivity.app.ShareExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		504EC3141FED79650016851F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -367,6 +463,7 @@
 			baseConfigurationReference = FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = App/Info.plist;
@@ -387,6 +484,7 @@
 			baseConfigurationReference = AF51FD2D460BCFE21FA515B2 /* Pods-App.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = App/Info.plist;
@@ -404,6 +502,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		994800000000000000000043 = {isa = XCConfigurationList; buildConfigurations = (994800000000000000000041, 994800000000000000000042, ); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
 		504EC2FF1FED79650016851F /* Build configuration list for PBXProject "App" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+    <key>com.apple.security.application-groups</key>
+    <array><string>group.com.super-productivity.app</string></array>
+</dict></plist>

--- a/ios/App/App/CustomViewController.swift
+++ b/ios/App/App/CustomViewController.swift
@@ -5,5 +5,6 @@ class CustomViewController: CAPBridgeViewController {
     override open func capacitorDidLoad() {
         bridge?.registerPluginInstance(WebDavHttpPlugin())
         bridge?.registerPluginInstance(StoreReviewPlugin())
+        bridge?.registerPluginInstance(ShareInboxPlugin())
     }
 }

--- a/ios/App/App/ShareInboxPlugin.swift
+++ b/ios/App/App/ShareInboxPlugin.swift
@@ -1,0 +1,31 @@
+import Capacitor
+
+@objc(ShareInboxPlugin)
+public class ShareInboxPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "ShareInboxPlugin"
+    public let jsName = "ShareInbox"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "getPending", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "acknowledge", returnType: CAPPluginReturnPromise)
+    ]
+
+    @objc func getPending(_ call: CAPPluginCall) {
+        do {
+            let shares = try ShareInbox.pending().map {
+                ["id": $0.id, "title": $0.title, "text": $0.text]
+            }
+            call.resolve(["shares": shares])
+        } catch {
+            call.reject("Could not read shared captures")
+        }
+    }
+
+    @objc func acknowledge(_ call: CAPPluginCall) {
+        do {
+            try ShareInbox.acknowledge(id: call.getString("id") ?? "")
+            call.resolve()
+        } catch {
+            call.reject("Could not acknowledge shared capture")
+        }
+    }
+}

--- a/ios/App/ShareExtension/Info.plist
+++ b/ios/App/ShareExtension/Info.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+    <key>CFBundleDisplayName</key><string>Super Productivity</string>
+    <key>CFBundleExecutable</key><string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key><string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleName</key><string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key><string>XPC!</string>
+    <key>CFBundleShortVersionString</key><string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key><string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>NSExtension</key><dict>
+        <key>NSExtensionPointIdentifier</key><string>com.apple.share-services</string>
+        <key>NSExtensionPrincipalClass</key><string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+        <key>NSExtensionAttributes</key><dict>
+            <key>NSExtensionActivationRule</key><dict>
+                <key>NSExtensionActivationSupportsText</key><true/>
+                <key>NSExtensionActivationSupportsWebURLWithMaxCount</key><integer>1</integer>
+            </dict>
+        </dict>
+    </dict>
+</dict></plist>

--- a/ios/App/ShareExtension/ShareExtension.entitlements
+++ b/ios/App/ShareExtension/ShareExtension.entitlements
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+    <key>com.apple.security.application-groups</key>
+    <array><string>group.com.super-productivity.app</string></array>
+</dict></plist>

--- a/ios/App/ShareExtension/ShareViewController.swift
+++ b/ios/App/ShareExtension/ShareViewController.swift
@@ -1,0 +1,92 @@
+import Social
+import UniformTypeIdentifiers
+
+/// Uses the system compose sheet; content stays on-device until the app imports it.
+/// https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/Share.html
+final class ShareViewController: SLComposeServiceViewController {
+    private var loaded = false
+    private var saving = false
+    private var sharedTitle = ""
+    private var status = ""
+
+    // Bundle the canonical English strings from en.json; no separate native copy
+    // to drift from the app's translation source.
+    private let strings: [String: String] = {
+        guard let url = Bundle.main.url(forResource: "en", withExtension: "json"),
+              let data = try? Data(contentsOf: url),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let features = root["F"] as? [String: Any],
+              let strings = features["IOS_SHARE"] as? [String: String] else {
+            return [:]
+        }
+        return strings
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        status = strings["NEXT_OPEN"] ?? ""
+        textView.isEditable = false
+        let items = extensionContext?.inputItems as? [NSExtensionItem] ?? []
+        sharedTitle = items.compactMap { $0.attributedTitle?.string }.first ?? ""
+        let providers = items.flatMap { $0.attachments ?? [] }
+        Task { @MainActor in
+            do {
+                var parts = items.compactMap { $0.attributedContentText?.string }
+                for provider in providers {
+                    let type: String
+                    if provider.hasItemConformingToTypeIdentifier(UTType.url.identifier) {
+                        type = UTType.url.identifier
+                    } else if provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) {
+                        type = UTType.plainText.identifier
+                    } else {
+                        continue
+                    }
+                    let item = try await provider.loadItem(forTypeIdentifier: type, options: nil)
+                    let text = (item as? URL)?.absoluteString ?? (item as? String) ?? ""
+                    if !text.isEmpty && !parts.contains(text) { parts.append(text) }
+                }
+                textView.text = parts.joined(separator: "\n\n")
+                loaded = true
+                textView.isEditable = true
+            } catch {
+                status = strings["INVALID"] ?? ""
+            }
+            validateContent()
+            reloadConfigurationItems()
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        navigationController?.navigationBar.topItem?.rightBarButtonItem?.title = strings["SAVE"]
+    }
+
+    override func isContentValid() -> Bool {
+        let text = contentText ?? ""
+        return loaded && !saving && !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && text.utf16.count <= 100_000
+    }
+
+    override func configurationItems() -> [Any]! {
+        let destination = SLComposeSheetConfigurationItem()!
+        destination.title = strings["DESTINATION"]
+        destination.value = loaded && !isContentValid() && !saving ? strings["INVALID"] : status
+        destination.tapHandler = nil
+        return [destination]
+    }
+
+    override func didSelectPost() {
+        guard isContentValid() else { return }
+        saving = true
+        validateContent()
+        do {
+            try ShareInbox.save(title: sharedTitle, text: contentText)
+            extensionContext?.completeRequest(returningItems: nil)
+        } catch {
+            saving = false
+            status = strings["SAVE_ERROR"] ?? ""
+            reloadConfigurationItems()
+            validateContent()
+        }
+    }
+}

--- a/ios/App/Shared/ShareInbox.swift
+++ b/ios/App/Shared/ShareInbox.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+struct SharedCapture: Codable {
+    let id: String
+    let title: String
+    let text: String
+}
+
+/// One immutable file per capture: extension writes and app acknowledgements
+/// never overwrite each other, including when either process is suspended.
+/// https://developer.apple.com/library/archive/technotes/tn2408/_index.html
+enum ShareInbox {
+    static let group = "group.com.super-productivity.app"
+
+    static func directory() throws -> URL {
+        guard let container = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: group
+        ) else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        let directory = container.appendingPathComponent("ShareInbox", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    static func save(title: String, text: String) throws {
+        let capture = SharedCapture(id: UUID().uuidString, title: title, text: text)
+        let file = try directory().appendingPathComponent(capture.id).appendingPathExtension("json")
+        try JSONEncoder().encode(capture).write(to: file, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
+    }
+
+    static func pending() throws -> [SharedCapture] {
+        try FileManager.default.contentsOfDirectory(at: directory(), includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "json" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+            .map { try JSONDecoder().decode(SharedCapture.self, from: Data(contentsOf: $0)) }
+    }
+
+    static func acknowledge(id: String) throws {
+        // IDs cross the JS bridge and become filenames; restrict to our UUIDs.
+        guard let uuid = UUID(uuidString: id) else { throw CocoaError(.fileReadInvalidFileName) }
+        let file = try directory().appendingPathComponent(uuid.uuidString).appendingPathExtension("json")
+        if FileManager.default.fileExists(atPath: file.path) {
+            try FileManager.default.removeItem(at: file)
+        }
+    }
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -81,6 +81,7 @@ import { MobileBottomNavComponent } from './core-ui/mobile-bottom-nav/mobile-bot
 import { StartupService } from './core/startup/startup.service';
 import { DataInitStateService } from './core/data-init/data-init-state.service';
 import { AppUriTaskActionsService } from './features/tasks/app-uri-actions/app-uri-task-actions.service';
+import { IosShareService } from './features/tasks/ios-share/ios-share.service';
 import { ExampleTasksService } from './core/example-tasks/example-tasks.service';
 import { KeyboardLayoutService } from './core/keyboard-layout/keyboard-layout.service';
 import { setKeyboardLayoutService } from './util/check-key-combo';
@@ -169,6 +170,7 @@ export class AppComponent implements OnDestroy, AfterViewInit {
   // Injected only to trigger its constructor eagerly at app start, so a
   // cold-launch add-task/complete-task URL action is never missed.
   private _appUriTaskActionsService = inject(AppUriTaskActionsService);
+  private _iosShareService = inject(IosShareService);
   readonly onboardingHintService = inject(OnboardingHintService);
 
   private _syncTriggerService = inject(SyncTriggerService);
@@ -234,6 +236,7 @@ export class AppComponent implements OnDestroy, AfterViewInit {
 
   constructor() {
     this._startupService.init();
+    this._iosShareService.start();
     void this._materialIconsLoaderService.ensureFontReady();
 
     // Skip onboarding for existing users with data

--- a/src/app/features/tasks/ios-share/ios-share.service.spec.ts
+++ b/src/app/features/tasks/ios-share/ios-share.service.spec.ts
@@ -1,0 +1,207 @@
+import { TestBed } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { BehaviorSubject, of, ReplaySubject } from 'rxjs';
+import { IOS_SHARE, IosSharePlugin, IosShareService } from './ios-share.service';
+import { DataInitStateService } from '../../../core/data-init/data-init-state.service';
+import { HydrationStateService } from '../../../op-log/apply/hydration-state.service';
+import { OperationWriteFlushService } from '../../../op-log/sync/operation-write-flush.service';
+import { OperationCaptureService } from '../../../op-log/capture/operation-capture.service';
+import { selectTaskEntities } from '../store/task.selectors';
+import { DEFAULT_TASK } from '../task.model';
+import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
+import { WorkContextType } from '../../work-context/work-context.model';
+import { SnackService } from '../../../core/snack/snack.service';
+import { SyncTriggerService } from '../../../imex/sync/sync-trigger.service';
+import { iosInterface } from '../../ios/ios-interface';
+
+describe('IosShareService', () => {
+  let plugin: jasmine.SpyObj<IosSharePlugin>;
+  let flush: jasmine.SpyObj<OperationWriteFlushService>;
+  let capture: jasmine.SpyObj<OperationCaptureService>;
+  let service: IosShareService;
+  let store: MockStore;
+  let loaded: ReplaySubject<boolean>;
+  let syncWindow: BehaviorSubject<boolean>;
+  const id = '7DCC80FA-577A-4D99-B16E-15D4B8787B62';
+
+  beforeEach(() => {
+    plugin = jasmine.createSpyObj('IosShare', ['getPending', 'acknowledge']);
+    plugin.getPending.and.resolveTo({
+      shares: [{ id, title: 'Article +work #tag', text: 'https://example.com/?a=1&b=2' }],
+    });
+    plugin.acknowledge.and.resolveTo();
+    flush = jasmine.createSpyObj('Flush', ['flushPendingWrites']);
+    flush.flushPendingWrites.and.resolveTo();
+    capture = jasmine.createSpyObj('Capture', ['hasUnrecoveredPersistFailure']);
+    capture.hasUnrecoveredPersistFailure.and.returnValue(false);
+    loaded = new ReplaySubject<boolean>(1);
+    syncWindow = new BehaviorSubject(false);
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: SyncTriggerService,
+          useValue: { afterInitialSyncDoneStrict$: of(true) },
+        },
+        provideMockStore({ selectors: [{ selector: selectTaskEntities, value: {} }] }),
+        { provide: IOS_SHARE, useValue: plugin },
+        {
+          provide: DataInitStateService,
+          useValue: { isAllDataLoadedInitially$: loaded },
+        },
+        {
+          provide: HydrationStateService,
+          useValue: {
+            isInSyncWindow$: syncWindow,
+            isInSyncWindow: () => syncWindow.value,
+          },
+        },
+        { provide: OperationWriteFlushService, useValue: flush },
+        { provide: OperationCaptureService, useValue: capture },
+        { provide: SnackService, useValue: { open: jasmine.createSpy('open') } },
+      ],
+    });
+    store = TestBed.inject(MockStore);
+    spyOn(store, 'dispatch');
+    service = TestBed.inject(IosShareService);
+  });
+
+  afterEach(() => {
+    store.resetSelectors();
+    localStorage.removeItem('sp-ios-share-receipts');
+  });
+
+  it('waits for hydration, then creates one literal Inbox task preserving the URL', async () => {
+    const imported = service.importPending();
+    await Promise.resolve();
+    expect(store.dispatch).not.toHaveBeenCalled();
+    loaded.next(true);
+    await imported;
+    const action = (store.dispatch as jasmine.Spy).calls.mostRecent().args[0];
+    expect(action.task.created).toEqual(jasmine.any(Number));
+    expect(store.dispatch).toHaveBeenCalledOnceWith(
+      TaskSharedActions.addTask({
+        task: {
+          ...DEFAULT_TASK,
+          id,
+          title: 'Article +work #tag',
+          notes: 'https://example.com/?a=1&b=2',
+          projectId: 'INBOX_PROJECT',
+          created: action.task.created,
+        },
+        workContextId: 'INBOX_PROJECT',
+        workContextType: WorkContextType.PROJECT,
+        isAddToBacklog: false,
+        isAddToBottom: true,
+        isIgnoreShortSyntax: true,
+      }),
+    );
+    expect(plugin.acknowledge).toHaveBeenCalledOnceWith({ id });
+  });
+
+  it('retains the native share until the task write completes', async () => {
+    let finish!: () => void;
+    flush.flushPendingWrites.and.returnValue(
+      new Promise<void>((resolve) => {
+        finish = resolve;
+      }),
+    );
+    loaded.next(true);
+    const imported = service.importPending();
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+    expect(store.dispatch).toHaveBeenCalledTimes(1);
+    expect(plugin.acknowledge).not.toHaveBeenCalled();
+    finish();
+    await imported;
+    expect(plugin.acknowledge).toHaveBeenCalled();
+  });
+
+  it('retains the share when persistence fails even if the flush resolves', async () => {
+    capture.hasUnrecoveredPersistFailure.and.returnValue(true);
+    loaded.next(true);
+    await expectAsync(service.importPending()).toBeRejected();
+    expect(plugin.acknowledge).not.toHaveBeenCalled();
+  });
+
+  it('does not recreate a task after a crash between persistence and acknowledgement', async () => {
+    store.overrideSelector(selectTaskEntities, {
+      [id]: { ...DEFAULT_TASK, id, projectId: 'INBOX_PROJECT' },
+    });
+    store.refreshState();
+    loaded.next(true);
+    await service.importPending();
+    expect(store.dispatch).not.toHaveBeenCalled();
+    expect(plugin.acknowledge).toHaveBeenCalledWith({ id });
+  });
+
+  it('retries acknowledgement without recreating an already deleted or archived task', async () => {
+    plugin.acknowledge.and.rejectWith(new Error('Native write failed'));
+    loaded.next(true);
+    await expectAsync(service.importPending()).toBeRejected();
+    plugin.acknowledge.and.resolveTo();
+    await service.importPending();
+    expect(store.dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits until remote replay ends before creating a task', async () => {
+    syncWindow.next(true);
+    loaded.next(true);
+    const imported = service.importPending();
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+    expect(store.dispatch).not.toHaveBeenCalled();
+    syncWindow.next(false);
+    await imported;
+    expect(store.dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses a text title fallback while preserving the complete multiline note', async () => {
+    const text = 'Read this #later\nMore context';
+    plugin.getPending.and.resolveTo({ shares: [{ id, title: '', text }] });
+    loaded.next(true);
+    await service.importPending();
+    expect(store.dispatch).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        task: jasmine.objectContaining({ title: 'Read this #later', notes: text }),
+        isIgnoreShortSyntax: true,
+      }),
+    );
+  });
+
+  it('keeps oversized shares instead of silently truncating notes', async () => {
+    plugin.getPending.and.resolveTo({
+      shares: [{ id, title: '', text: 'a'.repeat(100_001) }],
+    });
+    loaded.next(true);
+    await expectAsync(service.importPending()).toBeRejected();
+    expect(store.dispatch).not.toHaveBeenCalled();
+    expect(plugin.acknowledge).not.toHaveBeenCalled();
+  });
+
+  it('serializes cold start and native resume events', async () => {
+    let finish!: () => void;
+    plugin.getPending.and.returnValue(
+      new Promise((resolve) => {
+        finish = () => resolve({ shares: [] });
+      }),
+    );
+    loaded.next(true);
+    service.start();
+    iosInterface.onResume$.next();
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+    expect(plugin.getPending).toHaveBeenCalledTimes(1);
+    plugin.getPending.and.resolveTo({ shares: [] });
+    finish();
+    for (let i = 0; i < 20; i++) {
+      await Promise.resolve();
+    }
+    expect(plugin.getPending).toHaveBeenCalledTimes(2);
+    TestBed.resetTestingModule();
+    iosInterface.onResume$.next();
+    expect(plugin.getPending).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/features/tasks/ios-share/ios-share.service.ts
+++ b/src/app/features/tasks/ios-share/ios-share.service.ts
@@ -1,0 +1,135 @@
+import { DestroyRef, inject, Injectable, InjectionToken } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { registerPlugin } from '@capacitor/core';
+import { Store } from '@ngrx/store';
+import { concatMap, filter, firstValueFrom, startWith } from 'rxjs';
+import { DataInitStateService } from '../../../core/data-init/data-init-state.service';
+import { Log } from '../../../core/log';
+import { SnackService } from '../../../core/snack/snack.service';
+import { HydrationStateService } from '../../../op-log/apply/hydration-state.service';
+import { OperationCaptureService } from '../../../op-log/capture/operation-capture.service';
+import { OperationWriteFlushService } from '../../../op-log/sync/operation-write-flush.service';
+import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
+import { IS_IOS_NATIVE } from '../../../util/is-native-platform';
+import { INBOX_PROJECT } from '../../project/project.const';
+import { WorkContextType } from '../../work-context/work-context.model';
+import { selectTaskEntities } from '../store/task.selectors';
+import { DEFAULT_TASK } from '../task.model';
+import { iosInterface } from '../../ios/ios-interface';
+import { SyncTriggerService } from '../../../imex/sync/sync-trigger.service';
+
+export interface IosSharePlugin {
+  getPending(): Promise<{ shares: { id: string; title: string; text: string }[] }>;
+  acknowledge(options: { id: string }): Promise<void>;
+}
+
+export const IOS_SHARE = new InjectionToken<IosSharePlugin | null>('IOS_SHARE', {
+  providedIn: 'root',
+  factory: () => (IS_IOS_NATIVE ? registerPlugin<IosSharePlugin>('ShareInbox') : null),
+});
+
+const RECEIPTS_KEY = 'sp-ios-share-receipts';
+
+@Injectable({ providedIn: 'root' })
+export class IosShareService {
+  private _plugin = inject(IOS_SHARE);
+  private _store = inject(Store);
+  private _tasks = this._store.selectSignal(selectTaskEntities);
+  private _dataInit = inject(DataInitStateService);
+  private _syncTrigger = inject(SyncTriggerService);
+  private _hydration = inject(HydrationStateService);
+  private _flush = inject(OperationWriteFlushService);
+  private _capture = inject(OperationCaptureService);
+  private _destroyRef = inject(DestroyRef);
+  private _snack = inject(SnackService);
+
+  start(): void {
+    if (!this._plugin) {
+      return;
+    }
+    iosInterface.onResume$
+      .pipe(
+        startWith(null),
+        concatMap(() =>
+          this.importPending().catch(() => {
+            // Native payloads and error objects can contain shared user content.
+            Log.err('iOS share import failed; pending captures retained');
+            this._snack.open({ type: 'ERROR', msg: 'F.IOS_SHARE.IMPORT_ERROR' });
+          }),
+        ),
+        takeUntilDestroyed(this._destroyRef),
+      )
+      .subscribe();
+  }
+
+  /** Called serially at startup and on resume; the extension never writes app state. */
+  async importPending(): Promise<void> {
+    if (!this._plugin) {
+      return;
+    }
+    await firstValueFrom(this._dataInit.isAllDataLoadedInitially$);
+    await firstValueFrom(this._syncTrigger.afterInitialSyncDoneStrict$);
+    const { shares } = await this._plugin.getPending();
+    // Receipts bridge a failed native acknowledgement even if the user later
+    // deletes/archives the task. They contain IDs only and are local to this device.
+    const receipts = new Set<string>(
+      JSON.parse(localStorage.getItem(RECEIPTS_KEY) || '[]'),
+    );
+    const pendingIds = new Set(shares.map((share) => share.id));
+    for (const id of receipts) {
+      if (!pendingIds.has(id)) {
+        receipts.delete(id);
+      }
+    }
+    localStorage.setItem(RECEIPTS_KEY, JSON.stringify([...receipts]));
+    for (const share of shares) {
+      // The native extension enforces the same existing external-input limits.
+      // Check again before a bridge payload becomes a synced task.
+      if (!share.text.trim() || share.text.length > 100_000) {
+        throw new Error('Invalid shared text');
+      }
+      if (!receipts.has(share.id)) {
+        // A resume can overlap replay. Wait without a timeout/fail-open path,
+        // and recheck synchronously before dispatch so capture cannot be skipped.
+        do {
+          await firstValueFrom(
+            this._hydration.isInSyncWindow$.pipe(filter((active) => !active)),
+          );
+        } while (this._hydration.isInSyncWindow());
+        if (!this._tasks()[share.id]) {
+          this._store.dispatch(
+            TaskSharedActions.addTask({
+              task: {
+                ...DEFAULT_TASK,
+                id: share.id,
+                title: (share.title.trim() || share.text.trim().split('\n')[0]).slice(
+                  0,
+                  300,
+                ),
+                notes: share.text,
+                projectId: INBOX_PROJECT.id,
+                created: Date.now(),
+              },
+              workContextId: INBOX_PROJECT.id,
+              workContextType: WorkContextType.PROJECT,
+              isAddToBacklog: false,
+              isAddToBottom: true,
+              isIgnoreShortSyntax: true,
+            }),
+          );
+        }
+        // Flush drains writes even on failure; the sticky divergence marker is
+        // essential here. Never acknowledge content that exists only in memory.
+        await this._flush.flushPendingWrites();
+        if (this._capture.hasUnrecoveredPersistFailure()) {
+          throw new Error('Task persistence failed');
+        }
+        receipts.add(share.id);
+        localStorage.setItem(RECEIPTS_KEY, JSON.stringify([...receipts]));
+      }
+      await this._plugin.acknowledge({ id: share.id });
+      receipts.delete(share.id);
+      localStorage.setItem(RECEIPTS_KEY, JSON.stringify([...receipts]));
+    }
+  }
+}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -109,6 +109,14 @@
     }
   },
   "F": {
+    "IOS_SHARE": {
+      "SAVE": "Save",
+      "DESTINATION": "Inbox",
+      "NEXT_OPEN": "Added when you next open Super Productivity",
+      "SAVE_ERROR": "Could not save. Please try again.",
+      "IMPORT_ERROR": "Could not import shared content. It has been kept on this device; reopen the app to retry.",
+      "INVALID": "Share a link or text (up to 100,000 characters)."
+    },
     "ANDROID": {
       "FOREGROUND_SERVICE_START_FAILED_FOCUS": "Android blocked the persistent focus mode notification. The timer continues in the app, but background alerts may be unavailable. Check notification permission and battery/background restrictions.",
       "FOREGROUND_SERVICE_START_FAILED_TRACKING": "Android blocked the persistent time tracking notification. Time is still tracked in the app, but background recovery may be unavailable. Check notification permission and battery/background restrictions.",


### PR DESCRIPTION
## Problem

iOS users cannot capture a link or text directly from another app's share sheet into Super Productivity. Related: #9862 and https://github.com/super-productivity/super-productivity/discussions/9948.

## Solution

Adds an iOS share extension for capturing links and text. Choose Super Productivity in another app's share sheet and save; the content becomes one new Inbox task when Super Productivity next opens. Shared content is preserved in notes, works offline, and uses the existing task-create operation.

Captures are queued in an App Group container until task persistence succeeds. Stable task IDs, local receipts, and session submission tracking protect retries. Includes the Xcode target, extension packaging, release provisioning support, and documentation.

## Type of Change

- [x] New feature
- [x] Documentation

## Verification

- Passed: 12 importer tests covering hydration, replay timing, resume serialization, persistence failure, acknowledgement retry, and restart recovery.
- Passed: TypeScript, required per-file lint/format checks, documentation links, Xcode project parsing, and plist/workflow validation.
- Six native text-conversion checks are wired into the macOS release workflow but have not been run here.
- Native compilation, signing, and iPhone/iPad share-sheet behavior remain unverified. This PR is a draft pending that validation.

## iOS testers wanted

Is anyone with access to a Mac/Xcode and an iPhone or iPad willing to build this branch and test it? Please comment with your device and iOS version, the app you shared from, and what worked or failed.

Useful cases: Safari links, plain or formatted text, multiple shares while Super Productivity is closed, background/resume, airplane mode, cancel, and repeated reopening without duplicate tasks. Please use test data.

Build/signing instructions and the full checklist: [docs/ios-share-extension.md](https://github.com/super-productivity/super-productivity/blob/feat/discussion-9948-d4fca4/docs/ios-share-extension.md).

## Remaining limitations and release setup

- Both targets require `group.com.super-productivity.app`. The app provisioning profile must be regenerated, and CI needs `IOS_SHARE_PROVISION_PROFILE` for `com.super-productivity.app.ShareExtension`.
- A process exit after a task is deleted but before its durable receipt is saved can still cause that capture to be reimported on restart.
- Pending captures are not synced/exported until imported. Custom extension strings currently use English. Photos and file attachments are outside this change.

## Checklist

- [x] Relevant documentation/wiki changes included
- [x] `npm run checkFile` passed on changed TypeScript files
- [x] Tests added for the changes
- [ ] Full existing test suite passes (focused importer suite passed; full suite not run)
- [x] Commit messages follow the Angular format
