### PR TITLE
fix(electron): stop the macOS tray icon blinking during focus sessions

### DIFF
--- a/electron/indicator.test.cjs
+++ b/electron/indicator.test.cjs
@@ -419,3 +419,82 @@ test('tray title shows the task title when countdown display is disabled', () =>
   assert.equal(traySetTitleCalls.at(-1), 'Write release notes');
   assert.equal(traySetToolTipCalls.at(-1), 'Write release notes');
 });
+
+// A Flowtime session has no target duration, so focus mode publishes progress 0
+// while task tracking publishes the real task ratio. Both reached the tray icon
+// every second, flipping it between the progress ring and the plain running
+// icon — the blink reported in #9944 (and the dock-bar variant in #3131).
+test('tray icon has a single writer per tick while the focus overlay is hidden', () => {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: 'darwin',
+  });
+  const { initIndicator } = loadIndicatorModule();
+
+  initIndicator({
+    showApp: () => {},
+    quitApp: () => {},
+    ICONS_FOLDER: '/icons/',
+    forceDarkTray: false,
+    app: { on: () => {} },
+  });
+
+  const currentTaskUpdated = ipcHandlers.get('CURRENT_TASK_UPDATED');
+  const setProgressBar = ipcHandlers.get('SET_PROGRESS_BAR');
+  const task = {
+    id: 'T1',
+    title: 'Task',
+    timeSpent: 30 * 60000,
+    timeEstimate: 60 * 60000,
+  };
+
+  traySetImageCalls = [];
+  for (let i = 0; i < 3; i++) {
+    task.timeSpent += 1000;
+    // task-electron.effects: isFocusModeEnabled === isOverlayShown === false
+    currentTaskUpdated({}, { ...task }, false, 0, false, 0, 'Flowtime');
+    // focus-mode.effects: Flowtime publishes no meaningful progress
+    setProgressBar({}, { progress: -1, progressBarMode: 'none' });
+  }
+
+  const iconPaths = traySetImageCalls.map((image) => image.iconPath);
+  assert.deepEqual(iconPaths, ['/icons/indicator/running-anim-l/8.png']);
+});
+
+test('the focus overlay owns the tray icon while it is shown', () => {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: 'darwin',
+  });
+  const { initIndicator } = loadIndicatorModule();
+
+  initIndicator({
+    showApp: () => {},
+    quitApp: () => {},
+    ICONS_FOLDER: '/icons/',
+    forceDarkTray: false,
+    app: { on: () => {} },
+  });
+
+  const currentTaskUpdated = ipcHandlers.get('CURRENT_TASK_UPDATED');
+  const setProgressBar = ipcHandlers.get('SET_PROGRESS_BAR');
+
+  // isFocusModeEnabled === isOverlayShown === true
+  currentTaskUpdated(
+    {},
+    { id: 'T1', title: 'Task', timeSpent: 30 * 60000, timeEstimate: 60 * 60000 },
+    false,
+    0,
+    true,
+    0,
+    'Pomodoro',
+  );
+  traySetImageCalls = [];
+  setProgressBar({}, { progress: 0.2, progressBarMode: 'normal' });
+
+  assert.equal(traySetImageCalls.length, 1);
+  assert.match(
+    traySetImageCalls.at(-1).iconPath,
+    /\/icons\/indicator\/running-anim-l\/3\.png$/,
+  );
+});

--- a/electron/indicator.ts
+++ b/electron/indicator.ts
@@ -208,7 +208,12 @@ function initListeners(): void {
   initTaskWidgetSettingsListener();
 
   ipcMain.on(IPC.SET_PROGRESS_BAR, (ev: IpcMainEvent, { progress }) => {
-    if (_isRunning && tray) {
+    // Exactly one writer may own the tray icon per tick, otherwise the menu bar
+    // icon visibly blinks (#9944): the focus overlay owns it while it is shown
+    // (session progress), CURRENT_TASK_UPDATED owns it otherwise (task
+    // progress). Both fired every second before, so the icon flipped between
+    // the progress ring and the plain running icon twice per second.
+    if (_isRunning && tray && _lastIsFocusModeEnabled) {
       setTrayIcon(tray, getRunningIconPath(progress));
     }
 

--- a/src/app/features/focus-mode/store/focus-mode.effects.ts
+++ b/src/app/features/focus-mode/store/focus-mode.effects.ts
@@ -874,15 +874,9 @@ export class FocusModeEffects {
           // Throttle to prevent excessive IPC calls (timer ticks every 1s)
           // Use leading + trailing to ensure immediate feedback and final state
           throttleTime(500, undefined, { leading: true, trailing: true }),
-          withLatestFrom(
-            this.store.select(selectors.selectProgress),
-            this.store.select(selectors.selectIsRunning),
-          ),
-          tap(([_action, progress, isRunning]) => {
-            window.ea.setProgressBar({
-              progress: progress / 100,
-              progressBarMode: isRunning ? 'normal' : 'pause',
-            });
+          withLatestFrom(this.store.select(selectors.selectOsProgressBar)),
+          tap(([_action, osProgressBar]) => {
+            window.ea.setProgressBar(osProgressBar);
           }),
         ),
       { dispatch: false },

--- a/src/app/features/focus-mode/store/focus-mode.selectors.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.selectors.spec.ts
@@ -474,4 +474,27 @@ describe('FocusModeSelectors', () => {
       expect(result).toBe(false);
     });
   });
+
+  describe('selectOsProgressBar', () => {
+    it('should publish the session progress when a duration is set', () => {
+      const result = selectors.selectOsProgressBar.projector(50, true, 1500000);
+
+      expect(result).toEqual({ progress: 0.5, progressBarMode: 'normal' });
+    });
+
+    it('should publish pause mode when the session is not running', () => {
+      const result = selectors.selectOsProgressBar.projector(50, false, 1500000);
+
+      expect(result).toEqual({ progress: 0.5, progressBarMode: 'pause' });
+    });
+
+    // Flowtime has no target duration, so progress is always 0. Publishing it
+    // pinned the OS progress bar to empty and cycled against the task-progress
+    // writer in task-electron.effects (#9944, #3131).
+    it('should hide the bar for an open-ended (Flowtime) session', () => {
+      const result = selectors.selectOsProgressBar.projector(0, true, 0);
+
+      expect(result).toEqual({ progress: -1, progressBarMode: 'none' });
+    });
+  });
 });

--- a/src/app/features/focus-mode/store/focus-mode.selectors.ts
+++ b/src/app/features/focus-mode/store/focus-mode.selectors.ts
@@ -89,6 +89,30 @@ export const selectIsRunning = createSelector(
   (timer) => timer.isRunning && timer.purpose !== null,
 );
 
+/**
+ * What the running focus session should publish to the OS progress bar
+ * (taskbar/dock). Flowtime has no target duration, so `selectProgress` is
+ * always 0 there: publishing it would pin the bar to empty and cycle against
+ * the task-progress writer in `task-electron.effects` (#9944, #3131). Hide the
+ * bar instead - an open-ended session has no progress to show.
+ */
+export const selectOsProgressBar = createSelector(
+  selectProgress,
+  selectIsRunning,
+  selectTimeDuration,
+  (
+    progress,
+    isRunning,
+    duration,
+  ): { progress: number; progressBarMode: 'normal' | 'pause' | 'none' } =>
+    duration > 0
+      ? {
+          progress: progress / 100,
+          progressBarMode: isRunning ? 'normal' : 'pause',
+        }
+      : { progress: -1, progressBarMode: 'none' },
+);
+
 // Session completed selector
 export const selectIsSessionCompleted = createSelector(
   selectCurrentScreen,

--- a/src/app/features/tasks/store/task-electron.effects.ts
+++ b/src/app/features/tasks/store/task-electron.effects.ts
@@ -13,7 +13,10 @@ import {
 import { selectCurrentTask, selectTaskEntities } from './task.selectors';
 import { selectTodayTaskIds } from '../../work-context/store/work-context.selectors';
 import { GlobalConfigService } from '../../config/global-config.service';
-import { selectIsOverlayShown } from '../../focus-mode/store/focus-mode.selectors';
+import {
+  selectIsOverlayShown,
+  selectIsRunning as selectIsFocusTimerRunning,
+} from '../../focus-mode/store/focus-mode.selectors';
 import { TimeTrackingActions } from '../../time-tracking/store/time-tracking.actions';
 import { FocusModeService } from '../../focus-mode/focus-mode.service';
 import {
@@ -184,8 +187,11 @@ export class TaskElectronEffects {
         // collapses 1 IPC/sec into ~1 IPC/3s. Leading+trailing keeps the first
         // tick after start instant and the final value at the end of a window.
         throttleTime(3000, undefined, { leading: true, trailing: true }),
-        withLatestFrom(this._store$.select(selectIsOverlayShown)),
-        // Don't show progress bar when focus session is running
+        withLatestFrom(this._store$.select(selectIsFocusTimerRunning)),
+        // A running focus session owns the OS progress bar (it publishes its own
+        // session progress). Gating on the overlay being *shown* instead left
+        // both writers active whenever the overlay was hidden, so the bar and
+        // the tray icon cycled between the two values every second (#9944, #3131).
         filter(([a, isFocusSessionRunning]) => !isFocusSessionRunning),
         tap(([{ task }]) => {
           const progress = task.timeSpent / task.timeEstimate;


### PR DESCRIPTION
Fixes #9944. Same root cause as #3131 (dock-bar variant, stale-bot-closed and never fixed) — worth reopening/linking.

## The bug

The tray icon had **two writers per tick**:

- `CURRENT_TASK_UPDATED` set it from **task** progress, gated on the focus overlay being hidden.
- `SET_PROGRESS_BAR` set it from **focus-session** progress, gated on nothing.

In Flowtime the session has no target duration, so `selectProgress` is always `0` and the second writer resolved to the plain `running-l.png`. Both fired every second, so the menu bar icon flipped between the progress ring and the plain icon twice per second — the reported blink.

The same race cycled the dock/taskbar progress bar: focus mode published `0` every second while task tracking published the real ratio every 3s. The task-side filter was already *named* `isFocusSessionRunning` but actually read `selectIsOverlayShown`, so both writers stayed active whenever the overlay was hidden. That mismatch is the root cause of both symptoms.

Preconditions (why not everyone sees it): focus overlay hidden — the normal Flowtime working state — and the current task has a `timeEstimate`. Linux is immune because `getRunningIconPath` ignores progress there (#4905); Windows should show it too.

## The fix

One owner per surface:

| Surface | Owner |
| --- | --- |
| Tray icon, overlay shown | `SET_PROGRESS_BAR` (session progress) |
| Tray icon, overlay hidden | `CURRENT_TASK_UPDATED` (task progress) |
| OS progress bar, session running | focus-mode effect |
| OS progress bar, no session | task effect |

The two owners are exact complements: the `tick` that drives the focus-mode writer is itself gated on `selectIsRunning` (`focus-mode.service.ts:72`), the same selector the task writer now stands down on — so there is no window where nobody writes.

New `selectOsProgressBar` publishes `progressBarMode: 'none'` for a session with no target duration instead of a meaningless `0`.

## Behavior change

During a Flowtime session the dock/taskbar progress bar is now **hidden** rather than showing a flickering/empty bar — an open-ended session has no progress to show. The tray icon still shows the task-estimate ring.

## Testing

- `electron/indicator.test.cjs`: 3 simulated Flowtime seconds must produce exactly one icon write. Confirmed it fails without the gate and passes with it. Plus a companion test that the overlay still owns the icon when shown, so the gate can't be "fixed" by deleting the write.
- `focus-mode.selectors.spec.ts`: 3 cases for `selectOsProgressBar` incl. the Flowtime branch.
- `npm test` 15054/15054, `npm run test:electron` 301/301, `tsc --noEmit` clean, `checkFile` clean on all 5 files.

**Not verified:** no macOS available here, so there is no visual confirmation — the repro is a mock harness over the real `indicator.ts`, not a real `Tray`. I also inferred the overlay-hidden precondition rather than observing it; worth asking the reporter whether they mean the menu bar or the dock, and whether the overlay is open when it blinks.

https://claude.ai/code/session_01GyTGL79e4cRB3wsQfE55ws