### PR TITLE
fix: resolve 12 findings from the 7-day change review

### DIFF
--- a/android/app/src/main/java/com/superproductivity/superproductivity/webview/NativeInsetShimGate.kt
+++ b/android/app/src/main/java/com/superproductivity/superproductivity/webview/NativeInsetShimGate.kt
@@ -66,6 +66,16 @@ object NativeInsetShimGate {
      * there would switch the shim off as well and leave the device with no inset
      * owner: the #9316 symptom on a perfectly current WebView. Anything but the
      * current-package reading degrades to `null`, which runs the shim.
+     *
+     * KNOWN GAP (unobserved, so deliberately not guarded): "the current-package
+     * reading" is the package, not necessarily its `versionName`. `evaluate()`
+     * falls back to `parseMajorVersion(longVersionCode)` — the first three
+     * digits of the version code — when `versionName` does not parse, and that
+     * number can read >= 140 for an older WebView (124 -> 624). `SystemBars`
+     * reads `versionName` and would see 0 there, so the two would disagree and
+     * leave no inset owner. No device with an unparseable WebView `versionName`
+     * has been reported; if one ever is, make this require a `versionName`-
+     * derived major rather than widening the fallback.
      */
     fun activeProviderMajor(result: WebViewCompatibilityChecker.Result?): Int? =
         result?.takeIf { it.providerPackageIsCurrent }?.majorVersion

--- a/e2e/tests/task-multi-select/multi-select-desktop.spec.ts
+++ b/e2e/tests/task-multi-select/multi-select-desktop.spec.ts
@@ -10,6 +10,29 @@ const BAR = 'task-multi-select-bar .bar';
 const DONE_TASKS = '.task-list-inner[data-id="DONE"] > task.isDone';
 
 test.describe('Task multi-select (desktop)', () => {
+  // The checkbox is its own click target, so it needs its own opt-in
+  // (`done-toggle [isMultiSelectAware]`). Without it a modifier click there
+  // completes the task instead of selecting it, and nothing else notices:
+  // every other case in this file clicks the row's title area.
+  test('Ctrl+click on the done toggle selects the task instead of completing it', async ({
+    page,
+    workViewPage,
+    taskPage,
+    testPrefix,
+  }) => {
+    await workViewPage.waitForTaskList();
+    const title = `${testPrefix}-Toggle Select`;
+    await workViewPage.addTask(title);
+    const task = taskPage.getTaskByText(title);
+    const bar = page.locator(BAR);
+
+    await task.locator('done-toggle').click({ modifiers: ['Control'] });
+
+    await expect(bar).toContainText('1 selected');
+    await expect(task).toHaveClass(/isMultiSelected/);
+    await expect(task).not.toHaveClass(/isDone/);
+  });
+
   test('Ctrl+click and Shift+click build a selection that D completes at once', async ({
     page,
     workViewPage,

--- a/packages/sync-core/src/conflict-resolution.ts
+++ b/packages/sync-core/src/conflict-resolution.ts
@@ -223,6 +223,20 @@ const deepEqualInner = (
   if (typeof a !== typeof b) return false;
 
   if (typeof a === 'object') {
+    // `seen` tracks the objects on the CURRENT path, not everything visited, so
+    // it must be unwound on the way back up. A shared sub-object referenced
+    // twice (a DAG, not a cycle) is legitimate — `structuredClone` preserves
+    // aliasing and module-level defaults are routinely aliased — and leaving it
+    // in `seen` made the second visit bail as "circular", so two structurally
+    // identical values compared unequal. A real cycle revisits an ANCESTOR,
+    // which is still on the path, so it is still caught.
+    //
+    // shortcut: unwinding also drops the incidental memoisation, so a heavily
+    // aliased DAG is re-walked per reference (measured: fan-out 6 x depth 8 =
+    // 1.7M visits, ~530ms). No caller is anywhere near that — payloads arrive
+    // as JSON (pure trees, no aliasing) and the aliased inputs are small
+    // module-level config defaults — so this stays unguarded. If one ever is,
+    // add a proven-equal pair cache rather than reverting to a visited set.
     if (seen.has(a as object) || seen.has(b as object)) {
       logger.warn('sync-core.deepEqual detected circular reference, returning false');
       return false;
@@ -230,27 +244,32 @@ const deepEqualInner = (
     seen.add(a as object);
     seen.add(b as object);
 
-    if (Array.isArray(a) && Array.isArray(b)) {
-      if (a.length !== b.length) return false;
-      return a.every((val, i) =>
-        deepEqualInner(val, b[i], logger, maxDepth, seen, depth + 1),
+    try {
+      if (Array.isArray(a) && Array.isArray(b)) {
+        if (a.length !== b.length) return false;
+        return a.every((val, i) =>
+          deepEqualInner(val, b[i], logger, maxDepth, seen, depth + 1),
+        );
+      }
+
+      if (Array.isArray(a) !== Array.isArray(b)) return false;
+
+      const aRecord = a as Record<string, unknown>;
+      const bRecord = b as Record<string, unknown>;
+      const aKeys = Object.keys(aRecord);
+      const bKeys = Object.keys(bRecord);
+      if (aKeys.length !== bKeys.length) return false;
+      if (!aKeys.every((key) => Object.prototype.hasOwnProperty.call(bRecord, key))) {
+        return false;
+      }
+
+      return aKeys.every((key) =>
+        deepEqualInner(aRecord[key], bRecord[key], logger, maxDepth, seen, depth + 1),
       );
+    } finally {
+      seen.delete(a as object);
+      seen.delete(b as object);
     }
-
-    if (Array.isArray(a) !== Array.isArray(b)) return false;
-
-    const aRecord = a as Record<string, unknown>;
-    const bRecord = b as Record<string, unknown>;
-    const aKeys = Object.keys(aRecord);
-    const bKeys = Object.keys(bRecord);
-    if (aKeys.length !== bKeys.length) return false;
-    if (!aKeys.every((key) => Object.prototype.hasOwnProperty.call(bRecord, key))) {
-      return false;
-    }
-
-    return aKeys.every((key) =>
-      deepEqualInner(aRecord[key], bRecord[key], logger, maxDepth, seen, depth + 1),
-    );
   }
 
   return false;

--- a/packages/sync-core/tests/conflict-resolution.spec.ts
+++ b/packages/sync-core/tests/conflict-resolution.spec.ts
@@ -90,27 +90,14 @@ describe('deepEqual', () => {
   });
 
   /**
-   * DOCUMENTS CURRENT BEHAVIOUR — passes on master.
-   *
-   * `seen` is one WeakSet shared across the whole traversal, never unwound,
-   * and every visited object is added from BOTH sides. A DAG — the same object
-   * referenced twice, which is not a cycle — therefore trips the
-   * circular-reference bail on its second visit, and two structurally
-   * identical values compare unequal.
-   *
-   * Because `seen` is fed from both sides, aliasing on EITHER side is enough:
-   * a value with no sharing at all still compares unequal to an aliased one
-   * of the same shape. See `hasServerMigrationStateData` in
-   * src/app/op-log/sync/server-migration.service.ts, which compares live state
-   * against aliased module-level defaults.
-   *
-   * A true cycle must keep returning false — that contract is pinned by the
-   * spec above, and any fix here has to preserve it.
-   *
-   * When deepEqual is fixed, DELETE this spec rather than flipping its
-   * assertions: the `false` below is the bug, not the contract.
+   * A DAG — the same object referenced twice — is not a cycle. `structuredClone`
+   * preserves aliasing and module-level defaults are routinely aliased (see
+   * `hasServerMigrationStateData`, which compares live state against
+   * `MODEL_CONFIGS[key].defaultData`), so treating one as circular made
+   * structurally identical values compare unequal and minted a full-state
+   * SYNC_IMPORT that had no reason to exist.
    */
-  it('known defect (delete when deepEqual is fixed): returns false for a shared (non-circular) sub-object referenced twice', () => {
+  it('compares a shared (non-circular) sub-object referenced twice as equal', () => {
     const logger = createLogger();
     const shared = { weekDays: { mon: true, sat: false } };
     const a = { first: { cfg: shared }, second: { cfg: shared } };
@@ -120,24 +107,35 @@ describe('deepEqual', () => {
     // shape AND in sharing.
     expect(b.first.cfg).toBe(b.second.cfg);
 
-    expect(deepEqual(a, b, { logger })).toBe(false);
-    // Pin the mechanism, not just the outcome: this is the circular-reference
-    // bail firing on a DAG, not a depth or key-count mismatch.
-    expect(logger.warn).toHaveBeenCalledWith(
-      'sync-core.deepEqual detected circular reference, returning false',
-    );
+    expect(deepEqual(a, b, { logger })).toBe(true);
+    expect(logger.warn).not.toHaveBeenCalled();
 
-    // Breaking the aliasing on both sides makes the same values compare equal.
     const unaliased = {
       first: { cfg: { weekDays: { mon: true, sat: false } } },
       second: { cfg: { weekDays: { mon: true, sat: false } } },
     };
     expect(deepEqual(unaliased, structuredClone(unaliased))).toBe(true);
 
-    // ...but breaking it on ONE side only is not enough, because `seen` takes
-    // objects from both. This is why a JSON-sourced state (no aliasing) still
-    // compares unequal to an aliased default.
-    expect(deepEqual(unaliased, a)).toBe(false);
+    // Aliasing on ONE side only must not change the answer either: a
+    // JSON-sourced state carries no aliasing and is compared against defaults
+    // that do.
+    expect(deepEqual(unaliased, a)).toBe(true);
+    expect(deepEqual(a, unaliased)).toBe(true);
+  });
+
+  it('still detects a cycle reached through a shared sub-object', () => {
+    const logger = createLogger();
+    const makeCyclicViaDag = (): Record<string, unknown> => {
+      const shared: Record<string, unknown> = { value: 1 };
+      const root: Record<string, unknown> = { first: shared, second: shared };
+      shared['root'] = root;
+      return root;
+    };
+
+    expect(deepEqual(makeCyclicViaDag(), makeCyclicViaDag(), { logger })).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'sync-core.deepEqual detected circular reference, returning false',
+    );
   });
 
   it('returns false and logs when max depth is exceeded', () => {

--- a/src/app/features/planner/planner-task/planner-task.component.spec.ts
+++ b/src/app/features/planner/planner-task/planner-task.component.spec.ts
@@ -5,6 +5,7 @@ import { of } from 'rxjs';
 import { PlannerTaskComponent } from './planner-task.component';
 import { TaskService } from '../../tasks/task.service';
 import { DEFAULT_TASK, TaskCopy } from '../../tasks/task.model';
+import { DoneToggleComponent } from '../../../ui/done-toggle/done-toggle.component';
 import { MsToStringPipe } from '../../../ui/duration/ms-to-string.pipe';
 import { RenderLinksPipe } from '../../../ui/pipes/render-links.pipe';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -20,6 +21,7 @@ const makeTask = (overrides: Partial<TaskCopy> = {}): TaskCopy =>
 
 describe('PlannerTaskComponent', () => {
   let currentTaskId: WritableSignal<string | null>;
+  let taskServiceMock: { toggleDoneWithAnimation: jasmine.Spy };
 
   const create = (
     task: TaskCopy,
@@ -35,7 +37,7 @@ describe('PlannerTaskComponent', () => {
 
   beforeEach(() => {
     currentTaskId = signal<string | null>(null);
-    const taskServiceMock = {
+    taskServiceMock = {
       ...jasmine.createSpyObj('TaskService', [
         'setSelectedId',
         'toggleDoneWithAnimation',
@@ -57,7 +59,10 @@ describe('PlannerTaskComponent', () => {
     // (ignored via NO_ERRORS_SCHEMA); the pipes used in the template are kept.
     TestBed.overrideComponent(PlannerTaskComponent, {
       set: {
-        imports: [MsToStringPipe, RenderLinksPipe, TranslatePipe],
+        // `done-toggle` stays REAL: the planner's modifier-click behaviour is a
+        // property of how this template configures that shared component, so
+        // stubbing it would test nothing (see the spec at the bottom).
+        imports: [DoneToggleComponent, MsToStringPipe, RenderLinksPipe, TranslatePipe],
         schemas: [NO_ERRORS_SCHEMA],
       },
     });
@@ -122,5 +127,38 @@ describe('PlannerTaskComponent', () => {
       const { fixture } = create(makeTask({ isDone: false }));
       expect(fixture.debugElement.nativeElement.classList.contains('isDone')).toBe(false);
     });
+  });
+
+  describe('done toggle (#9929 fallout)', () => {
+    /**
+     * The Planner has no multi-select, so its `done-toggle` must NOT opt into
+     * the multi-select bail — a Ctrl/Cmd/Shift click here has to keep marking
+     * the task done. Adding `[isMultiSelectAware]="true"` to this template (as
+     * `task.component.html` correctly does) would swallow the toggle AND let
+     * the click bubble to the planner row, which opens the detail panel.
+     */
+    const clickToggle = (task: TaskCopy, init: MouseEventInit): void => {
+      const { fixture } = create(task);
+      const toggle = fixture.nativeElement.querySelector('done-toggle') as HTMLElement;
+      toggle.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true, ...init }),
+      );
+    };
+
+    it('marks the task done on a plain click', () => {
+      clickToggle(makeTask({ isDone: false }), {});
+      expect(taskServiceMock.toggleDoneWithAnimation).toHaveBeenCalled();
+    });
+
+    for (const [name, init] of [
+      ['ctrl', { ctrlKey: true }],
+      ['meta', { metaKey: true }],
+      ['shift', { shiftKey: true }],
+    ] as const) {
+      it(`still marks the task done on a ${name}+click`, () => {
+        clickToggle(makeTask({ isDone: false }), init);
+        expect(taskServiceMock.toggleDoneWithAnimation).toHaveBeenCalled();
+      });
+    }
   });
 });

--- a/src/app/features/tasks/task-bulk-action.service.spec.ts
+++ b/src/app/features/tasks/task-bulk-action.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { computed, Signal, signal } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { MatDialog } from '@angular/material/dialog';
-import { of } from 'rxjs';
+import { defer, Observable, of } from 'rxjs';
 import { TaskBulkActionService } from './task-bulk-action.service';
 import { TaskService } from './task.service';
 import { TaskMultiSelectService } from './task-multi-select.service';
@@ -27,6 +27,11 @@ describe('TaskBulkActionService', () => {
   let matDialog: { open: jasmine.Spy };
   let snackService: { open: jasmine.Spy };
   let moveToProjectService: { moveToProject: jasmine.Spy };
+  let projectService: {
+    getByIdOnce$: () => Observable<{ id: string; title: string }>;
+    moveTaskToBacklog: jasmine.Spy;
+    moveTaskToTodayList: jasmine.Spy;
+  };
   let entities: ReturnType<typeof signal<Record<string, Task>>>;
   let selectedIds: ReturnType<typeof signal<ReadonlySet<string>>>;
   let multiSelect: {
@@ -41,6 +46,7 @@ describe('TaskBulkActionService', () => {
   };
   let dialogResult: unknown;
   let isConfirmBeforeDelete: boolean;
+  let isEnableBacklog: boolean;
 
   const t = (id: string, overrides: Partial<Task> = {}): Task => ({
     ...DEFAULT_TASK,
@@ -66,6 +72,7 @@ describe('TaskBulkActionService', () => {
     selectedIds = signal<ReadonlySet<string>>(new Set());
     dialogResult = true;
     isConfirmBeforeDelete = true;
+    isEnableBacklog = true;
 
     taskService = jasmine.createSpyObj<TaskService>('TaskService', [
       'setDone',
@@ -94,6 +101,11 @@ describe('TaskBulkActionService', () => {
         .and.callFake(() => ({ afterClosed: () => of(dialogResult) })),
     };
     snackService = { open: jasmine.createSpy('open') };
+    projectService = {
+      getByIdOnce$: () => of({ id: 'p2', title: 'Project 2' }),
+      moveTaskToBacklog: jasmine.createSpy('moveTaskToBacklog'),
+      moveTaskToTodayList: jasmine.createSpy('moveTaskToTodayList'),
+    };
     moveToProjectService = {
       moveToProject: jasmine.createSpy('moveToProject').and.resolveTo(true),
     };
@@ -124,11 +136,7 @@ describe('TaskBulkActionService', () => {
         { provide: TaskMoveToProjectService, useValue: moveToProjectService },
         {
           provide: ProjectService,
-          useValue: {
-            getByIdOnce$: () => of({ id: 'p2', title: 'Project 2' }),
-            moveTaskToBacklog: jasmine.createSpy('moveTaskToBacklog'),
-            moveTaskToTodayList: jasmine.createSpy('moveTaskToTodayList'),
-          },
+          useValue: projectService,
         },
         { provide: MatDialog, useValue: matDialog },
         { provide: SnackService, useValue: snackService },
@@ -150,7 +158,13 @@ describe('TaskBulkActionService', () => {
             }),
           },
         },
-        { provide: WorkContextService, useValue: { flatDoneTodayNr$: of(0) } },
+        {
+          provide: WorkContextService,
+          useValue: {
+            flatDoneTodayNr$: of(0),
+            activeWorkContext$: defer(() => of({ isEnableBacklog })),
+          },
+        },
         { provide: TranslateService, useValue: { currentLang: 'en', defaultLang: 'en' } },
         { provide: TranslateStore, useValue: { getTranslations: () => ({}) } },
         { provide: LocaleDatePipe, useValue: { transform: () => 'DATE' } },
@@ -451,6 +465,23 @@ describe('TaskBulkActionService', () => {
     });
   });
 
+  describe('moveToBacklog in a context without a backlog', () => {
+    it('does nothing, like the single-task shortcut (#9374)', async () => {
+      // Today and tag views have no backlog of their own: the bar hides the
+      // button (isShowBacklogBtns) and the single-task shortcut bails on
+      // isEnableBacklog, but the bulk KEYBOARD path reached this unguarded and
+      // emitted one op per task against each task's own project - invisible in
+      // the view the user was looking at, and replicated to every device.
+      isEnableBacklog = false;
+      select([t('a'), t('b')]);
+
+      await service.moveToBacklog();
+
+      expect(projectService.moveTaskToBacklog).not.toHaveBeenCalled();
+      expect(snackService.open).not.toHaveBeenCalled();
+    });
+  });
+
   describe('scheduleFor', () => {
     it('plans day-only picks per task and routes today to the bulk action', async () => {
       select([
@@ -505,6 +536,28 @@ describe('TaskBulkActionService', () => {
         remindOption: null,
       });
       expect(taskService.scheduleTask).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('openDeadlineDialog', () => {
+    it("reports a removal when the dialog's Remove button closes with a null date", async () => {
+      // DialogDeadlineComponent.remove() closes with {date: null, ...}, which is
+      // a removal, not a set. Reporting DEADLINE_SET renders "Set the deadline
+      // of N tasks to " with an empty date, and counts tasks that had none.
+      select([t('a', { deadlineDay: '2026-09-10' }), t('b')]);
+      dialogResult = { date: null, time: null, remindOption: null };
+
+      await service.openDeadlineDialog();
+
+      expect(dispatchedTypes()).toEqual([TaskSharedActions.removeDeadline.type]);
+      const snackArg = snackService.open.calls.mostRecent().args[0] as {
+        msg: string;
+        translateParams: { count: number; date?: string };
+      };
+      expect(snackArg.msg).toContain('DEADLINE_REMOVED');
+      expect(snackArg.msg).not.toContain('DEADLINE_SET');
+      // Only the task that actually had a deadline is counted.
+      expect(snackArg.translateParams.count).toBe(1);
     });
   });
 

--- a/src/app/features/tasks/task-bulk-action.service.ts
+++ b/src/app/features/tasks/task-bulk-action.service.ts
@@ -472,14 +472,15 @@ export class TaskBulkActionService {
       return;
     }
     const pick = result as DateTimePick;
+    // The dialog's "Remove" button closes with `{date: null, …}`. That is a
+    // removal, not a set: it must report DEADLINE_REMOVED and count only the
+    // tasks that actually had a deadline, which is exactly `removeDeadline()`.
+    if (pick.date === null) {
+      await this.removeDeadline();
+      return;
+    }
     await this._runSuppressed(() => {
       tasks.forEach((task) => {
-        if (pick.date === null) {
-          if (task.deadlineDay || task.deadlineWithTime) {
-            this._store.dispatch(TaskSharedActions.removeDeadline({ taskId: task.id }));
-          }
-          return;
-        }
         if (pick.time && isValidSplitTime(pick.time)) {
           const deadlineWithTime = getDateTimeFromClockString(
             pick.time,
@@ -573,6 +574,18 @@ export class TaskBulkActionService {
   }
 
   private async _moveBetweenProjectLists(target: 'backlog' | 'regular'): Promise<void> {
+    // Gated on the ACTIVE context, like the single-task shortcut
+    // (task.component.ts, #9374) and the bulk bar's own isShowBacklogBtns().
+    // Today and tag views have no backlog, so the move is position-only against
+    // each task's OWN project: invisible where the user is looking, yet one
+    // synced op per task. The keyboard path is the only way to reach this once
+    // the bar hides the buttons, so the gate has to live here.
+    const { isEnableBacklog } = await firstValueFrom(
+      this._workContextService.activeWorkContext$,
+    );
+    if (!isEnableBacklog) {
+      return;
+    }
     const { eligible, skippedSubtasks } = splitParentOnly(this._resolveInVisualOrder());
     const tasks = eligible.filter((t) => !!t.projectId);
     if (!tasks.length) {

--- a/src/app/features/tasks/task/task.component.html
+++ b/src/app/features/tasks/task/task.component.html
@@ -29,6 +29,7 @@
         } @else {
           <done-toggle
             [isDone]="t.isDone"
+            [isMultiSelectAware]="true"
             [isCurrent]="isCurrent()"
             [showDoneAnimation]="showDoneAnimation()"
             [showUndoneAnimation]="showUndoneAnimation()"

--- a/src/app/op-log/backup/backup.service.ts
+++ b/src/app/op-log/backup/backup.service.ts
@@ -50,6 +50,14 @@ export class BackupService {
   private _store = inject(Store);
   private _stateSnapshotService = inject(StateSnapshotService);
   private _opLogStore = inject(OperationLogStoreService);
+
+  /**
+   * Ring entry that must survive the pre-restore capture, set only for the
+   * duration of `restoreImportBackupById`. Held here rather than threaded
+   * through `importCompleteBackup` -> `_persistImportToOperationLog`, which
+   * already carries six positional parameters.
+   */
+  private _protectedBackupId: string | null = null;
   private _operationWriteFlushService = inject(OperationWriteFlushService);
   private _lockService = inject(LockService);
   private _conflictJournalService = inject(ConflictJournalService);
@@ -290,8 +298,13 @@ export class BackupService {
     reason: ImportBackupReason,
     taskCount: number,
   ): Promise<ImportBackupRef> {
+    const meta = {
+      reason,
+      taskCount,
+      ...(this._protectedBackupId ? { protectBackupId: this._protectedBackupId } : {}),
+    };
     try {
-      return await this._opLogStore.saveImportBackup(state, { reason, taskCount });
+      return await this._opLogStore.saveImportBackup(state, meta);
     } catch (e) {
       if ((e as Error | undefined)?.name !== 'QuotaExceededError') {
         throw e;
@@ -300,7 +313,7 @@ export class BackupService {
         'BackupService: Recovery point hit storage quota; pruning ring and retrying',
       );
       await this._opLogStore.pruneImportBackups(1);
-      return this._opLogStore.saveImportBackup(state, { reason, taskCount });
+      return this._opLogStore.saveImportBackup(state, meta);
     }
   }
 
@@ -319,12 +332,22 @@ export class BackupService {
     if (!backup) {
       return false;
     }
-    await this.importCompleteBackup(
-      backup.state as AppDataComplete,
-      true, // isSkipLegacyWarnings
-      true, // isSkipReload - loadAllData updates state live
-      true, // isForceConflict
-    );
+    // The pre-restore capture below rotates the ring, and the entry being
+    // restored is the one that rotates out when it is the oldest non-guarded
+    // one. The eviction is committed immediately, so a failure further into the
+    // import (quota on the full-state write, IDB abort, app kill) would leave
+    // the user unable to retry the only snapshot holding their data.
+    this._protectedBackupId = backupId;
+    try {
+      await this.importCompleteBackup(
+        backup.state as AppDataComplete,
+        true, // isSkipLegacyWarnings
+        true, // isSkipReload - loadAllData updates state live
+        true, // isForceConflict
+      );
+    } finally {
+      this._protectedBackupId = null;
+    }
     return true;
   }
 

--- a/src/app/op-log/core/types/sync-results.types.ts
+++ b/src/app/op-log/core/types/sync-results.types.ts
@@ -266,6 +266,8 @@ export type DownloadResultForRejection =
  */
 export type DownloadCallback = (options?: {
   forceFromSeq0?: boolean;
+  /** See `isReDeliveryRetry` on `OperationLogDownloadService.downloadRemoteOps`. */
+  isReDeliveryRetry?: boolean;
   /** Local full-state boundaries to ignore while processing this recovery download. */
   ignoredLocalFullStateOpIds?: string[];
 }) => Promise<DownloadResultForRejection>;

--- a/src/app/op-log/persistence/import-backup-ring.util.spec.ts
+++ b/src/app/op-log/persistence/import-backup-ring.util.spec.ts
@@ -1,0 +1,78 @@
+import {
+  IMPORT_BACKUP_RING_SIZE,
+  ImportBackupReason,
+  listImportBackupsTx,
+  loadImportBackupByIdTx,
+  saveImportBackupTx,
+} from './import-backup-ring.util';
+import { OpLogTx } from './op-log-db-adapter';
+
+/** In-memory stand-in for the `import_backup` object store. */
+const createTx = (): OpLogTx & { rows: Map<string, unknown> } => {
+  const rows = new Map<string, unknown>();
+  const key = (store: string, id: string): string => `${store}::${id}`;
+  return {
+    rows,
+    get: async <T>(store: string, id: string): Promise<T | undefined> =>
+      rows.get(key(store, id)) as T | undefined,
+    put: async (store: string, value: { id: string }): Promise<void> => {
+      rows.set(key(store, value.id), value);
+    },
+    delete: async (store: string, id: string): Promise<void> => {
+      rows.delete(key(store, id));
+    },
+  } as unknown as OpLogTx & { rows: Map<string, unknown> };
+};
+
+describe('import backup ring', () => {
+  const save = (
+    tx: OpLogTx,
+    state: unknown,
+    reason: ImportBackupReason,
+    protectBackupId?: string,
+  ): Promise<{ backupId: string }> =>
+    saveImportBackupTx(tx, state, {
+      reason,
+      taskCount: 1,
+      ...(protectBackupId ? { protectBackupId } : {}),
+    });
+
+  it('keeps at most IMPORT_BACKUP_RING_SIZE snapshots', async () => {
+    const tx = createTx();
+    for (let i = 0; i < IMPORT_BACKUP_RING_SIZE + 2; i++) {
+      await save(tx, { i }, 'LOCAL_IMPORT');
+    }
+    expect((await listImportBackupsTx(tx)).length).toBe(IMPORT_BACKUP_RING_SIZE);
+  });
+
+  it('does not rotate out the entry currently being restored', async () => {
+    const tx = createTx();
+    // The oldest entry is the one holding the user's pre-loss data.
+    const oldest = await save(tx, { pre: 'loss' }, 'REMOTE_IMPORT');
+    for (let i = 0; i < IMPORT_BACKUP_RING_SIZE - 1; i++) {
+      await save(tx, { i }, 'REMOTE_IMPORT');
+    }
+    expect(await loadImportBackupByIdTx(tx, oldest.backupId)).not.toBeNull();
+
+    // Restoring it writes a pre-restore LOCAL_IMPORT capture into the same
+    // full ring. Without the protection that capture evicts — and physically
+    // deletes — the snapshot being restored, so a failure later in the import
+    // leaves nothing to retry.
+    await save(tx, { current: true }, 'LOCAL_IMPORT', oldest.backupId);
+
+    const kept = await listImportBackupsTx(tx);
+    expect(kept.map((e) => e.backupId)).toContain(oldest.backupId);
+    expect(await loadImportBackupByIdTx(tx, oldest.backupId)).not.toBeNull();
+    expect(kept.length).toBe(IMPORT_BACKUP_RING_SIZE);
+  });
+
+  it('still guards the newest pre-replacement capture from a plain restore', async () => {
+    const tx = createTx();
+    const remote = await save(tx, { remote: true }, 'REMOTE_IMPORT');
+    for (let i = 0; i < IMPORT_BACKUP_RING_SIZE; i++) {
+      await save(tx, { i }, 'LOCAL_IMPORT');
+    }
+    const kept = await listImportBackupsTx(tx);
+    expect(kept.map((e) => e.backupId)).toContain(remote.backupId);
+  });
+});

--- a/src/app/op-log/persistence/import-backup-ring.util.ts
+++ b/src/app/op-log/persistence/import-backup-ring.util.ts
@@ -35,6 +35,14 @@ export interface ImportBackupEntry extends ImportBackupRef {
 export interface ImportBackupCaptureMeta {
   reason?: ImportBackupReason;
   taskCount?: number;
+  /**
+   * Never rotate this entry out during THIS capture. Set while restoring it:
+   * the pre-restore snapshot is written before the restore is known to have
+   * succeeded, so without this a restore of the oldest entry deletes that
+   * entry, and a failure afterwards (quota, IDB abort, app kill) leaves the
+   * user with no way to retry the only snapshot holding their data.
+   */
+  protectBackupId?: string;
 }
 
 interface PointerRow {
@@ -60,20 +68,42 @@ const readRingMeta = async (tx: OpLogTx): Promise<ImportBackupMeta[]> => {
 };
 
 /**
- * Newest-first entries that survive a rotation to `size`. The newest
- * pre-replacement capture (REMOTE_IMPORT / FORCE_DOWNLOAD) survives when size > 0 so
- * restores cannot rotate the pre-loss snapshot out (#10003); the other slots go
- * to the newest remaining entries.
+ * Newest-first entries that survive a rotation to `size`.
+ *
+ * Two slots are privileged, then the rest go to the newest remaining entries:
+ * - `protectBackupId`, the entry currently being restored (see
+ *   {@link ImportBackupCaptureMeta.protectBackupId}).
+ * - the NEWEST pre-replacement capture (REMOTE_IMPORT / FORCE_DOWNLOAD), so a
+ *   restore's own LOCAL_IMPORT capture cannot rotate it out (#10003).
+ *
+ * Known gap: only the newest such capture is guarded, so a run of
+ * `IMPORT_BACKUP_RING_SIZE` further full-state ops still ages out an older
+ * pre-loss snapshot. Widening that is a ring-policy decision, not a bug fix.
  */
-const keepNewest = (entries: ImportBackupMeta[], size: number): ImportBackupMeta[] => {
+const keepNewest = (
+  entries: ImportBackupMeta[],
+  size: number,
+  protectBackupId?: string,
+): ImportBackupMeta[] => {
   if (size === 0) {
     return [];
   }
+  const privileged = new Set<ImportBackupMeta>();
+  const protectedEntry =
+    protectBackupId !== undefined
+      ? entries.find((e) => e.backupId === protectBackupId)
+      : undefined;
+  if (protectedEntry) {
+    privileged.add(protectedEntry);
+  }
   const guarded = entries.find((e) => e.reason !== 'LOCAL_IMPORT');
+  if (guarded) {
+    privileged.add(guarded);
+  }
   const others = entries
-    .filter((e) => e !== guarded)
-    .slice(0, Math.max(0, guarded ? size - 1 : size));
-  return entries.filter((e) => e === guarded || others.includes(e));
+    .filter((e) => !privileged.has(e))
+    .slice(0, Math.max(0, size - privileged.size));
+  return entries.filter((e) => privileged.has(e) || others.includes(e));
 };
 
 /**
@@ -94,7 +124,7 @@ export const saveImportBackupTx = async (
     taskCount: meta.taskCount ?? 0,
   };
   const entries = [entry, ...(await readRingMeta(tx))];
-  const kept = keepNewest(entries, IMPORT_BACKUP_RING_SIZE);
+  const kept = keepNewest(entries, IMPORT_BACKUP_RING_SIZE, meta.protectBackupId);
   for (const evicted of entries.filter((e) => !kept.includes(e))) {
     await tx.delete(STORE_NAMES.IMPORT_BACKUP, evicted.backupId);
   }

--- a/src/app/op-log/sync/operation-log-download.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-download.service.spec.ts
@@ -1446,6 +1446,7 @@ describe('OperationLogDownloadService', () => {
           it('should skip ops behind the cursor whose author counter the local clock covers, but keep their clocks', async () => {
             const result = await service.downloadRemoteOps(mockApiProvider, {
               forceFromSeq0: true,
+              isReDeliveryRetry: true,
             });
 
             expect(result.newOps.map((op) => op.id)).toEqual([
@@ -1460,10 +1461,26 @@ describe('OperationLogDownloadService', () => {
           it('should deliver everything in raw-rebuild mode (includeOwnAndAppliedOps)', async () => {
             const result = await service.downloadRemoteOps(mockApiProvider, {
               forceFromSeq0: true,
+              isReDeliveryRetry: true,
               includeOwnAndAppliedOps: true,
             });
 
             expect(result.newOps.length).toBe(6);
+          });
+
+          it('should deliver everything for a provider switch (forced, but not a re-delivery retry)', async () => {
+            // SyncWrapperService sets forceFromSeq0 on a provider SWITCH so the
+            // conflict gate can compare states. That cursor belongs to the
+            // provider being switched back to and the local clock was advanced
+            // by work done on the other provider, so filtering here would drop
+            // the server's history with no dialog and no merge, and this device
+            // would then upload its divergent state.
+            const result = await service.downloadRemoteOps(mockApiProvider, {
+              forceFromSeq0: true,
+            });
+
+            expect(result.newOps.length).toBe(6);
+            expect(mockOpLogStore.getVectorClock).not.toHaveBeenCalled();
           });
 
           it('should leave the normal (non-forced) download untouched', async () => {
@@ -1478,6 +1495,7 @@ describe('OperationLogDownloadService', () => {
 
             const result = await service.downloadRemoteOps(mockApiProvider, {
               forceFromSeq0: true,
+              isReDeliveryRetry: true,
             });
 
             expect(result.newOps.length).toBe(6);
@@ -1509,6 +1527,7 @@ describe('OperationLogDownloadService', () => {
 
             const result = await service.downloadRemoteOps(mockApiProvider, {
               forceFromSeq0: true,
+              isReDeliveryRetry: true,
             });
 
             expect(mockApiProvider.downloadOps).toHaveBeenCalledTimes(2);

--- a/src/app/op-log/sync/operation-log-download.service.ts
+++ b/src/app/op-log/sync/operation-log-download.service.ts
@@ -110,7 +110,11 @@ export class OperationLogDownloadService implements OnDestroy {
    */
   async downloadRemoteOps(
     syncProvider: OperationSyncCapable,
-    options?: { forceFromSeq0?: boolean; includeOwnAndAppliedOps?: boolean },
+    options?: {
+      forceFromSeq0?: boolean;
+      isReDeliveryRetry?: boolean;
+      includeOwnAndAppliedOps?: boolean;
+    },
   ): Promise<DownloadResult> {
     if (!syncProvider) {
       OpLog.warn(
@@ -124,7 +128,11 @@ export class OperationLogDownloadService implements OnDestroy {
 
   private async _downloadRemoteOpsViaApi(
     syncProvider: OperationSyncCapable,
-    options?: { forceFromSeq0?: boolean; includeOwnAndAppliedOps?: boolean },
+    options?: {
+      forceFromSeq0?: boolean;
+      isReDeliveryRetry?: boolean;
+      includeOwnAndAppliedOps?: boolean;
+    },
   ): Promise<DownloadResult> {
     const forceFromSeq0 = options?.forceFromSeq0 ?? false;
     OpLog.normal(
@@ -194,8 +202,15 @@ export class OperationLogDownloadService implements OnDestroy {
       // `<=` check is meaningless there — and the reproduced bug is
       // SuperSync-only anyway, so a future provider mode must opt in explicitly
       // rather than inherit a filter nobody reasoned about for it.
+      // Keyed on the CALLER'S intent, never on `forceFromSeq0` alone: that flag
+      // is also set for a provider switch (`SyncWrapperService`), whose whole
+      // point is a fresh state comparison that reaches the conflict gate. A
+      // switch back to a previously-used SuperSync account carries a non-zero
+      // cursor for that provider and a local clock inherited from the other
+      // one, so filtering there would silently drop the server's history, skip
+      // the dialog, and let this device upload its divergent state.
       const isReDeliveryFilterActive =
-        forceFromSeq0 &&
+        !!options?.isReDeliveryRetry &&
         !options?.includeOwnAndAppliedOps &&
         syncProvider.providerMode === 'superSyncOps';
       // Not const: a gap reset below switches to a new server epoch whose seq

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -512,6 +512,7 @@ export class OperationLogSyncService {
     // USE_REMOTE, CANCEL) — those paths return early above to avoid stale rejection handling.
     const downloadCallback = async (downloadOptions?: {
       forceFromSeq0?: boolean;
+      isReDeliveryRetry?: boolean;
       ignoredLocalFullStateOpIds?: string[];
     }): Promise<DownloadResultForRejection> => {
       const outcome = await this.downloadRemoteOps(syncProvider, {
@@ -617,6 +618,7 @@ export class OperationLogSyncService {
     syncProvider: OperationSyncCapable,
     options?: {
       forceFromSeq0?: boolean;
+      isReDeliveryRetry?: boolean;
       isNeverSynced?: boolean;
       ignoredLocalFullStateOpIds?: string[];
       /** Sync epoch captured at cycle start (#9074); fences local writes. */

--- a/src/app/op-log/sync/rejected-ops-handler.service.spec.ts
+++ b/src/app/op-log/sync/rejected-ops-handler.service.spec.ts
@@ -805,7 +805,10 @@ describe('RejectedOpsHandlerService', () => {
 
         // Should have called twice: normal then forced
         expect(downloadCallback).toHaveBeenCalledTimes(2);
-        expect(downloadCallback).toHaveBeenCalledWith({ forceFromSeq0: true });
+        expect(downloadCallback).toHaveBeenCalledWith({
+          forceFromSeq0: true,
+          isReDeliveryRetry: true,
+        });
       });
 
       it('should not resolve an op already retired by the forced download', async () => {

--- a/src/app/op-log/sync/rejected-ops-handler.service.ts
+++ b/src/app/op-log/sync/rejected-ops-handler.service.ts
@@ -477,7 +477,10 @@ export class RejectedOpsHandlerService {
               `concurrent ops still pending. Forcing full download from seq 0...`,
           );
 
-          const forceDownloadResult = await downloadCallback({ forceFromSeq0: true });
+          const forceDownloadResult = await downloadCallback({
+            forceFromSeq0: true,
+            isReDeliveryRetry: true,
+          });
           if (forceDownloadResult.kind === 'cancelled') {
             this._rollbackResolutionAttempts(opsToResolve);
             return { kind: 'cancelled' };

--- a/src/app/op-log/sync/remote-ops-processing.service.spec.ts
+++ b/src/app/op-log/sync/remote-ops-processing.service.spec.ts
@@ -2116,6 +2116,45 @@ describe('RemoteOpsProcessingService', () => {
       );
     });
 
+    it('should withdraw the causal repair base before validating a partial apply failure', async () => {
+      // A REPAIR minted after a partial apply failure must NOT claim the whole
+      // downloaded cursor: its snapshot only covers the ops that actually
+      // applied. A falsely causal REPAIR makes receivers drop their concurrent
+      // prefix ops outright (`SyncImportFilterService`, `isPrefixOp` +
+      // `repairBaseServerSeq !== undefined`) instead of replaying them after the
+      // repair boundary, deleting work that was never in the snapshot.
+      const repairSyncContext = TestBed.inject(RepairSyncContextService);
+      const remoteOps: Operation[] = [
+        createFullOp({ id: 'op-1' }),
+        createFullOp({ id: 'op-2' }),
+        createFullOp({ id: 'op-3' }),
+      ];
+
+      opLogStoreSpy.append.and.returnValue(Promise.resolve(1));
+      opLogStoreSpy.markApplied.and.returnValue(Promise.resolve());
+      opLogStoreSpy.markFailed.and.returnValue(Promise.resolve());
+      operationApplierServiceSpy.applyOperations.and.callFake(async (ops, options) => {
+        await options?.onReducersCommitted?.(ops);
+        return {
+          appliedOps: [remoteOps[0]],
+          failedOp: { op: remoteOps[1], error: new Error('Test error') },
+        };
+      });
+
+      let baseDuringValidation: number | undefined = -1;
+      validateStateServiceSpy.validateAndRepairCurrentState.and.callFake(async () => {
+        baseDuringValidation = repairSyncContext.baseServerSeq;
+        return true;
+      });
+
+      await repairSyncContext.runWithBaseServerSeq(150, async () => {
+        await expectAsync(service.applyNonConflictingOps(remoteOps)).toBeRejected();
+      });
+
+      expect(validateStateServiceSpy.validateAndRepairCurrentState).toHaveBeenCalled();
+      expect(baseDuringValidation).toBeUndefined();
+    });
+
     it('should preserve the incomplete-remote error when the deferred drain also fails', async () => {
       const remoteOps: Operation[] = [
         createFullOp({ id: 'op-1' }),

--- a/src/app/op-log/sync/remote-ops-processing.service.ts
+++ b/src/app/op-log/sync/remote-ops-processing.service.ts
@@ -671,6 +671,15 @@ export class RemoteOpsProcessingService {
           result.failedOp.error,
         );
 
+        // Same reasoning as the blocked-op withdrawal above: the cursor the
+        // caller supplied covers ops this client did NOT apply, so a REPAIR
+        // minted by the validation below must not claim it. A falsely causal
+        // REPAIR is auto-accepted by receivers, which then DROP their
+        // concurrent prefix ops (`SyncImportFilterService`, isPrefixOp +
+        // repairBaseServerSeq !== undefined) instead of replaying them after
+        // the repair boundary — deleting work the snapshot never contained.
+        this.repairSyncContext.dropBaseServerSeqForCurrentRun();
+
         await this._validateAndFlagSession(
           'partial-apply-failure',
           callerHoldsLock,

--- a/src/app/op-log/sync/server-migration.service.spec.ts
+++ b/src/app/op-log/sync/server-migration.service.spec.ts
@@ -1075,19 +1075,20 @@ describe('ServerMigrationService', () => {
         syncImportReason: 'FORCE_UPLOAD',
       });
 
-    it('known defect (delete when deepEqual is fixed): pins the DAG defect on the real simpleCounter default', () => {
+    it('compares the real (aliased) simpleCounter default equal to a clone of it', () => {
       const counters = initialSimpleCounterState.entities;
       // The aliasing: a shallow spread of EMPTY_SIMPLE_COUNTER shares these.
+      // deepEqual used to read the second visit to `streakWeekDays` as a
+      // circular reference, so a hydrated client's cloned slices never matched
+      // the module-level defaults and every FORCE_UPLOAD minted a SYNC_IMPORT.
       expect(counters['STANDING_DESK_ID']!.streakWeekDays).toBe(
         counters['COFFEE_COUNTER']!.streakWeekDays,
       );
 
-      // Reference identity short-circuits before `seen` is consulted...
       expect(deepEqual(initialSimpleCounterState, initialSimpleCounterState)).toBe(true);
-      // ...but a structurally identical copy does not.
       expect(
         deepEqual(structuredClone(initialSimpleCounterState), initialSimpleCounterState),
-      ).toBe(false);
+      ).toBe(true);
     });
 
     it('known defect (delete when the empty-state guard is fixed): proceeds for a fresh install whose only divergence is the sync config', async () => {
@@ -1125,17 +1126,17 @@ describe('ServerMigrationService', () => {
       expect(opLogStoreSpy.append).not.toHaveBeenCalled();
     });
 
-    it('known defect (delete when deepEqual is fixed): proceeds for a hydrated client with default config and no user data', async () => {
+    it('skips for a hydrated client with default config and no user data', async () => {
       // Isolates cause 2: every slice is a clone (as after any loadAllData) and
-      // globalConfig is at its default, so simpleCounter alone carries the guard.
+      // globalConfig is at its default, so simpleCounter alone carries the
+      // guard. With deepEqual reading aliased defaults correctly, the clone now
+      // matches and the empty-state guard skips instead of overwriting the
+      // server from a device holding nothing (#9256).
       stateSnapshotServiceSpy.getStateSnapshotAsync.and.resolveTo(snapshot());
 
       await forceUpload();
 
-      expect(opLogStoreSpy.append).toHaveBeenCalled();
-      expect(opLogStoreSpy.append.calls.mostRecent().args[0].opType).toBe(
-        OpType.SyncImport,
-      );
+      expect(opLogStoreSpy.append).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/op-log/sync/sync-local-state.service.spec.ts
+++ b/src/app/op-log/sync/sync-local-state.service.spec.ts
@@ -156,6 +156,24 @@ describe('SyncLocalStateService', () => {
       expect(opLogStoreSpy.getFirstOpEntry).not.toHaveBeenCalled();
     });
 
+    it('ignores a full-state op the processing loop will never reach (#8764)', async () => {
+      // The gate this defers to only inspects `takeInterpretableOpPrefix`, so a
+      // full-state op sitting BEHIND an uninterpretable op is invisible to it.
+      // Seeing it here too would leave neither side prompting, and a
+      // never-synced genesis client silently merges remote data over its own.
+      const futureVocabularyOp = {
+        ...regularOp.op,
+        id: 'future-vocabulary',
+        opType: 'FUTURE_OP' as unknown as OpType,
+      };
+      expect(
+        await service.isFreshOrNeverSyncedGenesisClient([
+          futureVocabularyOp,
+          syncImport.op,
+        ]),
+      ).toBe(true);
+    });
+
     it('is false for a client with ordinary history', async () => {
       opLogStoreSpy.getFirstOpEntry.and.resolveTo(regularOp);
       expect(await service.isFreshOrNeverSyncedGenesisClient([regularOp.op])).toBe(false);

--- a/src/app/op-log/sync/sync-local-state.service.ts
+++ b/src/app/op-log/sync/sync-local-state.service.ts
@@ -10,6 +10,7 @@ import {
   hasMeaningfulStateData,
 } from '../validation/has-meaningful-state-data.util';
 import { isExampleTaskCreateOp } from '../validation/is-example-task-op.util';
+import { takeInterpretableOpPrefix } from './remote-op-block.util';
 import {
   isFullStateOpType,
   isGenesisEntityType,
@@ -96,7 +97,14 @@ export class SyncLocalStateService {
     if (await this.isWhollyFreshClient()) {
       return true;
     }
-    if (incomingOps.some((op) => isFullStateOpType(op.opType))) {
+    // Must read the SAME prefix as the gate it defers to
+    // (`SyncImportConflictGateService.checkIncomingFullStateConflict`): a
+    // full-state op behind an uninterpretable one is never reached by
+    // `processRemoteOps`, so the gate does not prompt for it. Scanning the full
+    // batch here would leave neither side prompting (#8764).
+    if (
+      takeInterpretableOpPrefix(incomingOps).some((op) => isFullStateOpType(op.opType))
+    ) {
       return false;
     }
     return this.isNeverSyncedGenesisClient();

--- a/src/app/op-log/testing/integration/forced-download-pruned-import.integration.spec.ts
+++ b/src/app/op-log/testing/integration/forced-download-pruned-import.integration.spec.ts
@@ -57,10 +57,12 @@ import { CLIENT_ID_PROVIDER } from '../../util/client-id.provider';
  * 1. An installed client applies another device's SYNC_IMPORT plus follow-up ops.
  * 2. The 7-day retention window elapses; real compaction prunes them, so the
  *    applied-id filter no longer knows the import.
- * 3. A forced seq-0 download (concurrent-rejection retry, provider switch)
+ * 3. The concurrent-rejection retry's forced seq-0 download (`isReDeliveryRetry`)
  *    re-delivers the import. It must NOT resurface as a new incoming import
  *    while local work is pending — that is the sync-import conflict dialog
- *    from the field report, whose every answer destroys data.
+ *    from the field report, whose every answer destroys data. A provider
+ *    switch also forces seq 0 but is deliberately NOT filtered: its whole
+ *    point is a fresh state comparison that reaches the conflict gate.
  *
  * The second case guards the filter's false-positive edge: an op the local
  * clock covers only because the rejection resolver merged its clock, but
@@ -455,6 +457,7 @@ describe('Forced seq-0 download after compaction pruned an applied SYNC_IMPORT (
 
     const outcome = await syncService.downloadRemoteOps(provider, {
       forceFromSeq0: true,
+      isReDeliveryRetry: true,
     });
 
     // Server re-delivered 1..4 (fast-forwarded to the import); 1..3 are behind
@@ -488,6 +491,7 @@ describe('Forced seq-0 download after compaction pruned an applied SYNC_IMPORT (
 
     const outcome = await syncService.downloadRemoteOps(provider, {
       forceFromSeq0: true,
+      isReDeliveryRetry: true,
     });
 
     // Behind-cursor ops are skipped; the blocked op is above the cursor and delivered.

--- a/src/app/op-log/testing/integration/import-backup-ring.integration.spec.ts
+++ b/src/app/op-log/testing/integration/import-backup-ring.integration.spec.ts
@@ -1,0 +1,87 @@
+import { TestBed } from '@angular/core/testing';
+import { OperationLogStoreService } from '../../persistence/operation-log-store.service';
+import { StateSnapshotService } from '../../backup/state-snapshot.service';
+import { IMPORT_BACKUP_RING_SIZE } from '../../persistence/import-backup-ring.util';
+
+/**
+ * The recovery-point ring against REAL IndexedDB, not the in-memory `OpLogTx`
+ * fake the unit spec uses. The rotation deletes rows inside the same
+ * transaction that writes the new one, so "the protected entry survives" is a
+ * claim about committed storage — the unit spec can only show the policy picks
+ * the right ids, never that the row is still readable afterwards.
+ *
+ * Guards the restore path: `BackupService.restoreImportBackupById` writes a
+ * pre-restore capture into an already-full ring, and without `protectBackupId`
+ * that capture evicts and physically deletes the snapshot being restored, so a
+ * failure later in the import leaves the user nothing to retry.
+ */
+describe('import backup ring — integration (real IndexedDB)', () => {
+  let store: OperationLogStoreService;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        OperationLogStoreService,
+        {
+          provide: StateSnapshotService,
+          useValue: jasmine.createSpyObj('StateSnapshotService', [
+            'getStateSnapshot',
+            'getStateSnapshotForOperationLog',
+          ]),
+        },
+      ],
+    });
+    store = TestBed.inject(OperationLogStoreService);
+    await store.init();
+    await store._clearAllDataForTesting();
+  });
+
+  it('keeps the snapshot being restored readable after the pre-restore capture rotates the ring', async () => {
+    // The oldest entry is the one holding the user's pre-loss data.
+    const oldest = await store.saveImportBackup(
+      { marker: 'pre-loss' },
+      { reason: 'REMOTE_IMPORT', taskCount: 1 },
+    );
+    for (let i = 0; i < IMPORT_BACKUP_RING_SIZE - 1; i++) {
+      await store.saveImportBackup(
+        { marker: `filler-${i}` },
+        { reason: 'REMOTE_IMPORT', taskCount: 1 },
+      );
+    }
+
+    // Restoring `oldest` captures the current state first, into a full ring.
+    await store.saveImportBackup(
+      { marker: 'pre-restore' },
+      {
+        reason: 'LOCAL_IMPORT',
+        taskCount: 1,
+        protectBackupId: oldest.backupId,
+      },
+    );
+
+    const kept = await store.listImportBackups();
+    expect(kept.length).toBe(IMPORT_BACKUP_RING_SIZE);
+    expect(kept.map((e) => e.backupId)).toContain(oldest.backupId);
+
+    // The row itself survived the delete, not just the metadata listing.
+    const reloaded = await store.loadImportBackupById(oldest.backupId);
+    expect(reloaded).not.toBeNull();
+    expect((reloaded?.state as { marker: string }).marker).toBe('pre-loss');
+  });
+
+  it('still rotates the oldest entry out when nothing is protected', async () => {
+    const oldest = await store.saveImportBackup(
+      { marker: 'oldest' },
+      { reason: 'LOCAL_IMPORT', taskCount: 1 },
+    );
+    for (let i = 0; i < IMPORT_BACKUP_RING_SIZE; i++) {
+      await store.saveImportBackup(
+        { marker: `later-${i}` },
+        { reason: 'LOCAL_IMPORT', taskCount: 1 },
+      );
+    }
+
+    expect((await store.listImportBackups()).length).toBe(IMPORT_BACKUP_RING_SIZE);
+    expect(await store.loadImportBackupById(oldest.backupId)).toBeNull();
+  });
+});

--- a/src/app/plugins/oauth/plugin-oauth.service.spec.ts
+++ b/src/app/plugins/oauth/plugin-oauth.service.spec.ts
@@ -282,6 +282,81 @@ describe('PluginOAuthService', () => {
       expect(token).toBe('refreshed-token');
     });
 
+    it('keeps the old expiry when the refresh response omits expires_in', async () => {
+      // expires_in is OPTIONAL per RFC 6749 5.1. `response.expires_in * 1000`
+      // on an absent field yields NaN, which is then persisted; on next start
+      // restoreTokens rejects the record and discards the whole grant - the
+      // full re-consent loss #9939 set out to close.
+      const tokenUrl = 'https://oauth2.googleapis.com/token';
+      service.storeTokens('plugin-1', {
+        accessToken: 'old-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 60000,
+        tokenUrl,
+        clientId: 'cid',
+      });
+
+      const promise = service.getValidToken('plugin-1');
+      httpMock.expectOne(tokenUrl).flush({ access_token: 'refreshed-token' });
+
+      expect(await promise).toBe('refreshed-token');
+      const persisted = JSON.parse(service.serializeTokens('plugin-1') as string) as {
+        expiresAt: number;
+        accessToken: string;
+      };
+      expect(Number.isFinite(persisted.expiresAt)).toBeTrue();
+      expect(persisted.expiresAt).toBeGreaterThan(Date.now());
+    });
+
+    it('keeps the stored grant when the refresh response carries no access_token', async () => {
+      // GitHub answers 200 {"error":"bad_refresh_token"}. Persisting
+      // accessToken: undefined makes restoreTokens discard the grant on the
+      // next start.
+      const tokenUrl = 'https://oauth2.googleapis.com/token';
+      service.storeTokens('plugin-1', {
+        accessToken: 'old-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 60000,
+        tokenUrl,
+        clientId: 'cid',
+      });
+
+      const promise = service.getValidToken('plugin-1');
+      httpMock.expectOne(tokenUrl).flush({ error: 'bad_refresh_token' });
+
+      expect(await promise).toBeNull();
+      const persisted = JSON.parse(service.serializeTokens('plugin-1') as string) as {
+        accessToken: string;
+      };
+      expect(persisted.accessToken).toBe('old-token');
+    });
+
+    it('does not resurrect tokens cleared while a refresh was in flight', async () => {
+      // The user hits Disconnect mid-refresh. Re-inserting the record also
+      // re-emits tokensRefreshed$, whose bridge subscriber writes the
+      // credentials back to IndexedDB, so the disconnect survives a restart.
+      const tokenUrl = 'https://oauth2.googleapis.com/token';
+      service.storeTokens('plugin-1', {
+        accessToken: 'old-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 60000,
+        tokenUrl,
+        clientId: 'cid',
+      });
+      const refreshedEmissions: string[] = [];
+      service.tokensRefreshed$.subscribe((id) => refreshedEmissions.push(id));
+
+      const promise = service.getValidToken('plugin-1');
+      service.clearTokens('plugin-1');
+      httpMock
+        .expectOne(tokenUrl)
+        .flush({ access_token: 'refreshed-token', expires_in: 3600 });
+
+      expect(await promise).toBeNull();
+      expect(service.hasTokens('plugin-1')).toBeFalse();
+      expect(refreshedEmissions).toEqual([]);
+    });
+
     it('should keep tokens when client authentication fails', async () => {
       // invalid_client faults the app's own credentials, not the user's grant —
       // deleting their refresh token cannot fix it and re-consent would fail too.

--- a/src/app/plugins/oauth/plugin-oauth.service.ts
+++ b/src/app/plugins/oauth/plugin-oauth.service.ts
@@ -28,6 +28,18 @@ const RESERVED_OAUTH_PARAMS = new Set([
 /** The one RFC 6749 §5.2 code that proves the stored grant is dead — re-consent is the only fix. */
 const TERMINAL_OAUTH_ERROR_CODE = 'invalid_grant';
 
+/**
+ * Used when a refresh response omits `expires_in` (OPTIONAL per RFC 6749 5.1,
+ * and in practice usually omitted for tokens that do not expire at all).
+ *
+ * Guessing high is not free: refresh is driven only by `expiresAt`, never by a
+ * 401, so a provider that omits `expires_in` AND issues a short-lived token
+ * leaves the plugin with a dead token until this hour elapses. One hour is the
+ * common provider default and no such provider has been reported; if one is,
+ * refresh on 401 rather than shortening this guess for everyone.
+ */
+const DEFAULT_TOKEN_LIFETIME_SEC = 3600;
+
 /** Reads the `error` code out of an RFC 6749 §5.2 error body, if there is one. */
 const readOAuthErrorCode = (body: unknown): string | null => {
   if (typeof body !== 'object' || body === null) {
@@ -211,11 +223,30 @@ export class PluginOAuthService {
     }
 
     const response = await this._postTokenRequest<{
-      access_token: string;
-      expires_in: number;
+      access_token?: unknown;
+      expires_in?: unknown;
+      error?: unknown;
     }>(tokenUrl, params);
 
-    const expiresInMs = response.expires_in * 1000;
+    // A 200 is not proof of a usable token: `expires_in` is OPTIONAL (RFC 6749
+    // 5.1) and some servers report failure in a 200 body (GitHub's
+    // `{"error":"bad_refresh_token"}`). Persisting `undefined` / `NaN` here
+    // makes `restoreTokens` reject the record on the next start and discard the
+    // whole grant — the full re-consent loss of #9939, via the write path.
+    if (typeof response?.access_token !== 'string' || !response.access_token) {
+      throw new Error(
+        `OAuth refresh response carried no access_token${
+          readOAuthErrorCode(response) ? ` (error=${readOAuthErrorCode(response)})` : ''
+        }`,
+      );
+    }
+    // Absent or unusable `expires_in` falls back to a conservative lifetime
+    // rather than NaN: the token still works, it is just refreshed sooner.
+    const expiresInSec =
+      typeof response.expires_in === 'number' && Number.isFinite(response.expires_in)
+        ? response.expires_in
+        : DEFAULT_TOKEN_LIFETIME_SEC;
+    const expiresInMs = expiresInSec * 1000;
     return {
       accessToken: response.access_token,
       expiresAt: Date.now() + expiresInMs,
@@ -313,6 +344,15 @@ export class PluginOAuthService {
         tokens.refreshToken,
         tokens.clientSecret,
       );
+      // The store can have moved on during the network round trip: the user hit
+      // Disconnect (`clearTokens`), or a re-auth stored a fresh grant. Writing
+      // our now-stale record back would undo either — and `tokensRefreshed$`
+      // makes the bridge persist it to IndexedDB, so the resurrection survives
+      // a restart.
+      if (this._tokenStore.get(pluginId) !== tokens) {
+        PluginLog.log(`Discarding refreshed token for plugin ${pluginId}: store changed`);
+        return null;
+      }
       this._tokenStore.set(pluginId, {
         ...tokens,
         accessToken: refreshed.accessToken,

--- a/src/app/ui/done-toggle/done-toggle.component.spec.ts
+++ b/src/app/ui/done-toggle/done-toggle.component.spec.ts
@@ -1,0 +1,70 @@
+import { TestBed } from '@angular/core/testing';
+import { Component, signal } from '@angular/core';
+import { DoneToggleComponent } from './done-toggle.component';
+
+@Component({
+  standalone: true,
+  imports: [DoneToggleComponent],
+  template: `
+    <done-toggle
+      [isDone]="false"
+      [isMultiSelectAware]="isMultiSelectAware()"
+      (toggled)="toggledCount = toggledCount + 1"
+    ></done-toggle>
+  `,
+})
+class HostComponent {
+  readonly isMultiSelectAware = signal(false);
+  toggledCount = 0;
+}
+
+describe('DoneToggleComponent', () => {
+  const clickWith = (
+    init: MouseEventInit,
+  ): { host: HostComponent; ev: MouseEvent; el: HTMLElement } => {
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    const el = fixture.nativeElement.querySelector('done-toggle') as HTMLElement;
+    const ev = new MouseEvent('click', { bubbles: true, cancelable: true, ...init });
+    return { host: fixture.componentInstance, ev, el };
+  };
+
+  it('toggles and stops propagation on a plain click', () => {
+    const { host, ev, el } = clickWith({});
+    const stopped = spyOn(ev, 'stopPropagation');
+    el.dispatchEvent(ev);
+    expect(host.toggledCount).toBe(1);
+    expect(stopped).toHaveBeenCalled();
+  });
+
+  // The Planner uses this same component and has no multi-select, so a
+  // modifier click there must keep marking the task done. Bailing
+  // unconditionally swallowed the toggle AND let the click bubble to the
+  // planner row, which opened the detail panel instead.
+  it('toggles on a modifier click when the host is not multi-select aware', () => {
+    const { host, ev, el } = clickWith({ ctrlKey: true });
+    const stopped = spyOn(ev, 'stopPropagation');
+    el.dispatchEvent(ev);
+    expect(host.toggledCount).toBe(1);
+    // The other half of the reported symptom: the swallowed toggle ALSO let the
+    // click reach the planner row, which opened the detail panel. Emitting
+    // without stopping here would still leave that behaviour broken.
+    expect(stopped).toHaveBeenCalled();
+  });
+
+  it('lets a modifier click bubble untouched when the host is multi-select aware', () => {
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.componentInstance.isMultiSelectAware.set(true);
+    fixture.detectChanges();
+    const el = fixture.nativeElement.querySelector('done-toggle') as HTMLElement;
+    const ev = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      shiftKey: true,
+    });
+    const stopped = spyOn(ev, 'stopPropagation');
+    el.dispatchEvent(ev);
+    expect(fixture.componentInstance.toggledCount).toBe(0);
+    expect(stopped).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/ui/done-toggle/done-toggle.component.ts
+++ b/src/app/ui/done-toggle/done-toggle.component.ts
@@ -27,12 +27,20 @@ export class DoneToggleComponent {
   readonly isCurrent = input<boolean>(false);
   readonly showDoneAnimation = input<boolean>(false);
   readonly showUndoneAnimation = input<boolean>(false);
+  /**
+   * Opt in where the surrounding row supports multi-select (the task list).
+   * Off by default: the Planner renders this same toggle and has no
+   * multi-select, so a modifier click there must still mark the task done —
+   * bailing unconditionally swallowed the toggle and let the click bubble to
+   * the planner row, which opened the detail panel instead.
+   */
+  readonly isMultiSelectAware = input<boolean>(false);
   readonly toggled = output<void>();
 
   onClick(ev: MouseEvent): void {
     // A modifier click selects the task row instead of toggling done; let it
     // bubble to the row.
-    if (isMultiSelectModifierEvent(ev)) {
+    if (this.isMultiSelectAware() && isMultiSelectModifierEvent(ev)) {
       return;
     }
     this.toggled.emit();

--- a/src/app/ui/link-href.util.spec.ts
+++ b/src/app/ui/link-href.util.spec.ts
@@ -64,6 +64,14 @@ describe('toRenderableHref', () => {
       'ms.msdt:1234',
       // `host:port@other` is userinfo, not a port — never a bare host.
       'trusted-bank.com:8080@evil.com/login',
+      // Same trick behind a `www.` label: the visible prefix is the bait and
+      // the real host is what follows the `@`.
+      'www.trusted-bank.com:8080@evil.com/login',
+      'www.trusted-bank.com@evil.com/login',
+      // Accepted collateral of the rule above: a schemeless host with a real
+      // port is indistinguishable from the userinfo bait without parsing, so
+      // it stays text. Write `http://www.example.com:8080/x` to link it.
+      'www.example.com:8080/path',
     ].forEach((href) => {
       it(`returns null for "${href}"`, () => {
         expect(toRenderableHref(href)).toBeNull();

--- a/src/app/ui/link-href.util.ts
+++ b/src/app/ui/link-href.util.ts
@@ -15,7 +15,7 @@ import { isExternalUrlSchemeAllowed } from '../../../electron/shared-with-fronte
  * both stay out of the match set.
  */
 const BARE_HOST_RE =
-  /^(?:www\.[a-z0-9-]+(?:\.[a-z0-9-]+)*|[a-z0-9][a-z0-9-]*(?:\.[a-z0-9-]+)+(?=[/?#]))/i;
+  /^(?:www\.[a-z0-9-]+(?:\.[a-z0-9-]+)*(?=$|[/?#])|[a-z0-9][a-z0-9-]*(?:\.[a-z0-9-]+)+(?=[/?#]))/i;
 
 const _withScheme = (href: string): string => {
   if (href.startsWith('//')) {


### PR DESCRIPTION
A review of every commit in the trailing 7 days turned up 15 findings; 12 are fixed here, 3 are documented as known gaps with reasons. Every behavioural fix has a test that was **confirmed to fail without it** — several by reverting the fix and watching the new test go red.

## Sync / data loss

- **`remote-ops-processing`** — withdraw the causal repair base before validating a partial apply failure. The cursor the caller supplied covers ops this client did *not* apply, so a REPAIR minted by that validation claimed it. Receivers auto-accept a causal REPAIR and then **DROP** their concurrent prefix ops (`SyncImportFilterService`, `isPrefixOp` + `repairBaseServerSeq !== undefined`) instead of replaying them after the boundary — deleting work the snapshot never contained. The blocked-op path already withdrew; this path didn't.
- **`backup` + `import-backup-ring`** — protect the recovery point being restored from the pre-restore capture's ring rotation. The capture is committed before the restore is known to have succeeded, so restoring the oldest entry physically deleted it; a failure later in the import (quota, IDB abort, app kill) left nothing to retry. Covered against **real IndexedDB**, since the rotation deletes rows in the same transaction that writes the new one.
- **`operation-log-download`** — key the re-delivery filter on the caller's intent (`isReDeliveryRetry`) rather than `forceFromSeq0`, which a provider switch also sets. A switch back to a previously-used SuperSync account carries a non-zero cursor and a clock inherited from the other provider, so filtering there silently dropped the server's history, skipped the dialog, and let the device upload its divergent state.
- **`sync-local-state`** — read the same interpretable op prefix as the gate it defers to. A full-state op behind an uninterpretable one is never reached by `processRemoteOps`, so the gate doesn't prompt for it; scanning the full batch here left neither side prompting (#8764).
- **`sync-core/deepEqual`** — scope the circular-reference set to the current *path* rather than everything visited. A DAG (the same object referenced twice — `structuredClone` preserves aliasing, module-level defaults are routinely aliased) tripped the circular bail on its second visit, so structurally identical values compared unequal. A real cycle revisits an ancestor still on the path and is still caught.

## Security

- **`link-href`** — a bare `www.` host must now be followed by end-of-string or a path. `www.trusted-bank.com:8080@evil.com/login` matched, got `http://` prepended, resolved to host `evil.com`, and the scheme gate only judges the scheme — producing a live anchor to `shell.openExternal`.
- **`plugin-oauth`** — reject a refresh response carrying no `access_token` (a 200 with an RFC 6749 §5.2 error body, e.g. GitHub's `{"error":"bad_refresh_token"}`), fall back to a default lifetime instead of persisting `NaN` (which makes `restoreTokens` discard the whole grant on next start), and discard a refreshed token whose store entry changed mid-flight — otherwise a Disconnect or re-auth during the round trip is silently undone and the resurrection is persisted to IndexedDB.

## UI

- **`task-bulk-action`** — the deadline dialog's "Remove" now reports `DEADLINE_REMOVED` and counts only tasks that actually had a deadline; the backlog move is gated on the active work context, so the keyboard path can't emit one synced op per task in a view with no backlog.
- **`done-toggle`** — the multi-select bail is now opt-in. The Planner renders this same shared component and has no multi-select, so bailing unconditionally swallowed the toggle *and* let the click bubble to the planner row, opening the detail panel. Both hosts are pinned in opposite directions: an e2e Ctrl+clicks the task-list checkbox (every other multi-select test clicks the row title and would not notice), and `planner-task` renders the real `done-toggle` to prove a modifier click there still completes the task.

## Documented, deliberately not guarded

Per the repo's "hardening needs an observed instance" rule, these are recorded as known gaps rather than guarded:

- `NativeInsetShimGate` — the version-code fallback can disagree with what `SystemBars` reads from `versionName`, leaving no inset owner. No device with an unparseable WebView `versionName` has been reported.
- `import-backup-ring` — only the newest pre-replacement capture is guarded; a run of further full-state ops still ages out an older pre-loss snapshot. Widening that is a ring-policy decision.

Also not changed, with reasons: the WebDAV `TypeError` → `NetworkUnavailableSPError` remap is a documented deliberate tradeoff for #9985, and SuperSync's `trustProxy` hard-coding is an already-documented known gap and a product decision.

## Worth a second pair of eyes

- **`packages/sync-core/src/conflict-resolution.ts:317`** — the deepEqual fix changes which branch this caller takes when a local payload aliases a sub-object and the remote (JSON off the wire) does not. The new answer is the correct one, but the branch change is untested.
- **Two flipped assertions in `server-migration.service.spec.ts`** — both were `known defect (delete when deepEqual is fixed)` specs whose own docs prescribed exactly this change, and the deepEqual spec was replaced rather than flipped (plus a new cycle-through-DAG test pinning the preserved contract). A flipped assertion still deserves a look.

## Testing

Full unit suite 15074/0 · sync-core Vitest 271/271 · lint-rules · tools 52/52 · `tsc --noEmit` clean · `checkFile` clean on every touched file. The new e2e passes and fails on revert; the full e2e suite has not been run locally — 25 specs reference `done-toggle`, so that's for CI.

https://claude.ai/code/session_01SMH5eZWMjFa3Lht3ZZ1j7Q
