### PR TITLE
fix(tasks): keep long task titles reachable while editing (#9641)

### DIFF
--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.scss
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.scss
@@ -41,10 +41,6 @@ progress-bar {
   margin: var(--s);
   border-bottom: 2px solid var(--c-primary) !important;
 
-  ::ng-deep textarea {
-    font-weight: 600 !important;
-  }
-
   task-title {
     padding-top: var(--s-half);
     padding-bottom: var(--s-half);

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.spec.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.spec.ts
@@ -323,6 +323,63 @@ describe('TaskDetailPanelComponent', () => {
       expect(component.showScheduleIcon()).toBe('today');
     });
   });
+
+  describe('title editor sizing (#9641)', () => {
+    // task-title sizes its edit box from an invisible .height-measure span and
+    // overlays an absolutely positioned, overflow:hidden textarea on it. If the
+    // panel styles the textarea differently from the measurer, the text wraps
+    // to more lines than the box is tall, and because focusing moves the caret
+    // to the end the textarea scrolls down — hiding the start of a long title
+    // with no way to scroll back.
+    const LONG_TITLE =
+      'Test1 Test2 Test3 Test4 Test Test Test Test Test Test Test Test Test Test Test Test';
+
+    const startEditingTitle = (): { textarea: HTMLElement; measurer: HTMLElement } => {
+      const titleEl = fixture.nativeElement.querySelector('task-title') as HTMLElement;
+      titleEl.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      fixture.detectChanges();
+
+      const textarea = titleEl.querySelector('textarea') as HTMLElement | null;
+      const measurer = titleEl.querySelector('.height-measure') as HTMLElement | null;
+      expect(textarea).toBeTruthy();
+      expect(measurer).toBeTruthy();
+      return { textarea: textarea as HTMLElement, measurer: measurer as HTMLElement };
+    };
+
+    beforeEach(() => {
+      componentRef.setInput('task', { ...MOCK_TASK, title: LONG_TITLE });
+      // Phone-width viewport: a long title has to wrap for the bug to show.
+      fixture.nativeElement.style.width = '360px';
+      fixture.detectChanges();
+    });
+
+    it('renders the title textarea with the same text metrics as its measurer', () => {
+      const { textarea, measurer } = startEditingTitle();
+
+      expect(getComputedStyle(textarea).fontWeight).toBe(
+        getComputedStyle(measurer).fontWeight,
+      );
+    });
+
+    it('does not clip the title textarea below its own content height', () => {
+      const words = LONG_TITLE.split(' ');
+      const clipped: string[] = [];
+
+      for (let wordCount = 4; wordCount <= words.length; wordCount++) {
+        const title = words.slice(0, wordCount).join(' ');
+        componentRef.setInput('task', { ...MOCK_TASK, title });
+        fixture.detectChanges();
+        const { textarea } = startEditingTitle();
+        if (textarea.scrollHeight > textarea.clientHeight) {
+          clipped.push(
+            `${title} (${textarea.scrollHeight}px content in ${textarea.clientHeight}px box)`,
+          );
+        }
+      }
+
+      expect(clipped).toEqual([]);
+    });
+  });
 });
 
 const fakeTask = (id: string): TaskWithSubTasks =>

--- a/src/app/ui/task-title/task-title.component.scss
+++ b/src/app/ui/task-title/task-title.component.scss
@@ -98,7 +98,10 @@
   cursor: text;
   position: absolute;
   inset: 0;
-  font-weight: 500;
+  // Inherited, never hardcoded: .height-measure sizes the box this textarea is
+  // clipped to, so any metric that differs between the two shifts where lines
+  // wrap and hides text the caret can no longer reach (#9641).
+  font-weight: inherit;
   font-size: inherit;
   letter-spacing: inherit;
   font-family: var(--font-primary-stack);
@@ -135,7 +138,7 @@
   visibility: hidden;
   pointer-events: none;
   display: block;
-  font-weight: 500;
+  font-weight: inherit;
   font-size: inherit;
   letter-spacing: inherit;
   font-family: var(--font-primary-stack);

--- a/src/app/ui/task-title/task-title.component.spec.ts
+++ b/src/app/ui/task-title/task-title.component.spec.ts
@@ -213,6 +213,56 @@ describe('TaskTitleComponent', () => {
     });
   });
 
+  describe('edit box measurement (#9641)', () => {
+    // The invisible .height-measure span is what gives the wrapper its height
+    // while editing, and the textarea is absolutely positioned into that box
+    // with overflow:hidden. Any text metric that differs between the two layers
+    // (or between the display text and the editor) changes where lines wrap, so
+    // the textarea ends up taller than the box it is clipped to and the first
+    // line scrolls out of reach once the caret jumps to the end.
+    const TEXT_METRIC_PROPS = [
+      'fontWeight',
+      'fontSize',
+      'fontFamily',
+      'fontStyle',
+      'letterSpacing',
+      'wordSpacing',
+      'lineHeight',
+      'textTransform',
+      'overflowWrap',
+    ] as const;
+
+    const textMetricsOf = (el: HTMLElement): Record<string, string> => {
+      const computed = getComputedStyle(el);
+      const metrics: Record<string, string> = {};
+      TEXT_METRIC_PROPS.forEach((prop) => (metrics[prop] = computed[prop]));
+      return metrics;
+    };
+
+    const queryEl = (selector: string): HTMLElement => {
+      const el = fixture.nativeElement.querySelector(selector) as HTMLElement | null;
+      expect(el).withContext(selector).toBeTruthy();
+      return el as HTMLElement;
+    };
+
+    it('renders display text, measurer and textarea with identical text metrics', () => {
+      // Consumers set the weight on the host (the task detail panel uses bold);
+      // all three layers must follow it, or the box size and the rendered text
+      // disagree.
+      fixture.nativeElement.style.fontWeight = '700';
+      component.tmpValue.set('Test1 Test2 Test3 Test4 Test Test Test Test Test');
+      fixture.detectChanges();
+
+      const displayMetrics = textMetricsOf(queryEl('.display-value'));
+
+      component.focusInput();
+      fixture.detectChanges();
+
+      expect(textMetricsOf(queryEl('.height-measure'))).toEqual(displayMetrics);
+      expect(textMetricsOf(queryEl('textarea'))).toEqual(displayMetrics);
+    });
+  });
+
   describe('handleKeyDown trigger routing', () => {
     const buildKey = (key: string, opts: KeyboardEventInit = {}): KeyboardEvent =>
       new KeyboardEvent('keydown', { key, ...opts });


### PR DESCRIPTION
Fixes #9641.

## The bug

`task-title` stacks three layers: the rendered title, an invisible `.height-measure` span that gives the wrapper its height while editing, and a textarea absolutely positioned into that box with `overflow: hidden`. All three have to render with identical text metrics or the box and the text disagree about where lines wrap.

They didn't. In the task detail panel:

| layer | weight |
| --- | --- |
| rendered title | `bold` (700, from the host) |
| `.height-measure` | `500` (hardcoded) |
| textarea | `600` (forced by the panel via `::ng-deep … !important`) |

Roboto ships no SemiBold face, so on Android CSS weight matching promotes 600 to Bold — measured identical advance widths for 600 and 700 (263.31px vs 252.58px at 500), a 4.2% difference. At the panel's real phone geometry (282px content, 15px) that is enough to wrap a long title onto one more line than the box is tall.

The overflowing line is always the first one, which is what made the title unreachable: focusing moves the caret to the end, the textarea scrolls to the bottom, and with `overflow: hidden` there is no scrollbar and no way back.

Whether a given title trips it depends on where the extra 4.2% lands relative to a wrap boundary — which is why it reproduced reliably for the reporter and not at all for others. Nothing here depends on the keyboard or the viewport; tapping into the field is the trigger, so it reproduces on desktop too at the right width.

## The fix

Let all three layers inherit the weight from the host, as they already do for `font-size`, and drop the panel's `::ng-deep` override (which the styling guide forbids anyway).

Side effects, all of them the editor matching the text it overlays: detail panel editing 600 → 700, task rows and focus mode 500 → inherited. The display→edit weight jump on tap is gone too.

## Tests

Written first, both observed failing on the old CSS:

- `task-detail-panel.component.spec.ts` — sweeps title lengths at phone width and asserts no title needs more content height than its box. Before the fix the reporter's own title reports `45px content in 23px box`. A length sweep rather than one fixed string because wrap boundaries are font-dependent: under real Roboto the 8-word title clips at a different width than under the CI fallback font, so a single hardcoded case can pass vacuously.
- `task-title.component.spec.ts` — asserts display text, measurer and textarea resolve to identical text metrics when the host sets a weight.

Full unit suite green (15054).

Not visually verified in a running app — `ng serve` could not hold a listening socket in my sandbox. Worth an eyeball on the detail panel, a task row and focus mode while editing before merge.

https://claude.ai/code/session_01CsrzL4PSn9imn5m6gcUDhd