### PR TITLE
fix(sync): replay own genesis op as full state so op-log rebuilds keep legacy data

### DIFF
--- a/android/app/src/androidTest/java/com/superproductivity/superproductivity/ImeInsetShimInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/superproductivity/superproductivity/ImeInsetShimInstrumentedTest.kt
@@ -208,17 +208,52 @@ class ImeInsetShimInstrumentedTest {
         }
     }
 
-    private fun showIme(activity: CapacitorMainActivity, webView: WebView) {
+    /** Focuses the field and asks for the IME. Returns whether an input connection existed. */
+    private fun showIme(activity: CapacitorMainActivity, webView: WebView): Boolean {
         // View focus first, then the editable inside it, then the request: a
         // programmatic focus() without a user gesture does not raise the IME by
         // itself, and show(ime()) needs an editor attached to the focused view.
         onMainSync { webView.requestFocus() }
         evaluateJavaScript(webView, "document.getElementById('field').focus(); 'focused'")
+        // The JS focus returning is not enough: the input connection only exists
+        // once the renderer has reported the focused editable back to the browser
+        // process, which is asynchronous and can lag seconds on a loaded emulator.
+        // A request issued before then is dropped outright — "Ignoring
+        // showSoftInput() as view ... is not served", the whole failure in run
+        // 33975587718 — so wait for the connection instead of racing it.
+        val served = awaitServedView(activity, webView)
         onMainSync {
             WindowInsetsControllerCompat(activity.window, webView)
                 .show(WindowInsetsCompat.Type.ime())
         }
+        return served
     }
+
+    /**
+     * Waits until the IME has an input connection to [webView], i.e. a show
+     * request would reach the IME instead of being ignored. Reports a miss
+     * rather than failing on it, so that a genuine never-opens failure still
+     * fails on the geometry with the full reading rather than dying here.
+     */
+    private fun awaitServedView(
+        activity: CapacitorMainActivity,
+        webView: WebView,
+        timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS,
+    ): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + TimeUnit.SECONDS.toMillis(timeoutSeconds)
+        do {
+            if (onMainSync { inputMethodManager(activity).isActive(webView) }) return true
+            // Coarser than POLL_MS: isActive() can hit system_server synchronously,
+            // and this wait exists for the case where that server is already the
+            // slow part. Detection latency does not matter at this granularity.
+            SystemClock.sleep(SERVED_POLL_MS)
+        } while (SystemClock.elapsedRealtime() < deadline)
+        Log.i(TAG, "WebView still has no input connection after ${timeoutSeconds}s")
+        return false
+    }
+
+    private fun inputMethodManager(activity: CapacitorMainActivity): InputMethodManager =
+        activity.getSystemService(InputMethodManager::class.java)
 
     private fun hideIme(activity: CapacitorMainActivity, webView: WebView) {
         evaluateJavaScript(webView, "document.getElementById('field').blur(); 'blurred'")
@@ -238,16 +273,25 @@ class ImeInsetShimInstrumentedTest {
             it.keyboardOpenPerListener
         }
         if (first != null) return first
-        Log.i(TAG, "IME not open after show(ime()); retrying via InputMethodManager")
+        // Re-enter the whole sequence rather than re-issuing show() alone: what
+        // the retry is really for is the second wait for an input connection,
+        // since the likeliest reason the first request did nothing is that there
+        // was none yet. (The JS focus it repeats is a no-op while the field still
+        // holds focus — the focusing steps return early and the renderer re-reports
+        // nothing — so the wait, not the focus, is what makes this retry worth a try.)
+        Log.i(TAG, "IME not open after show(ime()); retrying the request and the wait")
+        val served = showIme(activity, webView)
         onMainSync {
-            activity.getSystemService(InputMethodManager::class.java)
+            inputMethodManager(activity)
                 .showSoftInput(webView, InputMethodManager.SHOW_IMPLICIT)
         }
         return awaitGeometry(
             activity,
             webView,
             "the IME to open (visible frame must drop by more than 15% of the root height; " +
-                "on an emulator make sure `settings put secure show_ime_with_hard_keyboard 1` ran)",
+                "WebView had an input connection: $served — false means the request was " +
+                "very likely dropped before reaching the IME; on an emulator make sure " +
+                "`settings put secure show_ime_with_hard_keyboard 1` ran)",
         ) { it.keyboardOpenPerListener }
     }
 
@@ -350,6 +394,7 @@ class ImeInsetShimInstrumentedTest {
         const val DEFAULT_TIMEOUT_SECONDS = 10L
         const val SHOW_IME_FIRST_TRY_SECONDS = 5L
         const val POLL_MS = 50L
+        const val SERVED_POLL_MS = 200L
         const val SETTLE_MS = 300L
         // Sub-pixel rounding between the visible frame and the view bottom.
         const val TOLERANCE_PX = 2

--- a/e2e/tests/migration/legacy-genesis-replay-9863.spec.ts
+++ b/e2e/tests/migration/legacy-genesis-replay-9863.spec.ts
@@ -1,0 +1,158 @@
+import { test, expect, Page } from '@playwright/test';
+import { CURRENT_SCHEMA_VERSION } from '@sp/shared-schema';
+import legacyData from '../../fixtures/legacy-full-migration-backup.json';
+import { skipOnboardingForE2E } from '../../utils/waits';
+import { WorkViewPage } from '../../pages/work-view.page';
+import { TaskPage } from '../../pages/task.page';
+import {
+  createLegacyMigratedClient,
+  closeLegacyClient,
+  readMigratedState,
+} from '../../utils/legacy-migration-helpers';
+
+/**
+ * Issue #9863 (follow-up finding): a legacy-migrated client's op-log opens
+ * with a MIGRATION genesis op that carries the whole pre-migration state. No
+ * reducer handled that op, so whenever the hydrator had to rebuild state from
+ * the log — here: a corrupt `state_cache` snapshot, the #7892 path — every
+ * task from before the app update vanished and only post-migration tasks
+ * survived. That path then PERSISTED the truncated state as the new snapshot,
+ * so the loss was permanent.
+ *
+ * The unit and integration specs pin the reducer wiring. This test is the
+ * end-to-end claim: real legacy data on disk, a real migration, a real corrupt
+ * snapshot, and the user's tasks still on screen after the reboot.
+ *
+ * Run: npm run e2e:file e2e/tests/migration/legacy-genesis-replay-9863.spec.ts -- --retries=0
+ */
+
+const PRE_MIGRATION_TASK = 'Legacy Migration - Standalone Task';
+const POST_MIGRATION_TASK = 'created-after-migration-9863';
+
+type MigratedState = {
+  task?: { ids: string[]; entities: Record<string, { title?: string }> };
+};
+
+/**
+ * Overwrite the snapshot with one `isValidSnapshot()` rejects (no core
+ * models in `state`) at the CURRENT schema version, so boot takes the
+ * corrupt-snapshot branch rather than the #9140 schema-migration fallback.
+ * `lastAppliedOpSeq` is pushed past every real op so the tasks can only come
+ * back through a replay from seq 0.
+ */
+const seedCorruptSnapshot = async (page: Page): Promise<string> =>
+  page.evaluate(
+    async ({ schemaVersion }) =>
+      new Promise<string>((resolve) => {
+        const timer = setTimeout(() => resolve('TIMEOUT'), 10000);
+        const done = (msg: string): void => {
+          clearTimeout(timer);
+          resolve(msg);
+        };
+        const req = indexedDB.open('SUP_OPS');
+        req.onblocked = () => done('BLOCKED');
+        req.onerror = () => done('OPEN-ERROR');
+        req.onsuccess = () => {
+          const db = req.result;
+          const tx = db.transaction('state_cache', 'readwrite');
+          tx.onabort = () => done('TX-ABORT');
+          const store = tx.objectStore('state_cache');
+          const row = {
+            id: 'current',
+            state: {},
+            lastAppliedOpSeq: 9999,
+            vectorClock: {},
+            compactedAt: Date.now(),
+            schemaVersion,
+          };
+          let putReq: IDBRequest;
+          try {
+            putReq = store.keyPath ? store.put(row) : store.put(row, 'current');
+          } catch (e) {
+            db.close();
+            done('PUT-THREW:' + String(e));
+            return;
+          }
+          putReq.onsuccess = () => {
+            db.close();
+            done('OK');
+          };
+          putReq.onerror = () => {
+            db.close();
+            done('PUT-ERROR:' + String(putReq.error));
+          };
+        };
+      }),
+    { schemaVersion: CURRENT_SCHEMA_VERSION },
+  );
+
+const migratedTaskTitles = async (page: Page): Promise<string[]> => {
+  const state = await readMigratedState<MigratedState>(page);
+  return (state.task?.ids ?? []).map((id) => state.task?.entities[id]?.title ?? '');
+};
+
+test.describe('@migration #9863 genesis op replay after snapshot loss', () => {
+  test('keeps pre-migration tasks when the snapshot is corrupt and the op-log is replayed', async ({
+    browser,
+    baseURL,
+  }) => {
+    const client = await createLegacyMigratedClient(
+      browser,
+      baseURL || 'http://localhost:4242',
+      legacyData.data,
+      'genesis-replay',
+    );
+    const { page } = client;
+    await page.addInitScript(skipOnboardingForE2E);
+    const workViewPage = new WorkViewPage(page);
+    const taskPage = new TaskPage(page);
+
+    try {
+      // Post-migration op on top of the genesis op: this is what used to
+      // survive the rebuild while everything older was dropped.
+      await page.goto('/#/project/TEST_PROJECT/tasks');
+      await workViewPage.waitForTaskList();
+      await expect(taskPage.getTaskByText(PRE_MIGRATION_TASK)).toBeVisible();
+      await workViewPage.addTask(POST_MIGRATION_TASK);
+      await expect(taskPage.getTaskByText(POST_MIGRATION_TASK)).toBeVisible();
+
+      expect(await seedCorruptSnapshot(page)).toBe('OK');
+
+      const consoleLines: string[] = [];
+      page.on('console', (msg) => consoleLines.push(msg.text()));
+
+      await page.reload();
+      await page.waitForLoadState('networkidle');
+      await page.goto('/#/project/TEST_PROJECT/tasks');
+      await workViewPage.waitForTaskList();
+
+      // The corrupt-snapshot branch handled the boot, not some other path.
+      expect(
+        consoleLines.some((line) =>
+          line.includes('Discarding corrupt snapshot and replaying the op-log'),
+        ),
+      ).toBe(true);
+
+      // Both generations of data are back. Pre-fix: only the second one.
+      await expect(taskPage.getTaskByText(POST_MIGRATION_TASK)).toBeVisible();
+      await expect(taskPage.getTaskByText(PRE_MIGRATION_TASK)).toBeVisible();
+
+      // This branch writes the rebuilt state back as the new snapshot, so the
+      // on-disk copy must hold the legacy tasks too — that is where the loss
+      // used to become permanent.
+      await expect
+        .poll(() => migratedTaskTitles(page), { timeout: 15000 })
+        .toEqual(expect.arrayContaining([PRE_MIGRATION_TASK, POST_MIGRATION_TASK]));
+
+      // A plain second boot reads that snapshot and shows the same data.
+      await page.reload();
+      await page.waitForLoadState('networkidle');
+      await page.goto('/#/project/TEST_PROJECT/tasks');
+      await workViewPage.waitForTaskList();
+      await expect(taskPage.getTaskByText(PRE_MIGRATION_TASK)).toBeVisible();
+      await expect(taskPage.getTaskByText(POST_MIGRATION_TASK)).toBeVisible();
+    } finally {
+      await closeLegacyClient(client);
+    }
+  });
+});

--- a/src/app/op-log/apply/bulk-hydration.meta-reducer.ts
+++ b/src/app/op-log/apply/bulk-hydration.meta-reducer.ts
@@ -11,7 +11,7 @@ import {
 import { OpLog } from '../../core/log';
 import { runWithBulkReplayLoggingSuppressed } from '../../util/bulk-replay-log-guard';
 import { reportBulkReplayReducerFailure } from './bulk-replay-failure-collector';
-import { isFullStateOpType } from '../core/operation.types';
+import { isFullStateOpType, isGenesisEntityType } from '../core/operation.types';
 
 /**
  * Meta-reducer that applies multiple operations in a single reducer pass.
@@ -122,6 +122,19 @@ export const bulkOperationsMetaReducer = <T>(
           let currentState = state;
           let shouldReplayWithoutFailedOperations = false;
           for (const op of candidateOps) {
+            // #9863: the client's OWN genesis op (legacy `pf` → op-log
+            // migration, disaster recovery) carries the complete pre-migration
+            // state and is the only place in the log that does. Replaying it
+            // as the inert no-op it must remain for every OTHER client would
+            // rebuild the store with post-migration data only — and the
+            // corrupt-snapshot path then persists that truncated state. Gate
+            // strictly on a KNOWN matching clientId: an unknown localClientId
+            // keeps the op inert (the pre-fix behaviour) rather than risking a
+            // foreign genesis op replacing this device's state mid-log.
+            const isOwnGenesisOp =
+              !!localClientId &&
+              op.clientId === localClientId &&
+              isGenesisEntityType(op.entityType);
             try {
               const isLww = hasArchives && isLwwUpdateActionType(op.actionType);
               const recreatesEntityAfterDelete =
@@ -150,7 +163,9 @@ export const bulkOperationsMetaReducer = <T>(
                     archivingOrDeletingEntityIds,
                   )
                 : op;
-              const opAction = convertOpToAction(opForApply);
+              const opAction = convertOpToAction(opForApply, {
+                replayAsFullState: isOwnGenesisOp,
+              });
               // Mark ops authored by a DIFFERENT client so reducers can preserve
               // per-device "local-only" settings against remote overwrites — while
               // replaying the device's OWN ops faithfully.
@@ -179,7 +194,7 @@ export const bulkOperationsMetaReducer = <T>(
               currentState = reducer(currentState, finalAction);
             } catch (error) {
               const isNewFailure = reportFailure(op, error);
-              if (isFullStateOpType(op.opType)) {
+              if (isFullStateOpType(op.opType) || isOwnGenesisOp) {
                 // A full-state operation replaces the entire model. Continuing
                 // from the pre-import state would expose a projection that never
                 // existed in the log, so discard the speculative batch.

--- a/src/app/op-log/apply/operation-converter.util.ts
+++ b/src/app/op-log/apply/operation-converter.util.ts
@@ -251,6 +251,17 @@ const assertValidTaskTimeSyncPayload = (
   }
 };
 
+export interface ConvertOpToActionOptions {
+  /**
+   * Replay this op as a full-state `loadAllData` even though its opType is not
+   * a full-state type. Set by the bulk meta-reducer for the client's OWN
+   * genesis op (#9863): its payload is the complete pre-migration state and
+   * nothing else in the log carries it, so replaying it as a no-op would
+   * rebuild the store with only post-migration data.
+   */
+  replayAsFullState?: boolean;
+}
+
 /**
  * Converts an Operation from the operation log back into a PersistentAction.
  * Used during sync replay and recovery to re-dispatch operations.
@@ -262,14 +273,18 @@ const assertValidTaskTimeSyncPayload = (
  * For full-state operations (SYNC_IMPORT, BACKUP_IMPORT, Repair), this wraps
  * the payload in `appDataComplete` to match the loadAllData action format.
  */
-export const convertOpToAction = (op: Operation): PersistentAction => {
+export const convertOpToAction = (
+  op: Operation,
+  options: ConvertOpToActionOptions = {},
+): PersistentAction => {
   // Resolve any aliased action types to their current names
   const actionType = ACTION_TYPE_ALIASES[op.actionType] ?? op.actionType;
   const lwwEntityType = getLwwEntityType(actionType);
 
   // Handle full-state operations (SYNC_IMPORT, BACKUP_IMPORT, Repair) specially
   // These need their payload wrapped in appDataComplete for the loadAllData action
-  const isFullStateOp = FULL_STATE_OP_TYPES.has(op.opType as OpType);
+  const isFullStateOp =
+    FULL_STATE_OP_TYPES.has(op.opType as OpType) || options.replayAsFullState === true;
   const isSingletonLww =
     !isFullStateOp &&
     lwwEntityType !== undefined &&

--- a/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
@@ -1805,6 +1805,46 @@ describe('OperationLogHydratorService', () => {
         );
       });
 
+      // #9863: a legacy-migrated client's log opens with its own MIGRATION
+      // genesis op. The corrupt-snapshot rebuild must hand that op to the bulk
+      // replay together with the local client id (the meta-reducer's ownership
+      // gate turns it into loadAllData), and must then persist the rebuilt
+      // state — this is the one replay path that writes its result back.
+      it('replays an own MIGRATION genesis op through the bulk apply and persists the rebuilt snapshot (#9863)', async () => {
+        mockOpLogStore.loadStateCache.and.resolveTo(createMockSnapshot());
+        mockSnapshotService.isValidSnapshot.and.returnValue(false);
+
+        const localClientId = 'test-client';
+        const genesisOp = createMockOperation('genesis-op', OpType.Batch, {
+          actionType: ActionType.MIGRATION_GENESIS_IMPORT,
+          entityType: 'MIGRATION',
+          entityId: '*',
+          payload: { task: { ids: ['pre-migration-task'], entities: {} } },
+          clientId: localClientId,
+          vectorClock: { [localClientId]: 1 },
+        });
+        const postMigrationOp = createMockOperation('post-migration-op', OpType.Create, {
+          clientId: localClientId,
+          vectorClock: { [localClientId]: 2 },
+        });
+        mockOpLogStore.getLastSeq.and.resolveTo(2);
+        mockOpLogStore.getOpsAfterSeq.and.resolveTo([
+          createMockEntry(1, genesisOp),
+          createMockEntry(2, postMigrationOp),
+        ]);
+
+        await service.hydrateStore();
+
+        expect(mockRecoveryService.attemptRecovery).not.toHaveBeenCalled();
+        expect(mockStore.dispatch).toHaveBeenCalledWith(
+          bulkApplyHydrationOperations({
+            operations: [genesisOp, postMigrationOp],
+            localClientId,
+          }),
+        );
+        expect(mockSnapshotService.saveCurrentStateAsSnapshot).toHaveBeenCalled();
+      });
+
       it('should attempt recovery for an invalid snapshot only when no ops exist (lastSeq === 0) (#7892)', async () => {
         const invalidSnapshot = createMockSnapshot();
         mockOpLogStore.loadStateCache.and.returnValue(Promise.resolve(invalidSnapshot));

--- a/src/app/op-log/testing/integration/migration-genesis-replay.integration.spec.ts
+++ b/src/app/op-log/testing/integration/migration-genesis-replay.integration.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * #9863 (follow-up finding): replaying the op-log from seq 0 used to drop every
+ * task that lived on the device BEFORE the legacy `pf` → op-log migration.
+ *
+ * The migration writes a single MIGRATION genesis op whose payload is the
+ * entire pre-migration state, and then dispatches `loadAllData` directly. No
+ * reducer handles the genesis action type, so a rebuild from the log (corrupt
+ * snapshot → #7892 path, or the #9140 fallback) reconstructed only what came
+ * AFTER the migration — and the corrupt-snapshot path then persisted that.
+ *
+ * The bulk meta-reducer now replays the client's OWN genesis op as a full-state
+ * `loadAllData`. It must stay inert for any OTHER client's genesis op (#9921)
+ * and when the local client id is unknown.
+ *
+ * Drives the REAL apply chain: `bulkApplyOperations` →
+ * `bulkOperationsMetaReducer` → `taskSharedCrudMetaReducer` → `taskReducer`,
+ * with the genesis op built exactly as `OperationLogMigrationService` does.
+ */
+import { Action, ActionReducer } from '@ngrx/store';
+import { bulkOperationsMetaReducer } from '../../apply/bulk-hydration.meta-reducer';
+import { bulkApplyOperations } from '../../apply/bulk-hydration.action';
+import { ActionType, Operation, OpType } from '../../core/operation.types';
+import { SINGLETON_ENTITY_ID } from '../../core/entity-registry';
+import { taskSharedCrudMetaReducer } from '../../../root-store/meta/task-shared-meta-reducers/task-shared-crud.reducer';
+import {
+  createBaseState,
+  createMockTask,
+} from '../../../root-store/meta/task-shared-meta-reducers/test-utils';
+import { RootState } from '../../../root-store/root-state';
+import {
+  TASK_FEATURE_NAME,
+  taskReducer,
+} from '../../../features/tasks/store/task.reducer';
+import { WorkContextType } from '../../../features/work-context/work-context.model';
+import { createValidAppData } from '../../validation/state-validity-test-utils';
+import { CURRENT_SCHEMA_VERSION } from '../../persistence/schema-migration.service';
+
+describe('MIGRATION genesis op replay-from-scratch (#9863)', () => {
+  const CLIENT_ID = 'legacy-client';
+  const PRE_MIGRATION_TASK_ID = 'task-from-before-the-update';
+  const POST_MIGRATION_TASK_ID = 'task-created-after-the-update';
+
+  // Real feature reducer for the task slice; everything else passes through.
+  const featureReducer: ActionReducer<RootState, Action> = (state, action) => {
+    const current = state ?? createBaseState();
+    return {
+      ...current,
+      [TASK_FEATURE_NAME]: taskReducer(current[TASK_FEATURE_NAME], action),
+    };
+  };
+  const rootReducer = bulkOperationsMetaReducer(
+    taskSharedCrudMetaReducer(featureReducer),
+  ) as ActionReducer<RootState, Action>;
+
+  const preMigrationTask = createMockTask({
+    id: PRE_MIGRATION_TASK_ID,
+    title: 'Existed on Android before the op-log migration',
+  });
+
+  // Mirrors OperationLogMigrationService._performMigration step 4.
+  const createGenesisOp = (): Operation => ({
+    id: 'genesis-op',
+    actionType: ActionType.MIGRATION_GENESIS_IMPORT,
+    opType: OpType.Batch,
+    entityType: 'MIGRATION',
+    entityId: SINGLETON_ENTITY_ID,
+    payload: createValidAppData({
+      task: {
+        ...createBaseState()[TASK_FEATURE_NAME],
+        ids: [PRE_MIGRATION_TASK_ID],
+        entities: { [PRE_MIGRATION_TASK_ID]: preMigrationTask },
+      },
+    }),
+    clientId: CLIENT_ID,
+    vectorClock: { [CLIENT_ID]: 1 },
+    timestamp: 1_000,
+    schemaVersion: CURRENT_SCHEMA_VERSION,
+  });
+
+  // Same payload, but as a full-state op type the replay already understands.
+  const createSyncImportOp = (): Operation => ({
+    ...createGenesisOp(),
+    id: 'sync-import-op',
+    actionType: ActionType.LOAD_ALL_DATA,
+    opType: OpType.SyncImport,
+    entityType: 'ALL',
+  });
+
+  const createPostMigrationAddOp = (): Operation => ({
+    id: 'post-migration-add',
+    actionType: ActionType.TASK_SHARED_ADD,
+    opType: OpType.Create,
+    entityType: 'TASK',
+    entityId: POST_MIGRATION_TASK_ID,
+    payload: {
+      actionPayload: {
+        task: createMockTask({
+          id: POST_MIGRATION_TASK_ID,
+          title: 'Created after the migration',
+        }),
+        workContextId: 'project1',
+        workContextType: WorkContextType.PROJECT,
+        isAddToBacklog: false,
+        isAddToBottom: false,
+      },
+      entityChanges: [],
+    },
+    clientId: CLIENT_ID,
+    vectorClock: { [CLIENT_ID]: 2 },
+    timestamp: 2_000,
+    schemaVersion: CURRENT_SCHEMA_VERSION,
+  });
+
+  // Options object rather than a defaulted param: an explicit `undefined`
+  // argument would trigger the default and silently reinstate the client id.
+  const replayFromScratch = (
+    operations: Operation[],
+    { localClientId }: { localClientId: string | undefined } = {
+      localClientId: CLIENT_ID,
+    },
+  ): RootState =>
+    rootReducer(createBaseState(), bulkApplyOperations({ operations, localClientId }));
+
+  it('control: a full-state SyncImport op followed by an add keeps both tasks', () => {
+    const state = replayFromScratch([createSyncImportOp(), createPostMigrationAddOp()]);
+
+    expect(state[TASK_FEATURE_NAME].ids).toEqual(
+      jasmine.arrayWithExactContents([PRE_MIGRATION_TASK_ID, POST_MIGRATION_TASK_ID]),
+    );
+  });
+
+  it('keeps the pre-migration tasks when the log opens with an own MIGRATION genesis op', () => {
+    const state = replayFromScratch([createGenesisOp(), createPostMigrationAddOp()]);
+
+    // The post-migration task proves the replay ran; the pre-migration task
+    // is the one that vanishes today.
+    expect(state[TASK_FEATURE_NAME].entities[POST_MIGRATION_TASK_ID]).toBeDefined();
+    expect(state[TASK_FEATURE_NAME].entities[PRE_MIGRATION_TASK_ID]).toBeDefined();
+    expect(state[TASK_FEATURE_NAME].ids).toEqual(
+      jasmine.arrayWithExactContents([PRE_MIGRATION_TASK_ID, POST_MIGRATION_TASK_ID]),
+    );
+  });
+
+  it('keeps a RECOVERY genesis op on the same path as MIGRATION', () => {
+    const recoveryGenesis: Operation = {
+      ...createGenesisOp(),
+      actionType: ActionType.RECOVERY_DATA_IMPORT,
+      entityType: 'RECOVERY',
+    };
+    const state = replayFromScratch([recoveryGenesis, createPostMigrationAddOp()]);
+
+    expect(state[TASK_FEATURE_NAME].ids).toEqual(
+      jasmine.arrayWithExactContents([PRE_MIGRATION_TASK_ID, POST_MIGRATION_TASK_ID]),
+    );
+  });
+
+  // A genesis op is local bookkeeping, not sync history: another device's
+  // genesis must never replace this device's state (#9921).
+  it("leaves another client's genesis op inert", () => {
+    const foreignGenesis: Operation = {
+      ...createGenesisOp(),
+      clientId: 'someOtherDevice',
+      vectorClock: { someOtherDevice: 1 },
+    };
+    const state = replayFromScratch([foreignGenesis, createPostMigrationAddOp()]);
+
+    expect(state[TASK_FEATURE_NAME].ids).toEqual([POST_MIGRATION_TASK_ID]);
+  });
+
+  // Ownership cannot be established without a local client id, so the op
+  // stays inert (the pre-fix behaviour) rather than risking a foreign genesis
+  // replacing local state mid-log.
+  it('leaves the genesis op inert when the local client id is unknown', () => {
+    const state = replayFromScratch([createGenesisOp(), createPostMigrationAddOp()], {
+      localClientId: undefined,
+    });
+
+    expect(state[TASK_FEATURE_NAME].ids).toEqual([POST_MIGRATION_TASK_ID]);
+  });
+});


### PR DESCRIPTION
Fixes #10051. Follow-up to #9863 (does not close it).

## Problem

A client migrated from the legacy `pf` database has a `MIGRATION` genesis op as its first log entry. Its payload is the entire pre-migration state, and nothing else in the log carries that data. No reducer handled the genesis action type, so whenever the hydrator rebuilt state from the log instead of the snapshot, it reconstructed only what came *after* the migration.

The corrupt-snapshot branch (#7892 path) then persisted that truncated state as the new snapshot, making the loss permanent. Observable symptom: everything from before the app update gone, everything created after it intact.

## Fix

The bulk meta-reducer replays the client's **own** genesis op (MIGRATION or RECOVERY) as a full-state `loadAllData`. Ownership is gated on a known, matching `localClientId`:

- another client's genesis op stays inert, as #9921 requires
- an unknown local client id keeps the op inert (pre-fix behaviour) rather than risk a foreign genesis replacing local state mid-log
- if the `loadAllData` reducer throws, the batch is discarded like any other full-state op

`convertOpToAction` gains an optional `replayAsFullState` flag so the genesis payload goes through the existing full-state wrapping.

Remote paths checked: SuperSync never uploads genesis ops. File-based providers do, but on both normal and USE_REMOTE download they land in the snapshot-covered partition, which is recorded and never dispatched.

## Tests

- **Integration** `migration-genesis-replay.integration.spec.ts`: real bulk-replay chain with the genesis op built as the migration service builds it. Own MIGRATION and RECOVERY genesis keep pre-migration tasks; foreign genesis and unknown client id stay inert; SyncImport control.
- **Unit** `operation-log-hydrator.service.spec.ts`: corrupt snapshot plus own genesis reaches the bulk replay with the local client id and the rebuilt snapshot is saved.
- **E2E** `legacy-genesis-replay-9863.spec.ts`: seeds the legacy fixture, migrates, adds a task, corrupts `state_cache`, reboots. Asserts both generations of tasks on screen and in the rebuilt on-disk snapshot, plus a stable second boot.

The integration spec and the E2E both fail on the pre-fix code and pass with it (E2E verified against a temporary revert). Full `src/app/op-log/**` suite green.

## Sync-risk notes

Only replay of a client's own genesis op changes, which previously did nothing. A normal boot never reaches it: the migration writes the snapshot frontier at the genesis seq, so the tail replay excludes it. No schema bump, no wire format change.

https://claude.ai/code/session_017DxcPHFSU1n5u9Cwce4aat
