### PR TITLE
test(tools): make the Windows artifact contract test checkout-agnostic

### DIFF
--- a/tools/verify-windows-artifact-contract.test.js
+++ b/tools/verify-windows-artifact-contract.test.js
@@ -6,7 +6,11 @@ const { readFileSync } = require('node:fs');
 const { join } = require('node:path');
 
 const ROOT = join(__dirname, '..');
-const readRoot = (...pathParts) => readFileSync(join(ROOT, ...pathParts), 'utf8');
+// `.gitattributes` forces LF only for scss/html/js/ts, so YAML lands in the
+// working tree with CRLF on Windows checkouts. Normalize before parsing so the
+// line-exact section lookup below works on every runner.
+const readRoot = (...pathParts) =>
+  readFileSync(join(ROOT, ...pathParts), 'utf8').replace(/\r\n/g, '\n');
 
 const BUILDER_YAML = readRoot('electron-builder.yaml');
 const RELEASE_WORKFLOW = readRoot('.github', 'workflows', 'build.yml');


### PR DESCRIPTION
The Windows Store release job failed in `npm run build` with
"nsis section not found": `.gitattributes` forces LF only for
scss/html/js/ts, so `electron-builder.yaml` is checked out with CRLF on
Windows runners. The section lookup compares whole lines
(`lines.indexOf('nsis:')`), which never matches `nsis:\r`.

Normalize CRLF when reading the packaging config and the release
workflow, so the line-exact parsing works on every runner.

Reproduced by converting electron-builder.yaml to CRLF locally: same
'nsis section not found' failure before the fix, 52/52 tools tests
passing after it under both LF and CRLF.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CqidJPDuEcUZVhMY7hW72S