### PR TITLE
fix(electron): let Flowtime keep its OS progress bar

### DIFF
--- a/electron/indicator.test.cjs
+++ b/electron/indicator.test.cjs
@@ -420,10 +420,12 @@ test('tray title shows the task title when countdown display is disabled', () =>
   assert.equal(traySetToolTipCalls.at(-1), 'Write release notes');
 });
 
-// A Flowtime session has no target duration, so focus mode publishes progress 0
-// while task tracking publishes the real task ratio. Both reached the tray icon
-// every second, flipping it between the progress ring and the plain running
-// icon — the blink reported in #9944 (and the dock-bar variant in #3131).
+// Both writers fire every second while a focus session runs with the overlay
+// hidden: CURRENT_TASK_UPDATED carries task progress, SET_PROGRESS_BAR carries
+// the session's. When both reached the icon it flipped between the two frames
+// twice a second — the blink reported in #9944. Values differ on purpose here:
+// identical ones would be swallowed by setTrayIcon's path dedupe and the test
+// would pass even with two writers.
 test('tray icon has a single writer per tick while the focus overlay is hidden', () => {
   Object.defineProperty(process, 'platform', {
     configurable: true,
@@ -452,16 +454,20 @@ test('tray icon has a single writer per tick while the focus overlay is hidden',
   for (let i = 0; i < 3; i++) {
     task.timeSpent += 1000;
     // task-electron.effects: isFocusModeEnabled === isOverlayShown === false
-    currentTaskUpdated({}, { ...task }, false, 0, false, 0, 'Flowtime');
-    // focus-mode.effects: Flowtime publishes no meaningful progress
-    setProgressBar({}, { progress: -1, progressBarMode: 'none' });
+    currentTaskUpdated({}, { ...task }, false, 0, false, 0, 'Pomodoro');
+    // focus-mode.effects: session progress, unrelated to the task estimate
+    setProgressBar({}, { progress: 0.2, progressBarMode: 'normal' });
   }
 
   const iconPaths = traySetImageCalls.map((image) => image.iconPath);
   assert.deepEqual(iconPaths, ['/icons/indicator/running-anim-l/8.png']);
 });
 
-test('the focus overlay owns the tray icon while it is shown', () => {
+// The mirror case: with the overlay shown CURRENT_TASK_UPDATED stands down, so
+// the icon has to follow SET_PROGRESS_BAR. During a Flowtime session that
+// message carries the *task* progress (the session owns no progress of its
+// own), which is what keeps the ring rendering instead of the plain icon.
+test('tray icon follows SET_PROGRESS_BAR while the focus overlay is shown', () => {
   Object.defineProperty(process, 'platform', {
     configurable: true,
     value: 'darwin',
@@ -487,14 +493,14 @@ test('the focus overlay owns the tray icon while it is shown', () => {
     0,
     true,
     0,
-    'Pomodoro',
+    'Flowtime',
   );
   traySetImageCalls = [];
-  setProgressBar({}, { progress: 0.2, progressBarMode: 'normal' });
+  setProgressBar({}, { progress: 0.5, progressBarMode: 'normal' });
 
   assert.equal(traySetImageCalls.length, 1);
   assert.match(
     traySetImageCalls.at(-1).iconPath,
-    /\/icons\/indicator\/running-anim-l\/3\.png$/,
+    /\/icons\/indicator\/running-anim-l\/8\.png$/,
   );
 });

--- a/electron/indicator.ts
+++ b/electron/indicator.ts
@@ -209,10 +209,11 @@ function initListeners(): void {
 
   ipcMain.on(IPC.SET_PROGRESS_BAR, (ev: IpcMainEvent, { progress }) => {
     // Exactly one writer may own the tray icon per tick, otherwise the menu bar
-    // icon visibly blinks (#9944): the focus overlay owns it while it is shown
-    // (session progress), CURRENT_TASK_UPDATED owns it otherwise (task
-    // progress). Both fired every second before, so the icon flipped between
-    // the progress ring and the plain running icon twice per second.
+    // icon visibly blinks (#9944): while the focus overlay is shown the icon
+    // follows whatever SET_PROGRESS_BAR carries, otherwise CURRENT_TASK_UPDATED
+    // owns it (and skips its own write on the same flag). Both used to write
+    // every second, flipping the icon between the progress ring and the plain
+    // running icon twice per second.
     if (_isRunning && tray && _lastIsFocusModeEnabled) {
       setTrayIcon(tray, getRunningIconPath(progress));
     }

--- a/src/app/features/focus-mode/store/focus-mode.effects.ts
+++ b/src/app/features/focus-mode/store/focus-mode.effects.ts
@@ -876,7 +876,11 @@ export class FocusModeEffects {
           throttleTime(500, undefined, { leading: true, trailing: true }),
           withLatestFrom(this.store.select(selectors.selectOsProgressBar)),
           tap(([_action, osProgressBar]) => {
-            window.ea.setProgressBar(osProgressBar);
+            // null = an open-ended (Flowtime) session, which owns nothing:
+            // task-electron.effects publishes the task's own progress instead.
+            if (osProgressBar) {
+              window.ea.setProgressBar(osProgressBar);
+            }
           }),
         ),
       { dispatch: false },

--- a/src/app/features/focus-mode/store/focus-mode.selectors.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.selectors.spec.ts
@@ -475,26 +475,46 @@ describe('FocusModeSelectors', () => {
     });
   });
 
+  describe('selectIsOsProgressBarOwnedBySession', () => {
+    it('should own the bar for a running timed session', () => {
+      const result = selectors.selectIsOsProgressBarOwnedBySession.projector(
+        true,
+        1500000,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    // Flowtime has no target duration, so it has no progress of its own. Owning
+    // the bar here would pin it to 0 and cycle against the task-progress writer
+    // in task-electron.effects (#9944).
+    it('should not own the bar for an open-ended (Flowtime) session', () => {
+      const result = selectors.selectIsOsProgressBarOwnedBySession.projector(true, 0);
+
+      expect(result).toBe(false);
+    });
+
+    it('should not own the bar while no session runs', () => {
+      const result = selectors.selectIsOsProgressBarOwnedBySession.projector(
+        false,
+        1500000,
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
   describe('selectOsProgressBar', () => {
-    it('should publish the session progress when a duration is set', () => {
-      const result = selectors.selectOsProgressBar.projector(50, true, 1500000);
+    it('should publish the session progress while it owns the bar', () => {
+      const result = selectors.selectOsProgressBar.projector(true, 50);
 
       expect(result).toEqual({ progress: 0.5, progressBarMode: 'normal' });
     });
 
-    it('should publish pause mode when the session is not running', () => {
-      const result = selectors.selectOsProgressBar.projector(50, false, 1500000);
+    it('should publish nothing while it does not own the bar', () => {
+      const result = selectors.selectOsProgressBar.projector(false, 0);
 
-      expect(result).toEqual({ progress: 0.5, progressBarMode: 'pause' });
-    });
-
-    // Flowtime has no target duration, so progress is always 0. Publishing it
-    // pinned the OS progress bar to empty and cycled against the task-progress
-    // writer in task-electron.effects (#9944, #3131).
-    it('should hide the bar for an open-ended (Flowtime) session', () => {
-      const result = selectors.selectOsProgressBar.projector(0, true, 0);
-
-      expect(result).toEqual({ progress: -1, progressBarMode: 'none' });
+      expect(result).toBeNull();
     });
   });
 });

--- a/src/app/features/focus-mode/store/focus-mode.selectors.ts
+++ b/src/app/features/focus-mode/store/focus-mode.selectors.ts
@@ -90,27 +90,25 @@ export const selectIsRunning = createSelector(
 );
 
 /**
- * What the running focus session should publish to the OS progress bar
- * (taskbar/dock). Flowtime has no target duration, so `selectProgress` is
- * always 0 there: publishing it would pin the bar to empty and cycle against
- * the task-progress writer in `task-electron.effects` (#9944, #3131). Hide the
- * bar instead - an open-ended session has no progress to show.
+ * Whether the running focus session owns the OS progress bar (taskbar/dock).
+ * Exactly one writer may own that surface, so `task-electron.effects` stands
+ * down on this same flag — when both wrote, the bar cycled between the two
+ * values every second (#9944). An open-ended (Flowtime) session has no target
+ * duration and therefore no progress of its own, so it leaves the bar to the
+ * task writer rather than publishing a meaningless 0.
  */
-export const selectOsProgressBar = createSelector(
-  selectProgress,
+export const selectIsOsProgressBarOwnedBySession = createSelector(
   selectIsRunning,
   selectTimeDuration,
-  (
-    progress,
-    isRunning,
-    duration,
-  ): { progress: number; progressBarMode: 'normal' | 'pause' | 'none' } =>
-    duration > 0
-      ? {
-          progress: progress / 100,
-          progressBarMode: isRunning ? 'normal' : 'pause',
-        }
-      : { progress: -1, progressBarMode: 'none' },
+  (isRunning, duration) => isRunning && duration > 0,
+);
+
+/** What the focus session should publish, or `null` when it owns nothing. */
+export const selectOsProgressBar = createSelector(
+  selectIsOsProgressBarOwnedBySession,
+  selectProgress,
+  (isOwnedBySession, progress): { progress: number; progressBarMode: 'normal' } | null =>
+    isOwnedBySession ? { progress: progress / 100, progressBarMode: 'normal' } : null,
 );
 
 // Session completed selector

--- a/src/app/features/tasks/store/task-electron.effects.spec.ts
+++ b/src/app/features/tasks/store/task-electron.effects.spec.ts
@@ -1,0 +1,135 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { BehaviorSubject, Subject } from 'rxjs';
+import { TaskElectronEffects } from './task-electron.effects';
+import { TimeTrackingActions } from '../../time-tracking/store/time-tracking.actions';
+import {
+  selectIsOsProgressBarOwnedBySession,
+  selectIsOverlayShown,
+} from '../../focus-mode/store/focus-mode.selectors';
+import { selectCurrentTask, selectTaskEntities } from './task.selectors';
+import { selectTodayTaskIds } from '../../work-context/store/work-context.selectors';
+import { GlobalConfigService } from '../../config/global-config.service';
+import { FocusModeService } from '../../focus-mode/focus-mode.service';
+import { TaskService } from '../task.service';
+import { LOCAL_ACTIONS } from '../../../util/local-actions.token';
+import { DEFAULT_TASK, Task } from '../task.model';
+
+/**
+ * The OS progress bar (taskbar/dock) must only ever have one writer: a timed
+ * focus session publishes its own progress, and this effect has to stand down
+ * for exactly as long as that is true. Gating on the focus overlay being
+ * *shown* instead left both writers active whenever the overlay was hidden, so
+ * the bar cycled between the two values every second (#9944).
+ */
+describe('TaskElectronEffects', () => {
+  let effects: TaskElectronEffects;
+  let actions$: Subject<any>;
+  let store: MockStore;
+  let setProgressBarSpy: jasmine.Spy;
+
+  const task: Task = {
+    ...DEFAULT_TASK,
+    id: 'T1',
+    title: 'Task',
+    projectId: 'project-1',
+    timeSpent: 30 * 60000,
+    timeEstimate: 60 * 60000,
+  };
+
+  const addTimeSpent = (): ReturnType<typeof TimeTrackingActions.addTimeSpent> =>
+    TimeTrackingActions.addTimeSpent({
+      task,
+      date: '2026-01-05',
+      duration: 1000,
+      isFromTrackingReminder: false,
+    });
+
+  beforeEach(() => {
+    actions$ = new Subject<any>();
+    setProgressBarSpy = jasmine.createSpy('setProgressBar');
+    (window as any).ea = {
+      on: () => {},
+      onSwitchTask: () => {},
+      updateCurrentTask: () => {},
+      updateTodayTasks: () => {},
+      setProgressBar: setProgressBarSpy,
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        TaskElectronEffects,
+        provideMockActions(() => actions$),
+        provideMockStore({
+          selectors: [
+            { selector: selectCurrentTask, value: task },
+            { selector: selectTaskEntities, value: { T1: task } },
+            { selector: selectTodayTaskIds, value: [] },
+            { selector: selectIsOverlayShown, value: false },
+            { selector: selectIsOsProgressBarOwnedBySession, value: false },
+          ],
+        }),
+        { provide: LOCAL_ACTIONS, useValue: actions$ },
+        { provide: GlobalConfigService, useValue: {} },
+        { provide: TaskService, useValue: { setCurrentId: () => {} } },
+        {
+          provide: FocusModeService,
+          useValue: {
+            currentSessionTime$: new BehaviorSubject(0),
+            mode: () => 'Flowtime',
+          },
+        },
+      ],
+    });
+
+    effects = TestBed.inject(TaskElectronEffects);
+    store = TestBed.inject(MockStore);
+  });
+
+  afterEach(() => {
+    store.resetSelectors();
+    delete (window as any).ea;
+  });
+
+  describe('setTaskBarProgress$', () => {
+    it('should publish task progress while no focus session owns the bar', () => {
+      const sub = effects.setTaskBarProgress$.subscribe();
+      actions$.next(addTimeSpent());
+      sub.unsubscribe();
+
+      expect(setProgressBarSpy).toHaveBeenCalledWith({
+        progress: 0.5,
+        progressBarMode: 'normal',
+      });
+    });
+
+    it('should stand down while a timed focus session owns the bar', () => {
+      store.overrideSelector(selectIsOsProgressBarOwnedBySession, true);
+      store.refreshState();
+
+      const sub = effects.setTaskBarProgress$.subscribe();
+      actions$.next(addTimeSpent());
+      sub.unsubscribe();
+
+      expect(setProgressBarSpy).not.toHaveBeenCalled();
+    });
+
+    // An open-ended (Flowtime) session owns nothing, so the task progress has to
+    // keep flowing even though the focus overlay may be hidden or shown.
+    it('should keep publishing during an open-ended focus session', () => {
+      store.overrideSelector(selectIsOverlayShown, true);
+      store.overrideSelector(selectIsOsProgressBarOwnedBySession, false);
+      store.refreshState();
+
+      const sub = effects.setTaskBarProgress$.subscribe();
+      actions$.next(addTimeSpent());
+      sub.unsubscribe();
+
+      expect(setProgressBarSpy).toHaveBeenCalledWith({
+        progress: 0.5,
+        progressBarMode: 'normal',
+      });
+    });
+  });
+});

--- a/src/app/features/tasks/store/task-electron.effects.ts
+++ b/src/app/features/tasks/store/task-electron.effects.ts
@@ -14,8 +14,8 @@ import { selectCurrentTask, selectTaskEntities } from './task.selectors';
 import { selectTodayTaskIds } from '../../work-context/store/work-context.selectors';
 import { GlobalConfigService } from '../../config/global-config.service';
 import {
+  selectIsOsProgressBarOwnedBySession,
   selectIsOverlayShown,
-  selectIsRunning as selectIsFocusTimerRunning,
 } from '../../focus-mode/store/focus-mode.selectors';
 import { TimeTrackingActions } from '../../time-tracking/store/time-tracking.actions';
 import { FocusModeService } from '../../focus-mode/focus-mode.service';
@@ -187,12 +187,14 @@ export class TaskElectronEffects {
         // collapses 1 IPC/sec into ~1 IPC/3s. Leading+trailing keeps the first
         // tick after start instant and the final value at the end of a window.
         throttleTime(3000, undefined, { leading: true, trailing: true }),
-        withLatestFrom(this._store$.select(selectIsFocusTimerRunning)),
-        // A running focus session owns the OS progress bar (it publishes its own
-        // session progress). Gating on the overlay being *shown* instead left
-        // both writers active whenever the overlay was hidden, so the bar and
-        // the tray icon cycled between the two values every second (#9944, #3131).
-        filter(([a, isFocusSessionRunning]) => !isFocusSessionRunning),
+        withLatestFrom(this._store$.select(selectIsOsProgressBarOwnedBySession)),
+        // Stand down while a timed focus session owns the OS progress bar, so
+        // that surface only ever has one writer. Gating on the focus overlay
+        // being *shown* instead left both writers active whenever the overlay
+        // was hidden, and the bar cycled between the two values every second
+        // (#9944). Open-ended (Flowtime) sessions own nothing, so the task
+        // progress below keeps the bar meaningful there.
+        filter(([a, isOwnedByFocusSession]) => !isOwnedByFocusSession),
         tap(([{ task }]) => {
           const progress = task.timeSpent / task.timeEstimate;
           window.ea.setProgressBar({


### PR DESCRIPTION
Follow-up to #10043 (already merged), from review feedback on that PR. Also closes out the dock-bar half of #3131.

## What #10043 got wrong

It fixed the blink by giving each surface a single owner, but drew the ownership line at *"a focus session is running"*. Two consequences nobody actually decided:

1. **The dock/taskbar bar vanished for the whole of a Flowtime session.** Focus mode published `progressBarMode: 'none'` every second and the task writer stood down. That is the opposite of what #3131 asks for ("the icon in the dock should display the progress properly while in Focus mode").
2. **The tray icon lost its progress ring during Flowtime with the overlay open.** `CURRENT_TASK_UPDATED` stands down when the overlay is shown, so the icon follows `SET_PROGRESS_BAR` — which then carried no usable progress, resolving to the plain running icon. (Pre-existing, not introduced by #10043, but #10043 was the chance to clear it.)

## The fix

Move the line from "a focus session is running" to **"a *timed* focus session is running"**, expressed once as `selectIsOsProgressBarOwnedBySession` and consumed by both writers:

| State | OS progress bar | Tray icon |
| --- | --- | --- |
| Timed session running | focus-mode effect | overlay shown → `SET_PROGRESS_BAR`; hidden → `CURRENT_TASK_UPDATED` |
| Flowtime / no session | task effect | same |

An open-ended session owns nothing, so task progress keeps flowing to both surfaces and the ring renders in either overlay state. The complement stays exact — neither surface ever has two writers or none.

Drops the now-unreachable `progressBarMode: 'pause'`: `pauseFocusSession` → `syncSessionPauseToTracking$` → `unsetCurrentTask` → `setTaskBarNoProgress$` hides the bar on the very next action, so that branch never rendered.

Also corrects the `indicator.ts` comment — the gate is on overlay *visibility*, not on which effect sent the message. With the overlay open and the timer not running, it is the task writer painting through that branch.

## Testing

- **New `task-electron.effects.spec.ts`** — the ownership swap had zero coverage; reverting the predicate to `selectIsOverlayShown` left the entire suite green. Reverting it now fails 2 of these 3 specs.
- **Retargeted the tray regression test** at a countdown session where the two writers carry *different* values. With identical values, `setTrayIcon`'s path dedupe would swallow the second write and the test would pass even with two writers. Still fails with the gate removed (`not ok 9`).
- `npm test` 15132/15132, `npm run test:electron` 301/301, `tsc --noEmit` clean, `checkFile` clean on all 6 changed files.

**Not verified:** still no macOS here, so no visual confirmation — the repro is a mock harness over the real `indicator.ts`, not a real `Tray`.

**Known, left alone as out of scope:** during Flowtime the task writer now feeds the bar for tasks without a `timeEstimate`, where `timeSpent / 0` sends `Infinity`/`NaN` into `setProgressBar`. Pre-existing and already reachable in plain time tracking; this just adds one more state.

https://claude.ai/code/session_01GyTGL79e4cRB3wsQfE55ws