### PR TITLE
build(gitattributes): pin YAML to LF so Windows checkouts parse it

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,7 @@
 *.html text eol=lf
 *.js text eol=lf
 *.ts text eol=lf
+# Tools parse these line-exactly without a YAML parser (none is allowed as a
+# dependency), so keep them LF in the working tree on Windows checkouts too.
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/tools/verify-windows-artifact-contract.test.js
+++ b/tools/verify-windows-artifact-contract.test.js
@@ -6,9 +6,10 @@ const { readFileSync } = require('node:fs');
 const { join } = require('node:path');
 
 const ROOT = join(__dirname, '..');
-// `.gitattributes` forces LF only for scss/html/js/ts, so YAML lands in the
-// working tree with CRLF on Windows checkouts. Normalize before parsing so the
-// line-exact section lookup below works on every runner.
+// `.gitattributes` now pins YAML to LF, so Windows checkouts match Linux ones.
+// Normalize anyway: the line-exact section lookup below must not silently depend
+// on how a given checkout resolved EOLs (a CRLF working tree is what broke the
+// v18.22.0 Windows release job).
 const readRoot = (...pathParts) =>
   readFileSync(join(ROOT, ...pathParts), 'utf8').replace(/\r\n/g, '\n');
 


### PR DESCRIPTION
The v18.22.0 release run failed in the windows-bin Lint step with "nsis
section not found": `.gitattributes` pinned LF for scss/html/js/ts only,
so `* text=auto` left `electron-builder.yaml` CRLF in the working tree on
the Windows runner, and the line-exact `lines.indexOf('nsis:')` lookup in
tools/verify-windows-artifact-contract.test.js never matched `nsis:\r`.
That aborted the job before it built or signed anything, so the v18.22.0
draft release carries Linux and Mac assets but no Windows binaries.

#10036 fixed that one parser by normalizing CRLF on read. This removes the
cause instead: the project forbids adding a YAML parser, so tools parse
`electron-builder.yaml` and the workflows line-exactly and the next such
check would hit the same Windows-only failure. Pinning `*.yml`/`*.yaml` to
LF makes every checkout agree.

The read-side normalization stays as defense in depth. Verified on a CRLF
working tree: the pre-#10036 parser reproduces 'nsis section not found',
the current one passes, and the tools suite is 52/52 on an LF tree.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VqPaEj2PJxViF8f7SWWnvq