### PR TITLE
fix(webdav): survive stale read-after-write on reused connections (#9985)

### DIFF
--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -255,6 +255,19 @@ export const createWindow = async ({
     ) {
       removeKeyInAnyCase(requestHeaders, 'User-Agent');
     }
+    // WebDavHttpAdapter marks desktop uploads because renderer fetch strips
+    // Connection. Consume the marker here; it must not reach the server.
+    const webdavUploadHeader = Object.keys(requestHeaders).find(
+      (key) => key.toLowerCase() === 'x-superproductivity-webdav-upload',
+    );
+    if (webdavUploadHeader) {
+      delete requestHeaders[webdavUploadHeader];
+      // #9985: avoid verifying on a PUT connection retaining the old file.
+      if (details.method === 'PUT') {
+        removeKeyInAnyCase(requestHeaders, 'Connection');
+        requestHeaders.Connection = 'close';
+      }
+    }
     applyJiraImageAuth(details.url, requestHeaders, details.resourceType);
     callback({ requestHeaders });
   });

--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -255,14 +255,21 @@ export const createWindow = async ({
     ) {
       removeKeyInAnyCase(requestHeaders, 'User-Agent');
     }
-    // WebDavHttpAdapter marks desktop uploads because renderer fetch strips
-    // Connection. Consume the marker here; it must not reach the server.
+    // WebDavHttpAdapter marks desktop uploads because renderer fetch refuses to
+    // set Connection itself. Consume the marker here; it must not reach the
+    // server. The literal below mirrors that adapter's ELECTRON_UPLOAD_HEADER
+    // and is pinned to it by electron/webdav-connection.test.cjs — the two
+    // build targets cannot import each other.
     const webdavUploadHeader = Object.keys(requestHeaders).find(
       (key) => key.toLowerCase() === 'x-superproductivity-webdav-upload',
     );
     if (webdavUploadHeader) {
       delete requestHeaders[webdavUploadHeader];
       // #9985: avoid verifying on a PUT connection retaining the old file.
+      // HTTP/1.1 only — Connection is a connection-specific header that RFC 9113
+      // forbids over HTTP/2, so any conformant client drops it there. The
+      // WebdavApi verification retry budget is the cross-protocol safety net;
+      // the reported STRATO HiDrive failure was reproduced over HTTP/1.1.
       if (details.method === 'PUT') {
         removeKeyInAnyCase(requestHeaders, 'Connection');
         requestHeaders.Connection = 'close';

--- a/electron/webdav-connection.test.cjs
+++ b/electron/webdav-connection.test.cjs
@@ -1,0 +1,138 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const http = require('node:http');
+const ts = require('typescript');
+
+// Execute the real request hook and its header helpers without booting Electron.
+const source = ts.createSourceFile(
+  'main-window.ts',
+  fs.readFileSync(path.join(__dirname, 'main-window.ts'), 'utf8'),
+  ts.ScriptTarget.Latest,
+  true,
+);
+let hook;
+const helpers = [];
+const visit = (node) => {
+  if (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === 'onBeforeSendHeaders'
+  ) {
+    hook = node.arguments[0].getText(source);
+  }
+  if (
+    ts.isVariableDeclaration(node) &&
+    node.name.getText(source) === 'removeKeyInAnyCase'
+  ) {
+    helpers.push(`const ${node.getText(source)};`);
+  }
+  ts.forEachChild(node, visit);
+};
+visit(source);
+assert.ok(hook, 'main-window must register its request hook');
+const beforeSendHeaders = vm.runInNewContext(
+  ts.transpile(`${helpers.join('\n')}\n(${hook});`),
+  { URL, applyJiraImageAuth() {} },
+);
+const headersFor = (method, host, requestHeaders = {}) => {
+  let result;
+  beforeSendHeaders(
+    { method, url: `https://${host}/sync-data.json`, requestHeaders },
+    (response) => (result = response.requestHeaders),
+  );
+  return result;
+};
+
+test('upload verification escapes a connection holding the old file (#9985)', async (t) => {
+  let stored = '{"version":1}';
+  const snapshots = new Map();
+  const sockets = [];
+  const receivedMarkers = [];
+  const server = http.createServer((req, res) => {
+    receivedMarkers.push(req.headers['x-superproductivity-webdav-upload']);
+    if (!snapshots.has(req.socket)) snapshots.set(req.socket, stored);
+    sockets.push(req.socket);
+    if (req.method === 'PUT') {
+      let body = '';
+      req.on('data', (chunk) => (body += chunk));
+      req.on('end', () => {
+        stored = body;
+        res.writeHead(204);
+        res.end();
+      });
+    } else {
+      res.end(snapshots.get(req.socket));
+    }
+  });
+  const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
+  t.after(() => {
+    agent.destroy();
+    server.closeAllConnections();
+    server.close();
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const request = (method, body) =>
+    new Promise((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: '127.0.0.1',
+          port: server.address().port,
+          method,
+          agent,
+          headers: headersFor(
+            method,
+            'dav.example.com',
+            method === 'PUT' ? { 'X-SuperProductivity-WebDAV-Upload': '1' } : {},
+          ),
+        },
+        (res) => {
+          let data = '';
+          res.on('data', (chunk) => (data += chunk));
+          res.on('end', () => resolve(data));
+          res.on('error', reject);
+        },
+      );
+      req.on('error', reject);
+      req.end(body);
+    });
+
+  assert.equal(await request('GET'), '{"version":1}');
+  await request('PUT', '{"version":2}');
+  assert.deepEqual(receivedMarkers, [undefined, undefined]);
+  assert.equal(stored, '{"version":2}', 'the upload itself succeeded');
+  assert.equal(await request('GET'), stored, 'verification must see the new file');
+  assert.equal(sockets[0], sockets[1], 'reproduce PUT on a reused connection');
+  assert.notEqual(sockets[1], sockets[2], 'verification needs a fresh connection');
+});
+
+test('preserves connection reuse for unmarked requests, including other integrations PUTs', () => {
+  for (const [method, host] of [
+    ['GET', 'dav.example.com'],
+    ['PROPFIND', 'dav.example.com'],
+    ['GET', 'another-dav.example.com'],
+    ['POST', 'api.example.com'],
+    ['PUT', 'api.example.com'],
+    ['PUT', 'dav.example.com'],
+  ]) {
+    assert.equal(headersFor(method, host).Connection, undefined);
+  }
+});
+
+test('replaces an existing Connection header regardless of casing', () => {
+  const headers = headersFor('PUT', 'dav.example.com', {
+    connection: 'keep-alive',
+    'x-superproductivity-webdav-upload': '1',
+  });
+  assert.equal(headers.Connection, 'close');
+  assert.equal(Object.keys(headers).length, 1);
+});
+
+test('consumes the WebDAV marker without forwarding it on non-PUT requests', () => {
+  const headers = headersFor('GET', 'dav.example.com', {
+    'X-SuperProductivity-WebDAV-Upload': '1',
+  });
+  assert.equal(Object.keys(headers).length, 0);
+});

--- a/electron/webdav-connection.test.cjs
+++ b/electron/webdav-connection.test.cjs
@@ -3,13 +3,24 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const vm = require('node:vm');
-const http = require('node:http');
 const ts = require('typescript');
+
+const readRepoFile = (relative) =>
+  fs.readFileSync(path.join(__dirname, '..', relative), 'utf8');
+
+// The marker header is a contract between two separate build targets: the
+// renderer-side WebDavHttpAdapter emits it, this main-process hook consumes it.
+// Neither can import the other, so read the producer's constant here — renaming
+// it on one side must fail loudly instead of silently disabling the #9985 fix.
+const MARKER = /ELECTRON_UPLOAD_HEADER = '([^']+)'/.exec(
+  readRepoFile('packages/sync-providers/src/file-based/webdav/webdav-http-adapter.ts'),
+)?.[1];
+assert.ok(MARKER, 'WebDavHttpAdapter must define ELECTRON_UPLOAD_HEADER');
 
 // Execute the real request hook and its header helpers without booting Electron.
 const source = ts.createSourceFile(
   'main-window.ts',
-  fs.readFileSync(path.join(__dirname, 'main-window.ts'), 'utf8'),
+  readRepoFile('electron/main-window.ts'),
   ts.ScriptTarget.Latest,
   true,
 );
@@ -46,66 +57,12 @@ const headersFor = (method, host, requestHeaders = {}) => {
   return result;
 };
 
-test('upload verification escapes a connection holding the old file (#9985)', async (t) => {
-  let stored = '{"version":1}';
-  const snapshots = new Map();
-  const sockets = [];
-  const receivedMarkers = [];
-  const server = http.createServer((req, res) => {
-    receivedMarkers.push(req.headers['x-superproductivity-webdav-upload']);
-    if (!snapshots.has(req.socket)) snapshots.set(req.socket, stored);
-    sockets.push(req.socket);
-    if (req.method === 'PUT') {
-      let body = '';
-      req.on('data', (chunk) => (body += chunk));
-      req.on('end', () => {
-        stored = body;
-        res.writeHead(204);
-        res.end();
-      });
-    } else {
-      res.end(snapshots.get(req.socket));
-    }
-  });
-  const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
-  t.after(() => {
-    agent.destroy();
-    server.closeAllConnections();
-    server.close();
-  });
-  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
-  const request = (method, body) =>
-    new Promise((resolve, reject) => {
-      const req = http.request(
-        {
-          hostname: '127.0.0.1',
-          port: server.address().port,
-          method,
-          agent,
-          headers: headersFor(
-            method,
-            'dav.example.com',
-            method === 'PUT' ? { 'X-SuperProductivity-WebDAV-Upload': '1' } : {},
-          ),
-        },
-        (res) => {
-          let data = '';
-          res.on('data', (chunk) => (data += chunk));
-          res.on('end', () => resolve(data));
-          res.on('error', reject);
-        },
-      );
-      req.on('error', reject);
-      req.end(body);
-    });
-
-  assert.equal(await request('GET'), '{"version":1}');
-  await request('PUT', '{"version":2}');
-  assert.deepEqual(receivedMarkers, [undefined, undefined]);
-  assert.equal(stored, '{"version":2}', 'the upload itself succeeded');
-  assert.equal(await request('GET'), stored, 'verification must see the new file');
-  assert.equal(sockets[0], sockets[1], 'reproduce PUT on a reused connection');
-  assert.notEqual(sockets[1], sockets[2], 'verification needs a fresh connection');
+test('the hook recognises the exact marker the adapter emits (#9985)', () => {
+  // Guards the cross-target string contract in both directions: the hook must
+  // act on the producer's constant, and must not forward it to the server.
+  const headers = headersFor('PUT', 'dav.example.com', { [MARKER]: '1' });
+  assert.equal(headers.Connection, 'close');
+  assert.equal(Object.keys(headers).length, 1);
 });
 
 test('preserves connection reuse for unmarked requests, including other integrations PUTs', () => {

--- a/packages/sync-providers/src/file-based/webdav/webdav-api.ts
+++ b/packages/sync-providers/src/file-based/webdav/webdav-api.ts
@@ -429,6 +429,13 @@ export class WebdavApi {
    * CORS-safelisted request header, so on the web build it forces a preflight
    * that many WebDAV servers reject. The fetch path already passes
    * `cache: 'no-store'` and the native path adds its own no-cache headers.
+   *
+   * Known gap (#9985): only the body is checked, so a response pairing the
+   * correct body with the *previous* version's `ETag` — possible on a stale
+   * connection when both versions happen to be the same length — is accepted
+   * and its stale rev stored, costing a 412 on the next conditional PUT. Not
+   * guarded because no report shows that combination: STRATO's stale headers
+   * came with a stale or truncated body, which the hash check already catches.
    */
   private async _readBackUpload(
     path: string,

--- a/packages/sync-providers/src/file-based/webdav/webdav-api.ts
+++ b/packages/sync-providers/src/file-based/webdav/webdav-api.ts
@@ -35,10 +35,29 @@ export interface WebdavApiDeps {
   httpAdapter: WebDavHttpAdapter;
   /** Nextcloud's DAV layer exposes its canonical validator in `OC-ETag`. */
   useCanonicalOcEtag?: boolean;
+  /**
+   * Injectable sleep for the post-upload verification backoff, so tests do not
+   * pay the real wait. Defaults to a plain `setTimeout`.
+   */
+  delay?: (ms: number) => Promise<void>;
 }
 
 export class WebdavApi {
   private static readonly L = 'WebdavApi';
+
+  /**
+   * Read-back budget for `_verifyUpload`. The PUT has already been accepted by
+   * the time we verify, so re-reading is idempotent and never re-writes.
+   *
+   * #9985: some servers answer a GET that reuses the PUT's keep-alive
+   * connection with the *previous* version's body and `ETag`, or truncate it
+   * mid-stream (`net::ERR_CONTENT_LENGTH_MISMATCH`). The stored file is
+   * correct; only the read is transiently wrong, so one bad read must not be
+   * reported as a conflict. A genuine concurrent write still shows up on every
+   * attempt and is reported after the budget is spent.
+   */
+  private static readonly VERIFY_MAX_ATTEMPTS = 3;
+  private static readonly VERIFY_RETRY_DELAY_MS = 1000;
   private readonly xmlParser: WebdavXmlParser;
   private readonly directoryCreationQueue = new Map<string, Promise<void>>();
 
@@ -372,8 +391,46 @@ export class WebdavApi {
    * concurrent write by another client landing in the same window. Both cases
    * are surfaced as RemoteFileChangedUnexpectedly so the adapter's existing
    * self-healing path (re-download and retry) handles them uniformly.
+   *
+   * Every failure mode is re-read up to `VERIFY_MAX_ATTEMPTS` times first —
+   * see the constant for why a single bad read is not evidence of a conflict.
    */
   private async _verifyUpload(
+    path: string,
+    fullPath: string,
+    expectedHash: string,
+  ): Promise<string> {
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await this._readBackUpload(path, fullPath, expectedHash);
+      } catch (e) {
+        if (attempt >= WebdavApi.VERIFY_MAX_ATTEMPTS) {
+          throw e;
+        }
+        this._deps.logger.normal(
+          `${WebdavApi.L}._verifyUpload() re-reading after a failed attempt`,
+          errorMeta(e, { path, attempt }),
+        );
+        await this._sleep(WebdavApi.VERIFY_RETRY_DELAY_MS);
+      }
+    }
+  }
+
+  private async _sleep(ms: number): Promise<void> {
+    if (this._deps.delay) {
+      await this._deps.delay(ms);
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * One read-back attempt. Deliberately sends no `Cache-Control`: it is not a
+   * CORS-safelisted request header, so on the web build it forces a preflight
+   * that many WebDAV servers reject. The fetch path already passes
+   * `cache: 'no-store'` and the native path adds its own no-cache headers.
+   */
+  private async _readBackUpload(
     path: string,
     fullPath: string,
     expectedHash: string,
@@ -381,9 +438,6 @@ export class WebdavApi {
     const remoteResponse = await this._makeRequest({
       url: fullPath,
       method: WebDavHttpMethod.GET,
-      headers: {
-        [WebDavHttpHeader.CACHE_CONTROL]: 'no-cache',
-      },
     });
 
     if (!remoteResponse.data || remoteResponse.data.length === 0) {

--- a/packages/sync-providers/src/file-based/webdav/webdav-http-adapter.ts
+++ b/packages/sync-providers/src/file-based/webdav/webdav-http-adapter.ts
@@ -5,6 +5,7 @@ import type { NativeHttpExecutor } from '../../http/native-http-retry';
 import {
   AuthFailSPError,
   HttpNotOkAPIError,
+  NetworkUnavailableSPError,
   PotentialCorsError,
   RemoteFileNotFoundAPIError,
   TooManyRequestsAPIError,
@@ -132,6 +133,22 @@ export class WebDavHttpAdapter {
 
           response = await this._convertFetchResponse(fetchResponse);
         } catch (fetchError) {
+          if (fetchError instanceof TypeError && this._deps.platformInfo.isElectron) {
+            // #9985: the desktop shell injects `Access-Control-Allow-*: *` on
+            // every response and forces preflights to 200, so CORS cannot be
+            // the cause here. Reporting it sent a user chasing a dead end while
+            // the real failure was a truncated response from the WebDAV server.
+            // Structured meta only — some browsers embed the full URL in
+            // `error.message`, which must never reach an exportable log.
+            this._deps.logger.critical(
+              `${WebDavHttpAdapter.L}.request() network failure`,
+              errorMeta(fetchError, { url: scrubbedUrl, method: options.method }),
+            );
+            throw new NetworkUnavailableSPError(
+              `Network request to ${scrubbedUrl} failed. Check your connection ` +
+                `and whether the server is reachable.`,
+            );
+          }
           if (this._isLikelyCors(fetchError)) {
             // Privacy: PotentialCorsError carries only the scrubbed URL,
             // never the raw fetch error. The original-error meta below is
@@ -162,6 +179,7 @@ export class WebDavHttpAdapter {
       if (
         e instanceof AuthFailSPError ||
         e instanceof PotentialCorsError ||
+        e instanceof NetworkUnavailableSPError ||
         e instanceof HttpNotOkAPIError ||
         e instanceof RemoteFileNotFoundAPIError ||
         e instanceof TooManyRequestsAPIError
@@ -207,8 +225,8 @@ export class WebDavHttpAdapter {
    *
    * Bias is intentional: WebDAV's most common deployment failure mode
    * IS misconfigured CORS, so over-attributing offline / DNS to CORS
-   * still surfaces an actionable hint to the user. Native-platform
-   * paths never hit this branch.
+   * still surfaces an actionable hint to the user. Native-platform and
+   * Electron paths never hit this branch — Electron is handled above.
    */
   private _isLikelyCors(error: unknown): boolean {
     if (!(error instanceof TypeError)) return false;

--- a/packages/sync-providers/src/file-based/webdav/webdav-http-adapter.ts
+++ b/packages/sync-providers/src/file-based/webdav/webdav-http-adapter.ts
@@ -43,6 +43,17 @@ export interface WebDavHttpAdapterDeps {
 
 export class WebDavHttpAdapter {
   private static readonly L = 'WebDavHttpAdapter';
+  /**
+   * Marks a desktop WebDAV upload so `electron/main-window.ts` can put
+   * `Connection: close` on it — renderer `fetch` refuses to set that header
+   * itself (#9985). The main process matches this exact name as a literal (the
+   * two build targets cannot import each other), and the Electron test
+   * `webdav-connection.test.cjs` reads this constant so the two cannot drift.
+   *
+   * HTTP/1.1 only: RFC 9113 forbids connection-specific headers over HTTP/2, so
+   * the marker is inert there and `WebdavApi`'s verification retry budget is
+   * what covers h2 servers.
+   */
   private static readonly ELECTRON_UPLOAD_HEADER = 'X-SuperProductivity-WebDAV-Upload';
 
   /**
@@ -152,9 +163,17 @@ export class WebDavHttpAdapter {
               `${WebDavHttpAdapter.L}.request() network failure`,
               errorMeta(fetchError, { url: scrubbedUrl, method: options.method }),
             );
+            // No host in the message: NetworkUnavailableSPError is documented as
+            // safe to render verbatim, and the host is already in the log meta.
+            //
+            // Known gap: Chromium reports the real cause (#9985's
+            // net::ERR_CONTENT_LENGTH_MISMATCH) only to devtools, never on the
+            // TypeError — whose message is a bare "Failed to fetch" — so there
+            // is nothing further to extract here. Recovering it would mean
+            // piping `session.webRequest.onErrorOccurred` back to the renderer.
             throw new NetworkUnavailableSPError(
-              `Network request to ${scrubbedUrl} failed. Check your connection ` +
-                `and whether the server is reachable.`,
+              'Network request failed. Check your connection and whether the ' +
+                'server is reachable.',
             );
           }
           if (this._isLikelyCors(fetchError)) {

--- a/packages/sync-providers/src/file-based/webdav/webdav-http-adapter.ts
+++ b/packages/sync-providers/src/file-based/webdav/webdav-http-adapter.ts
@@ -43,6 +43,7 @@ export interface WebDavHttpAdapterDeps {
 
 export class WebDavHttpAdapter {
   private static readonly L = 'WebDavHttpAdapter';
+  private static readonly ELECTRON_UPLOAD_HEADER = 'X-SuperProductivity-WebDAV-Upload';
 
   /**
    * Sync correctness (#7144): force revalidation on the NATIVE HTTP path. iOS
@@ -123,9 +124,16 @@ export class WebDavHttpAdapter {
         });
         try {
           const fetchImpl = this._deps.webFetch();
+          // Electron's main-window request hook consumes this marker and sets
+          // Connection: close, which renderer fetch cannot set itself (#9985).
+          // Keep it off the web/native paths and preserve conditional headers.
+          const headers =
+            this._deps.platformInfo.isElectron && options.method === 'PUT'
+              ? { ...options.headers, [WebDavHttpAdapter.ELECTRON_UPLOAD_HEADER]: '1' }
+              : options.headers;
           const fetchResponse = await fetchImpl(options.url, {
             method: options.method,
-            headers: options.headers,
+            headers,
             body: options.body,
             // Disable HTTP caching to ensure we get fresh metadata for sync operations
             cache: 'no-store',

--- a/packages/sync-providers/src/platform/provider-platform-info.ts
+++ b/packages/sync-providers/src/platform/provider-platform-info.ts
@@ -17,4 +17,13 @@ export interface ProviderPlatformInfo {
   readonly isAndroidWebView: boolean;
   /** True when running on iOS via Capacitor. */
   readonly isIosNative: boolean;
+  /**
+   * True when running inside the Electron desktop shell.
+   *
+   * Optional so hosts that predate it keep today's behaviour: every consumer
+   * treats a missing value as `false`, and the flag only ever *disables* a
+   * heuristic. Electron neutralises CORS app-wide (see `electron/main-window.ts`),
+   * so a failed request there is never a cross-origin problem — #9985.
+   */
+  readonly isElectron?: boolean;
 }

--- a/packages/sync-providers/src/platform/provider-platform-info.ts
+++ b/packages/sync-providers/src/platform/provider-platform-info.ts
@@ -20,10 +20,9 @@ export interface ProviderPlatformInfo {
   /**
    * True when running inside the Electron desktop shell.
    *
-   * Optional so hosts that predate it keep today's behaviour: every consumer
-   * treats a missing value as `false`, and the flag only ever *disables* a
-   * heuristic. Electron neutralises CORS app-wide (see `electron/main-window.ts`),
-   * so a failed request there is never a cross-origin problem — #9985.
+   * Optional so hosts that predate it keep today's behaviour: consumers treat
+   * a missing value as `false`. Enables the desktop WebDAV transport handling
+   * coordinated with `electron/main-window.ts` (#9985).
    */
   readonly isElectron?: boolean;
 }

--- a/packages/sync-providers/tests/file-based/webdav/webdav-api.spec.ts
+++ b/packages/sync-providers/tests/file-based/webdav/webdav-api.spec.ts
@@ -72,6 +72,8 @@ const makeApi = (
     getCfg: async () => overrideCfg,
     httpAdapter: adapter as unknown as WebDavHttpAdapter,
     useCanonicalOcEtag,
+    // Instant delay so verification retries do not slow the suite down.
+    delay: async () => {},
   });
 
 const makeNextcloudApi = (adapter: MockAdapter): WebdavApi =>
@@ -154,6 +156,16 @@ const putsOf = (adapter: MockAdapter): DavRequest[] =>
   adapter.request.mock.calls
     .map((call: unknown[]) => call[0] as DavRequest)
     .filter((req) => req.method === 'PUT');
+
+const getsOf = (adapter: MockAdapter): DavRequest[] =>
+  adapter.request.mock.calls
+    .map((call: unknown[]) => call[0] as DavRequest)
+    .filter((req) => req.method === 'GET');
+
+const headerValue = (req: DavRequest, name: string): string | undefined =>
+  Object.entries(req.headers ?? {}).find(
+    ([key]) => key.toLowerCase() === name.toLowerCase(),
+  )?.[1];
 
 describe('WebdavApi', () => {
   describe('listFiles', () => {
@@ -529,7 +541,8 @@ describe('WebdavApi', () => {
       const data = 'good';
       // skip conditional (no expectedRev)
       adapter.request.mockResolvedValueOnce(okResponse('', 201)); // PUT
-      adapter.request.mockResolvedValueOnce(okResponse('truncated')); // verify
+      // Every verification attempt sees the same truncated copy.
+      adapter.request.mockResolvedValue(okResponse('truncated'));
 
       await expect(
         makeApi(adapter).upload({ path: 'op-1.json', data }),
@@ -582,6 +595,142 @@ describe('WebdavApi', () => {
       expect(err.message).toContain('Base URL');
       expect(err.message).toContain('Sync Folder Path');
       expect(err.message).not.toContain('op-1.json');
+    });
+  });
+
+  /**
+   * #9985: STRATO HiDrive answers a GET that reuses the keep-alive connection of
+   * the PUT which just succeeded with the PREVIOUS version's body/ETag (and a
+   * Content-Length that then truncates, surfacing in Chromium as
+   * net::ERR_CONTENT_LENGTH_MISMATCH). The write itself landed, so the read-back
+   * is the only thing that is wrong — re-reading is safe and idempotent, and it
+   * must never re-issue the PUT.
+   */
+  describe('post-upload verification resilience (#9985)', () => {
+    const makeApiWithDelay = (
+      adapter: MockAdapter,
+      delay: (ms: number) => Promise<void>,
+    ): WebdavApi =>
+      new WebdavApi({
+        logger: NOOP_SYNC_LOGGER,
+        getCfg: async () => cfg,
+        httpAdapter: adapter as unknown as WebDavHttpAdapter,
+        delay,
+      });
+
+    it('re-reads when the verification GET serves the previous version', async () => {
+      const adapter = makeAdapter();
+      const data = 'the new body';
+      adapter.request.mockResolvedValueOnce(okResponse('', 204)); // PUT
+      adapter.request.mockResolvedValueOnce(
+        okResponse('the previous body', 200, { etag: '"old-rev"' }),
+      );
+      adapter.request.mockResolvedValueOnce(okResponse(data, 200, { etag: '"new-rev"' }));
+
+      const r = await makeApi(adapter).upload({ path: 'op-1.json', data });
+
+      expect(r.rev).toBe('"new-rev"');
+      expect(putsOf(adapter)).toHaveLength(1);
+      expect(getsOf(adapter)).toHaveLength(2);
+    });
+
+    it('re-reads when the verification GET fails at transport level', async () => {
+      const adapter = makeAdapter();
+      const data = 'the new body';
+      adapter.request.mockResolvedValueOnce(okResponse('', 204)); // PUT
+      adapter.request.mockRejectedValueOnce(
+        new HttpNotOkAPIError(new Response('', { status: 500 })),
+      );
+      adapter.request.mockResolvedValueOnce(okResponse(data));
+
+      const r = await makeApi(adapter).upload({ path: 'op-1.json', data });
+
+      expect(r.rev).toBe(await md5HashWasm(data));
+      expect(putsOf(adapter)).toHaveLength(1);
+    });
+
+    it('re-reads when the verification GET returns an empty body', async () => {
+      const adapter = makeAdapter();
+      const data = 'the new body';
+      adapter.request.mockResolvedValueOnce(okResponse('', 204)); // PUT
+      adapter.request.mockResolvedValueOnce(okResponse(''));
+      adapter.request.mockResolvedValueOnce(okResponse(data));
+
+      const r = await makeApi(adapter).upload({ path: 'op-1.json', data });
+
+      expect(r.rev).toBe(await md5HashWasm(data));
+      expect(putsOf(adapter)).toHaveLength(1);
+    });
+
+    it('re-reads when the verification GET 404s right after a successful PUT', async () => {
+      const adapter = makeAdapter();
+      const data = 'the new body';
+      adapter.request.mockResolvedValueOnce(okResponse('', 204)); // PUT
+      adapter.request.mockRejectedValueOnce(new RemoteFileNotFoundAPIError('op-1.json'));
+      adapter.request.mockResolvedValueOnce(okResponse(data));
+
+      const r = await makeApi(adapter).upload({ path: 'op-1.json', data });
+
+      expect(r.rev).toBe(await md5HashWasm(data));
+      expect(putsOf(adapter)).toHaveLength(1);
+    });
+
+    it('still reports a conflict when every attempt disagrees, without re-PUTting', async () => {
+      const adapter = makeAdapter();
+      adapter.request.mockResolvedValueOnce(okResponse('', 204)); // PUT
+      // A genuine concurrent write stays visible on every re-read.
+      adapter.request.mockResolvedValue(okResponse('another clients body'));
+
+      await expect(
+        makeApi(adapter).upload({ path: 'op-1.json', data: 'mine' }),
+      ).rejects.toBeInstanceOf(RemoteFileChangedUnexpectedly);
+
+      expect(putsOf(adapter)).toHaveLength(1);
+      expect(getsOf(adapter)).toHaveLength(3);
+    });
+
+    it('surfaces the transport error when every attempt fails to read', async () => {
+      const adapter = makeAdapter();
+      adapter.request.mockResolvedValueOnce(okResponse('', 204)); // PUT
+      adapter.request.mockRejectedValue(new AuthFailSPError('Authentication failed'));
+
+      await expect(
+        makeApi(adapter).upload({ path: 'op-1.json', data: 'mine' }),
+      ).rejects.toBeInstanceOf(AuthFailSPError);
+      expect(putsOf(adapter)).toHaveLength(1);
+    });
+
+    it('waits between verification attempts instead of hammering the server', async () => {
+      const waited: number[] = [];
+      const adapter = makeAdapter();
+      const data = 'the new body';
+      adapter.request.mockResolvedValueOnce(okResponse('', 204)); // PUT
+      adapter.request.mockResolvedValueOnce(okResponse('stale'));
+      adapter.request.mockResolvedValueOnce(okResponse(data));
+
+      await makeApiWithDelay(adapter, async (ms) => {
+        waited.push(ms);
+      }).upload({ path: 'op-1.json', data });
+
+      expect(waited).toHaveLength(1);
+      expect(waited[0]).toBeGreaterThan(0);
+    });
+
+    it('sends no Cache-Control request header on the verification GET', async () => {
+      // `Cache-Control` is not a CORS-safelisted request header, so on the web
+      // build it forces a preflight many WebDAV servers reject — turning every
+      // upload verification into a genuine CORS failure. The fetch path already
+      // passes `cache: 'no-store'` and the native path adds its own no-cache
+      // headers, so the API layer must not add one of its own.
+      const adapter = makeAdapter();
+      const data = 'body';
+      adapter.request.mockResolvedValueOnce(okResponse('', 204)); // PUT
+      adapter.request.mockResolvedValueOnce(okResponse(data));
+
+      await makeApi(adapter).upload({ path: 'op-1.json', data });
+
+      const verifyGet = getsOf(adapter).at(-1) as DavRequest;
+      expect(headerValue(verifyGet, WebDavHttpHeader.CACHE_CONTROL)).toBeUndefined();
     });
   });
 

--- a/packages/sync-providers/tests/file-based/webdav/webdav-http-adapter.spec.ts
+++ b/packages/sync-providers/tests/file-based/webdav/webdav-http-adapter.spec.ts
@@ -4,6 +4,7 @@ import { WebDavHttpAdapter } from '../../../src/file-based/webdav/webdav-http-ad
 import {
   AuthFailSPError,
   HttpNotOkAPIError,
+  NetworkUnavailableSPError,
   PotentialCorsError,
   RemoteFileNotFoundAPIError,
   TooManyRequestsAPIError,
@@ -14,6 +15,7 @@ import type { ProviderPlatformInfo, WebFetchFactory } from '../../../src/platfor
 
 const makeDeps = (overrides: {
   isNativePlatform?: boolean;
+  isElectron?: boolean;
   fetchImpl?: typeof fetch;
   nativeHttp?: NativeHttpExecutor;
   logger?: SyncLogger;
@@ -27,6 +29,7 @@ const makeDeps = (overrides: {
     isNativePlatform: overrides.isNativePlatform ?? false,
     isAndroidWebView: false,
     isIosNative: false,
+    isElectron: overrides.isElectron ?? false,
   },
   webFetch: () => overrides.fetchImpl ?? (globalThis.fetch as typeof fetch),
   nativeHttp: overrides.nativeHttp ?? vi.fn(),
@@ -209,6 +212,62 @@ describe('WebDavHttpAdapter', () => {
       await expect(
         adapter.request({ url: 'https://dav.example.com/x', method: 'GET' }),
       ).rejects.toBeInstanceOf(HttpNotOkAPIError);
+    });
+
+    /**
+     * #9985: the desktop app injects `Access-Control-Allow-{Origin,Headers,
+     * Methods}: *` on every response and forces preflights to 200 (see
+     * `electron/main-window.ts`), so CORS can never be the cause there. Blaming
+     * it sent a user chasing a dead end while the real failure was a truncated
+     * response (`net::ERR_CONTENT_LENGTH_MISMATCH`) from a misbehaving server.
+     */
+    it('never blames CORS on Electron, where CORS is disabled app-wide', async () => {
+      const fetchImpl = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+      const adapter = new WebDavHttpAdapter(
+        makeDeps({ isElectron: true, fetchImpl: fetchImpl as unknown as typeof fetch }),
+      );
+
+      const err = await adapter
+        .request({ url: 'https://dav.example.com/x', method: 'GET' })
+        .catch((e) => e);
+
+      expect(err).not.toBeInstanceOf(PotentialCorsError);
+      expect(err).toBeInstanceOf(NetworkUnavailableSPError);
+    });
+
+    it('keeps the CORS hint on the web build, where CORS is real', async () => {
+      const fetchImpl = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+      const adapter = new WebDavHttpAdapter(
+        makeDeps({ isElectron: false, fetchImpl: fetchImpl as unknown as typeof fetch }),
+      );
+
+      await expect(
+        adapter.request({ url: 'https://dav.example.com/x', method: 'GET' }),
+      ).rejects.toBeInstanceOf(PotentialCorsError);
+    });
+
+    it('leaks no credentials or path through the Electron network error', async () => {
+      const fetchImpl = vi
+        .fn()
+        .mockRejectedValue(
+          new TypeError(
+            'NetworkError when attempting to fetch resource at https://user:pass@dav.example.com/x?token=secret',
+          ),
+        );
+      const adapter = new WebDavHttpAdapter(
+        makeDeps({ isElectron: true, fetchImpl: fetchImpl as unknown as typeof fetch }),
+      );
+
+      const err = await adapter
+        .request({
+          url: 'https://user:pass@dav.example.com/x?token=secret',
+          method: 'GET',
+        })
+        .catch((e) => e);
+
+      const msg = (err as Error).message ?? '';
+      expect(msg).not.toContain('user:pass');
+      expect(msg).not.toContain('secret');
     });
 
     it('PotentialCorsError carries only the scrubbed URL, never the raw error', async () => {

--- a/packages/sync-providers/tests/file-based/webdav/webdav-http-adapter.spec.ts
+++ b/packages/sync-providers/tests/file-based/webdav/webdav-http-adapter.spec.ts
@@ -303,6 +303,9 @@ describe('WebDavHttpAdapter', () => {
       const msg = (err as Error).message ?? '';
       expect(msg).not.toContain('user:pass');
       expect(msg).not.toContain('secret');
+      // NetworkUnavailableSPError is documented as safe to render verbatim, so
+      // the user's private WebDAV host must not ride along in the message.
+      expect(msg).not.toContain('dav.example.com');
     });
 
     it('PotentialCorsError carries only the scrubbed URL, never the raw error', async () => {

--- a/packages/sync-providers/tests/file-based/webdav/webdav-http-adapter.spec.ts
+++ b/packages/sync-providers/tests/file-based/webdav/webdav-http-adapter.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NOOP_SYNC_LOGGER, type SyncLogger } from '@sp/sync-core';
 import { WebDavHttpAdapter } from '../../../src/file-based/webdav/webdav-http-adapter';
+import { WebDavHttpHeader } from '../../../src/file-based/webdav/webdav.const';
 import {
   AuthFailSPError,
   HttpNotOkAPIError,
@@ -67,33 +68,67 @@ describe('WebDavHttpAdapter', () => {
       );
     });
 
-    it('sends no-cache request headers on the native path (#7144)', async () => {
-      // Regression guard: iOS URLSession / upstream proxies otherwise serve a
-      // stale sync-data.json, which hides remote changes and defeats the
-      // content-hash conflict check, causing silent overwrite/data loss.
-      const nativeHttp = vi.fn().mockResolvedValue({
-        status: 200,
-        headers: {},
-        data: 'native-body',
-      });
-      const adapter = new WebDavHttpAdapter(
-        makeDeps({ isNativePlatform: true, nativeHttp }),
-      );
+    it.each(['GET', 'PUT'])(
+      'sends no-cache headers without an Electron marker on native %s (#7144)',
+      async (method) => {
+        // Regression guard: iOS URLSession / upstream proxies otherwise serve a
+        // stale sync-data.json, which hides remote changes and defeats the
+        // content-hash conflict check, causing silent overwrite/data loss.
+        const nativeHttp = vi.fn().mockResolvedValue({
+          status: 200,
+          headers: {},
+          data: 'native-body',
+        });
+        const adapter = new WebDavHttpAdapter(
+          makeDeps({ isNativePlatform: true, nativeHttp }),
+        );
 
-      await adapter.request({
-        url: 'https://dav.example.com/sync/file',
-        method: 'GET',
-        headers: { Authorization: 'Basic abc' },
-      });
+        await adapter.request({
+          url: 'https://dav.example.com/sync/file',
+          method,
+          headers: { Authorization: 'Basic abc' },
+        });
 
-      const sentHeaders = (
-        nativeHttp.mock.calls[0][0] as { headers: Record<string, string> }
-      ).headers;
-      expect(sentHeaders['Cache-Control']).toBe('no-cache, no-store');
-      expect(sentHeaders['Pragma']).toBe('no-cache');
-      // Caller headers are preserved.
-      expect(sentHeaders['Authorization']).toBe('Basic abc');
-    });
+        const sentHeaders = (
+          nativeHttp.mock.calls[0][0] as { headers: Record<string, string> }
+        ).headers;
+        expect(sentHeaders['Cache-Control']).toBe('no-cache, no-store');
+        expect(sentHeaders['Pragma']).toBe('no-cache');
+        expect(sentHeaders['X-SuperProductivity-WebDAV-Upload']).toBeUndefined();
+        // Caller headers are preserved.
+        expect(sentHeaders['Authorization']).toBe('Basic abc');
+      },
+    );
+
+    it.each([
+      [true, 'PUT', '1'],
+      [true, 'GET', null],
+      [false, 'PUT', null],
+    ])(
+      'marks only Electron WebDAV PUTs (electron=%s, method=%s)',
+      async (isElectron, method, marker) => {
+        const fetchImpl = vi.fn().mockResolvedValue(okFetchResponse());
+        const adapter = new WebDavHttpAdapter(
+          makeDeps({
+            isElectron,
+            fetchImpl: fetchImpl as unknown as typeof fetch,
+          }),
+        );
+        const headers = {
+          Authorization: 'Basic abc',
+          [WebDavHttpHeader.IF_MATCH]: '"rev"',
+        };
+        await adapter.request({ url: 'https://dav.example.com/file', method, headers });
+        const sent = new Headers((fetchImpl.mock.calls[0][1] as RequestInit).headers);
+        expect(sent.get('X-SuperProductivity-WebDAV-Upload')).toBe(marker);
+        expect(sent.get('Authorization')).toBe('Basic abc');
+        expect(sent.get('If-Match')).toBe('"rev"');
+        expect(headers).toEqual({
+          Authorization: 'Basic abc',
+          [WebDavHttpHeader.IF_MATCH]: '"rev"',
+        });
+      },
+    );
 
     it('uses fetch when not native', async () => {
       const fetchImpl = vi.fn().mockResolvedValue(okFetchResponse(200, 'web-body'));

--- a/src/app/op-log/sync-providers/platform/app-provider-platform-info.ts
+++ b/src/app/op-log/sync-providers/platform/app-provider-platform-info.ts
@@ -1,4 +1,5 @@
 import type { ProviderPlatformInfo } from '@sp/sync-providers/platform';
+import { IS_ELECTRON } from '../../../app.constants';
 import { IS_IOS_NATIVE, IS_NATIVE_PLATFORM } from '../../../util/is-native-platform';
 import { IS_ANDROID_WEB_VIEW } from '../../../util/is-android-web-view';
 
@@ -12,4 +13,5 @@ export const APP_PROVIDER_PLATFORM_INFO: ProviderPlatformInfo = {
   isNativePlatform: IS_NATIVE_PLATFORM,
   isAndroidWebView: IS_ANDROID_WEB_VIEW,
   isIosNative: IS_IOS_NATIVE,
+  isElectron: IS_ELECTRON,
 };


### PR DESCRIPTION
Fixes #9985.

STRATO HiDrive has a server-side bug with persistent HTTP/1.1 connections: a GET that reuses the keep-alive connection of a PUT that just succeeded may answer with the *previous* version's body and ETag, or with the previous version's `Content-Length`, which truncates the response (`net::ERR_CONTENT_LENGTH_MISMATCH`). The write itself lands correctly — only the read-back is wrong. Super Productivity surfaced this as `RemoteFileChangedUnexpectedly` / "Concurrent upload detected", and on desktop it misreported the transport failure as a CORS error, sending the reporter chasing a dead end.

## What changed

**1. The verification read-back is retried (`WebdavApi`)** — up to 3 attempts, 1s apart. The PUT has already been accepted by then, so re-reading is idempotent and never re-issues the write. A genuine concurrent write still shows up on every attempt and is reported after the budget is spent. This is the cross-platform fix.

**2. Desktop uploads close their connection (`electron/main-window.ts`)** — the WebDAV adapter marks Electron PUTs with a private header; the main-process request hook consumes the marker and sets `Connection: close`, which renderer `fetch` cannot set itself. Verification then cannot land on the poisoned connection. Scoped to WebDAV PUTs, so no other integration loses connection reuse.

**3. Network failures are no longer blamed on CORS on desktop** — the shell injects `Access-Control-Allow-*: *` and forces preflights to 200, so CORS can never be the cause there. Electron `TypeError`s now become `NetworkUnavailableSPError`, which the sync wrapper already treats as transient and self-healing.

**4. The verification GET no longer sends `Cache-Control`** — it is not a CORS-safelisted request header, so on the web build it forced a preflight many WebDAV servers reject. `fetch`'s `cache: 'no-store'` already makes the UA append `Cache-Control: no-cache` and `Pragma: no-cache`, and the native path adds its own, so nothing is lost on the wire.

## Review round

A review of the first two commits produced the third:

- The marker header name existed as independent literals in two build targets that cannot import each other — renaming either side would have silently disabled the fix with every test still green. The Electron test now reads `ELECTRON_UPLOAD_HEADER` out of the adapter source; verified it fails when the constant is renamed.
- Dropped a 70-line real-HTTP-server test. Mutation testing showed every regression it caught was also caught by the casing and non-PUT tests, and it exercised Node's HTTP client rather than the transport that ships.
- Removed the hostname from `NetworkUnavailableSPError`'s message, which is documented as safe to render verbatim; the host stays in the structured log meta.
- Recorded two known gaps rather than guarding them, per the repo's "hardening needs an observed instance" rule: a response pairing a correct body with a stale ETag, and Chromium exposing `net::ERR_*` only to devtools.

## Verification

294 Electron tests, 443 provider tests, provider typecheck, and `checkFile` on every changed `.ts` file. New coverage: stale-body re-read, transport-error re-read, empty-body re-read, post-PUT 404 re-read, conflict still reported after the budget without re-PUTting, backoff between attempts, no `Cache-Control` on the verification GET, marker routing/removal/casing, and preservation of conditional headers.

## Before merging

Two open items, both called out by the review:

- [ ] **`Connection: close` over HTTP/2 is unverified.** RFC 9113 forbids connection-specific headers on h2, so the marker should be inert there and the retry budget is what covers those servers — but this was only ever exercised against a Node HTTP/1.1 server. If Chromium rejects the request instead of stripping the header, desktop WebDAV uploads would fail on h2 endpoints, and auto-syncs stay silent by design. One manual sync from the running desktop app against a TLS WebDAV endpoint settles it. The reported STRATO failure was reproduced over HTTP/1.1.
- [ ] `NetworkUnavailableSPError`'s message begins with `"Network request failed."`, which `_isLikelyCors` matches as a CORS signal. Unreachable today — that helper guards on `instanceof TypeError` — but it is the exact misclassification this issue is about, so it is worth rewording.

Sync-risk note: no schema change, no op semantics change, no vector-clock or reducer changes. The retry path is read-only and asserted never to re-PUT.

https://claude.ai/code/session_01D168PgJ4vDPBwfTLPRRocJ
