### PR TITLE
feat(supersync): report client app version for the checkpoint gate (#9962)

### DIFF
--- a/android/app/src/androidTest/java/com/superproductivity/superproductivity/ImeInsetShimInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/superproductivity/superproductivity/ImeInsetShimInstrumentedTest.kt
@@ -208,17 +208,52 @@ class ImeInsetShimInstrumentedTest {
         }
     }
 
-    private fun showIme(activity: CapacitorMainActivity, webView: WebView) {
+    /** Focuses the field and asks for the IME. Returns whether an input connection existed. */
+    private fun showIme(activity: CapacitorMainActivity, webView: WebView): Boolean {
         // View focus first, then the editable inside it, then the request: a
         // programmatic focus() without a user gesture does not raise the IME by
         // itself, and show(ime()) needs an editor attached to the focused view.
         onMainSync { webView.requestFocus() }
         evaluateJavaScript(webView, "document.getElementById('field').focus(); 'focused'")
+        // The JS focus returning is not enough: the input connection only exists
+        // once the renderer has reported the focused editable back to the browser
+        // process, which is asynchronous and can lag seconds on a loaded emulator.
+        // A request issued before then is dropped outright — "Ignoring
+        // showSoftInput() as view ... is not served", the whole failure in run
+        // 33975587718 — so wait for the connection instead of racing it.
+        val served = awaitServedView(activity, webView)
         onMainSync {
             WindowInsetsControllerCompat(activity.window, webView)
                 .show(WindowInsetsCompat.Type.ime())
         }
+        return served
     }
+
+    /**
+     * Waits until the IME has an input connection to [webView], i.e. a show
+     * request would reach the IME instead of being ignored. Reports a miss
+     * rather than failing on it, so that a genuine never-opens failure still
+     * fails on the geometry with the full reading rather than dying here.
+     */
+    private fun awaitServedView(
+        activity: CapacitorMainActivity,
+        webView: WebView,
+        timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS,
+    ): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + TimeUnit.SECONDS.toMillis(timeoutSeconds)
+        do {
+            if (onMainSync { inputMethodManager(activity).isActive(webView) }) return true
+            // Coarser than POLL_MS: isActive() can hit system_server synchronously,
+            // and this wait exists for the case where that server is already the
+            // slow part. Detection latency does not matter at this granularity.
+            SystemClock.sleep(SERVED_POLL_MS)
+        } while (SystemClock.elapsedRealtime() < deadline)
+        Log.i(TAG, "WebView still has no input connection after ${timeoutSeconds}s")
+        return false
+    }
+
+    private fun inputMethodManager(activity: CapacitorMainActivity): InputMethodManager =
+        activity.getSystemService(InputMethodManager::class.java)
 
     private fun hideIme(activity: CapacitorMainActivity, webView: WebView) {
         evaluateJavaScript(webView, "document.getElementById('field').blur(); 'blurred'")
@@ -238,16 +273,25 @@ class ImeInsetShimInstrumentedTest {
             it.keyboardOpenPerListener
         }
         if (first != null) return first
-        Log.i(TAG, "IME not open after show(ime()); retrying via InputMethodManager")
+        // Re-enter the whole sequence rather than re-issuing show() alone: what
+        // the retry is really for is the second wait for an input connection,
+        // since the likeliest reason the first request did nothing is that there
+        // was none yet. (The JS focus it repeats is a no-op while the field still
+        // holds focus — the focusing steps return early and the renderer re-reports
+        // nothing — so the wait, not the focus, is what makes this retry worth a try.)
+        Log.i(TAG, "IME not open after show(ime()); retrying the request and the wait")
+        val served = showIme(activity, webView)
         onMainSync {
-            activity.getSystemService(InputMethodManager::class.java)
+            inputMethodManager(activity)
                 .showSoftInput(webView, InputMethodManager.SHOW_IMPLICIT)
         }
         return awaitGeometry(
             activity,
             webView,
             "the IME to open (visible frame must drop by more than 15% of the root height; " +
-                "on an emulator make sure `settings put secure show_ime_with_hard_keyboard 1` ran)",
+                "WebView had an input connection: $served — false means the request was " +
+                "very likely dropped before reaching the IME; on an emulator make sure " +
+                "`settings put secure show_ime_with_hard_keyboard 1` ran)",
         ) { it.keyboardOpenPerListener }
     }
 
@@ -350,6 +394,7 @@ class ImeInsetShimInstrumentedTest {
         const val DEFAULT_TIMEOUT_SECONDS = 10L
         const val SHOW_IME_FIRST_TRY_SECONDS = 5L
         const val POLL_MS = 50L
+        const val SERVED_POLL_MS = 200L
         const val SETTLE_MS = 300L
         // Sub-pixel rounding between the visible frame and the view bottom.
         const val TOLERANCE_PX = 2

--- a/packages/shared-schema/src/supersync-http-contract.ts
+++ b/packages/shared-schema/src/supersync-http-contract.ts
@@ -165,6 +165,14 @@ export const SuperSyncDownloadOpsQuerySchema = z.object({
   sinceSeq: z.coerce.number().int().min(0),
   limit: z.coerce.number().int().min(1).max(1000).optional(),
   excludeClient: SuperSyncClientIdSchema.optional(),
+  /**
+   * Bare semver of the calling app (`18.22.0`), recorded per device for the
+   * server's checkpoint gate (#9962). A query parameter rather than a header
+   * so browser clients need no new CORS allowance from older servers, which
+   * strip it as an unknown key. Loosely typed on purpose: the server drops a
+   * malformed value instead of failing the download.
+   */
+  appVersion: z.string().optional(),
 });
 
 export const SuperSyncUploadSnapshotRequestSchema = z

--- a/packages/super-sync-server/docs/architecture.md
+++ b/packages/super-sync-server/docs/architecture.md
@@ -101,9 +101,11 @@ This serialization mechanism is a load-bearing decision; see
   data deletion can remove them.
 - `user_sync_state` owns `lastSeq`, the optional compressed snapshot cache, the
   latest causal full-state marker, and the latest explicit state-replacement
-  boundary. `sync_devices` is used only for per-device identity/metadata and
-  last-seen tracking. Its `lastAckedSeq` field is dormant legacy schema state:
-  current sync and retention code neither advances nor reads it.
+  boundary. `sync_devices` is used only for per-device identity/metadata,
+  last-seen tracking, and the client-reported `app_version` (a bare semver,
+  never exposed) that feeds the checkpoint gate below. Its `lastAckedSeq`
+  field is dormant legacy schema state: current sync and retention code
+  neither advances nor reads it.
 - Normal sync bootstraps from operation rows. `GET /ops` can fast-forward to the
   latest causal full-state operation; clients do not download the server's
   cached snapshot blob.
@@ -129,10 +131,15 @@ This serialization mechanism is a load-bearing decision; see
   recovery uses a
   separate bounded cleanup policy.
 - Routine incremental sync does not create periodic full-state boundaries.
-  Adding a client cadence requires a compatibility design (#9962): released
-  v18.14.0 clients accept schema-4 operations but treat `REPAIR` as a reset and
-  discard concurrent edits. Reusing current repair semantics alone cannot safely
-  enable automatic checkpoints for accounts with those clients.
+  Adding a client cadence requires a compatibility design (#9962): every
+  release before v18.21.2 treats `REPAIR` as a reset and discards concurrent
+  edits. Reusing current repair semantics alone cannot safely enable automatic
+  checkpoints for accounts with those clients. The prerequisite is in place:
+  clients report their version on download, `sync_devices.app_version` stores
+  it, and `checkpoint-gate.ts` decides per account whether every device seen
+  inside retention is at or above the cut (a device with no reported version
+  counts as old). The daily cleanup logs the fleet-wide roll-up as
+  `Cleanup [checkpoint-gate]`; no client uploads checkpoints yet.
 - Server-generated restore is unavailable when the required replay range
   contains encrypted operations.
 

--- a/packages/super-sync-server/prisma/migrations/20260911000000_add_sync_device_app_version/migration.sql
+++ b/packages/super-sync-server/prisma/migrations/20260911000000_add_sync_device_app_version/migration.sql
@@ -1,0 +1,10 @@
+-- Client-reported app version per device (#9962). Automatic full-state
+-- checkpoints are only safe for an account once every client that still syncs
+-- it runs a release whose REPAIR handling keeps concurrent edits (v18.21.2+);
+-- this column is what the gate reads (src/sync/checkpoint-gate.ts).
+--
+-- Nullable, no default: ADD COLUMN without a default is a catalog-only change
+-- on PostgreSQL (no table rewrite, no backfill). sync_devices is small (one
+-- row per device inside retention), so no CONCURRENTLY shape is needed either.
+-- Devices that never report a version keep NULL and count as old.
+ALTER TABLE "sync_devices" ADD COLUMN "app_version" TEXT;

--- a/packages/super-sync-server/prisma/schema.prisma
+++ b/packages/super-sync-server/prisma/schema.prisma
@@ -151,6 +151,9 @@ model SyncDevice {
   userId       Int     @map("user_id")
   deviceName   String? @map("device_name")
   userAgent    String? @map("user_agent")
+  /// Bare semver the client last reported on download (`18.22.0`), NULL until
+  /// it does. Read by the checkpoint gate (#9962); never shown to users.
+  appVersion   String? @map("app_version")
   lastSeenAt   BigInt  @map("last_seen_at")
   /// Reserved: written once at device registration, never read or updated.
   lastAckedSeq Int     @default(0) @map("last_acked_seq")

--- a/packages/super-sync-server/src/sync/checkpoint-gate.ts
+++ b/packages/super-sync-server/src/sync/checkpoint-gate.ts
@@ -1,0 +1,139 @@
+/**
+ * Client-checkpoint gate (#9962).
+ *
+ * Under mandatory E2EE only a client can create the causal full-state
+ * boundary that authorizes the old-ops sweep to prune a user's history, and
+ * routine incremental sync never creates one. An automatic checkpoint cadence
+ * would fix that, but releases before v18.21.2 treat a REPAIR op as a full
+ * reset and drop offline edits concurrent with it (the narrower REPAIR
+ * semantics landed in 78a459294104, first shipped in v18.21.2). So a cadence
+ * may only ever be enabled for an account whose every active device runs a
+ * release at or above that cut.
+ *
+ * Clients report their bare semver as the `appVersion` query parameter on the
+ * download path (sync.routes.ts → DeviceService.touchDevice). A device with
+ * no reported version counts as old: every release that reports one is newer
+ * than the cut, so silence can only mean a pre-reporting client.
+ *
+ * Pure functions only; the per-account and fleet-wide queries live in
+ * DeviceService.
+ */
+
+export const MIN_CHECKPOINT_SAFE_APP_VERSION = '18.21.2';
+
+/**
+ * Longest version string the server stores. Longer values are dropped, not
+ * truncated, so a stored value is always a complete, parseable version.
+ */
+const MAX_APP_VERSION_LENGTH = 32;
+// `MAJOR.MINOR.PATCH` with an optional prerelease tag (`18.23.0-beta.1`).
+const APP_VERSION_RE = /^(\d{1,4})\.(\d{1,4})\.(\d{1,4})(-[0-9A-Za-z.-]+)?$/;
+
+/**
+ * Accepts a client-supplied version for storage, or `undefined` when it is
+ * absent or not a version. Deliberately lenient about presence and strict
+ * about shape: a malformed value must never fail the download it rides on,
+ * and an unparseable stored value would only ever count as old anyway.
+ */
+export const parseAppVersion = (raw: unknown): string | undefined =>
+  typeof raw === 'string' &&
+  raw.length <= MAX_APP_VERSION_LENGTH &&
+  APP_VERSION_RE.test(raw)
+    ? raw
+    : undefined;
+
+interface ParsedVersion {
+  tuple: [number, number, number];
+  isPrerelease: boolean;
+}
+
+const toParsedVersion = (version: string): ParsedVersion | undefined => {
+  const match = APP_VERSION_RE.exec(version);
+  if (!match) {
+    return undefined;
+  }
+  return {
+    tuple: [Number(match[1]), Number(match[2]), Number(match[3])],
+    isPrerelease: match[4] !== undefined,
+  };
+};
+
+const compareTuples = (a: readonly number[], b: readonly number[]): number => {
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return a[i] - b[i];
+    }
+  }
+  return 0;
+};
+
+const MIN_SAFE = toParsedVersion(MIN_CHECKPOINT_SAFE_APP_VERSION)!;
+
+/**
+ * Whether one reported version keeps concurrent edits across a REPAIR.
+ * A prerelease of the cut itself (`18.21.2-beta.1`) may predate the fix and
+ * counts as old; a prerelease of any later version is fine.
+ */
+export const isCheckpointSafeAppVersion = (
+  appVersion: string | null | undefined,
+): boolean => {
+  const parsed = appVersion ? toParsedVersion(appVersion) : undefined;
+  if (!parsed) {
+    return false;
+  }
+  const cmp = compareTuples(parsed.tuple, MIN_SAFE.tuple);
+  return cmp > 0 || (cmp === 0 && !parsed.isPrerelease);
+};
+
+export interface CheckpointGateDevice {
+  appVersion: string | null;
+}
+
+/**
+ * Whether every device of an account is checkpoint-safe. An account with no
+ * device inside the window is NOT safe: there is nobody to create a
+ * checkpoint for, and "no devices" must never read as "all devices agree".
+ */
+export const isAccountCheckpointSafe = (
+  devices: readonly CheckpointGateDevice[],
+): boolean =>
+  devices.length > 0 && devices.every((d) => isCheckpointSafeAppVersion(d.appVersion));
+
+export interface CheckpointGateFleetSummary {
+  /** Accounts with at least one device in the window whose devices are all safe. */
+  safeAccounts: number;
+  /** Accounts with at least one device in the window. */
+  totalAccounts: number;
+  /** Devices in the window that never reported a version. */
+  unversionedDevices: number;
+}
+
+/**
+ * Fleet-wide roll-up of the gate over one row per device in the window. This
+ * is the number that decides when a cadence can be switched on, so it is
+ * logged by the daily cleanup unconditionally.
+ */
+export const summarizeCheckpointGate = (
+  devices: readonly (CheckpointGateDevice & { userId: number })[],
+): CheckpointGateFleetSummary => {
+  const byUser = new Map<number, CheckpointGateDevice[]>();
+  let unversionedDevices = 0;
+  for (const device of devices) {
+    if (device.appVersion === null) {
+      unversionedDevices++;
+    }
+    const list = byUser.get(device.userId);
+    if (list) {
+      list.push(device);
+    } else {
+      byUser.set(device.userId, [device]);
+    }
+  }
+  let safeAccounts = 0;
+  for (const list of byUser.values()) {
+    if (isAccountCheckpointSafe(list)) {
+      safeAccounts++;
+    }
+  }
+  return { safeAccounts, totalAccounts: byUser.size, unversionedDevices };
+};

--- a/packages/super-sync-server/src/sync/cleanup.ts
+++ b/packages/super-sync-server/src/sync/cleanup.ts
@@ -1,6 +1,7 @@
 import { getSyncService } from './sync.service';
 import { Logger } from '../logger';
 import { DEFAULT_SYNC_CONFIG, MS_PER_DAY } from './sync.types';
+import { MIN_CHECKPOINT_SAFE_APP_VERSION } from './checkpoint-gate';
 
 let cleanupTimer: NodeJS.Timeout | null = null;
 let initialCleanupTimer: NodeJS.Timeout | null = null;
@@ -54,6 +55,20 @@ const runDailyCleanup = async (): Promise<void> => {
     }
   } catch (error) {
     Logger.error(`Cleanup [stale-devices] failed: ${error}`);
+  }
+
+  // 2b. Checkpoint gate (#9962), read-only. Logged unconditionally: this count
+  // is what decides when an automatic client checkpoint cadence can be enabled,
+  // and it should be visible falling toward "all safe" run by run.
+  try {
+    const gate = await syncService.summarizeCheckpointGate(cutoffTime);
+    Logger.info(
+      `Cleanup [checkpoint-gate]: ${gate.safeAccounts} of ${gate.totalAccounts} account(s) ` +
+        `with a device inside retention run only clients >= ${MIN_CHECKPOINT_SAFE_APP_VERSION}; ` +
+        `${gate.unversionedDevices} device(s) report no version.`,
+    );
+  } catch (error) {
+    Logger.error(`Cleanup [checkpoint-gate] failed: ${error}`);
   }
 
   // 3. Clean up expired rate limit counters

--- a/packages/super-sync-server/src/sync/services/device.service.ts
+++ b/packages/super-sync-server/src/sync/services/device.service.ts
@@ -11,6 +11,7 @@ import {
   RETENTION_MS,
   SyncDeviceInfo,
 } from '../sync.types';
+import { CheckpointGateFleetSummary, summarizeCheckpointGate } from '../checkpoint-gate';
 
 /** Upper bound on rows `listDevices` returns, and so on the dialog's row count. */
 const MAX_LISTED_DEVICES = 100;
@@ -60,7 +61,9 @@ export class DeviceService {
    * for those are never written, and harvesting a hostname would put the first
    * user-identifying cleartext beyond the account email on a server whose whole
    * point is that op payloads are opaque to it. The clientId's platform prefix
-   * (E/A/I/B) is enough to tell devices apart.
+   * (E/A/I/B) is enough to tell devices apart. `app_version` IS written (by
+   * `touchDevice`) but is a bare semver read only by the checkpoint gate, so
+   * it stays out of the list too.
    *
    * The retention filter makes the "devices drop off the list after the
    * retention period" promise hold by construction — the daily cleanup job
@@ -97,17 +100,43 @@ export class DeviceService {
    *
    * The INSERT half registers download-only devices, which the upload
    * transaction's upsert would otherwise never create.
+   *
+   * `appVersion` (already validated by `parseAppVersion`) is recorded for the
+   * checkpoint gate (#9962). A changed version bypasses the throttle so an
+   * update is visible on the next poll, and an absent one (WebSocket heartbeat,
+   * pre-reporting clients) never overwrites a known version with NULL.
    */
-  async touchDevice(userId: number, clientId: string): Promise<void> {
+  async touchDevice(
+    userId: number,
+    clientId: string,
+    appVersion?: string,
+  ): Promise<void> {
     const nowBig = BigInt(Date.now());
     const staleBefore = nowBig - BigInt(DEVICE_TOUCH_THROTTLE_MS);
+    const version = appVersion ?? null;
     await prisma.$executeRaw`
-      INSERT INTO sync_devices (client_id, user_id, last_seen_at, last_acked_seq, created_at)
-      VALUES (${clientId}, ${userId}, ${nowBig}::bigint, 0, ${nowBig}::bigint)
+      INSERT INTO sync_devices (client_id, user_id, last_seen_at, last_acked_seq, created_at, app_version)
+      VALUES (${clientId}, ${userId}, ${nowBig}::bigint, 0, ${nowBig}::bigint, ${version})
       ON CONFLICT (user_id, client_id) DO UPDATE
-      SET last_seen_at = EXCLUDED.last_seen_at
+      SET last_seen_at = EXCLUDED.last_seen_at,
+          app_version = COALESCE(EXCLUDED.app_version, sync_devices.app_version)
       WHERE sync_devices.last_seen_at < ${staleBefore}::bigint
+         OR (EXCLUDED.app_version IS NOT NULL
+             AND sync_devices.app_version IS DISTINCT FROM EXCLUDED.app_version)
     `;
+  }
+
+  /**
+   * Fleet-wide gate roll-up over every device seen after `sinceTime`. One row
+   * per device in the window (bounded by the stale-device cleanup, so tens of
+   * thousands at most); grouped in-process so the comparison has one home.
+   */
+  async summarizeCheckpointGate(sinceTime: number): Promise<CheckpointGateFleetSummary> {
+    const rows = await prisma.syncDevice.findMany({
+      where: { lastSeenAt: { gt: BigInt(sinceTime) } },
+      select: { userId: true, appVersion: true },
+    });
+    return summarizeCheckpointGate(rows);
   }
 
   async deleteStaleDevices(beforeTime: number): Promise<number> {

--- a/packages/super-sync-server/src/sync/sync.routes.ts
+++ b/packages/super-sync-server/src/sync/sync.routes.ts
@@ -2,6 +2,7 @@ import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { SuperSyncDownloadOpsQuerySchema } from '@sp/shared-schema';
 import { authenticate, getAuthUser } from '../middleware';
 import { getSyncService } from './sync.service';
+import { parseAppVersion } from './checkpoint-gate';
 import { Logger } from '../logger';
 import {
   UploadOpsRequest,
@@ -128,13 +129,15 @@ export const syncRoutes = async (fastify: FastifyInstance): Promise<void> => {
             .send(createValidationErrorResponse(parseResult.error.issues));
         }
 
-        const { sinceSeq, limit = 500, excludeClient } = parseResult.data;
+        const { sinceSeq, limit = 500, excludeClient, appVersion } = parseResult.data;
         const syncService = getSyncService();
 
         // `excludeClient` is the caller's own id (it means "don't echo my ops
-        // back"), so a caller that omits it simply isn't recorded.
+        // back"), so a caller that omits it simply isn't recorded. `appVersion`
+        // rides along for the checkpoint gate (#9962); a malformed one is
+        // dropped rather than failing the download.
         if (excludeClient) {
-          syncService.touchDevice(userId, excludeClient);
+          syncService.touchDevice(userId, excludeClient, parseAppVersion(appVersion));
         }
 
         Logger.debug(

--- a/packages/super-sync-server/src/sync/sync.service.ts
+++ b/packages/super-sync-server/src/sync/sync.service.ts
@@ -10,6 +10,7 @@ import {
   createStateReplacementRequiredResults,
   SyncDeviceInfo,
 } from './sync.types';
+import { CheckpointGateFleetSummary } from './checkpoint-gate';
 import { Logger } from '../logger';
 import { Prisma } from '@prisma/client';
 import {
@@ -633,9 +634,9 @@ export class SyncService {
    * deliberately outside any transaction: this is advisory metadata for a UI
    * list and must never fail, slow, or lengthen the lock window of a sync.
    */
-  touchDevice(userId: number, clientId: string): void {
+  touchDevice(userId: number, clientId: string, appVersion?: string): void {
     void this.deviceService
-      .touchDevice(userId, clientId)
+      .touchDevice(userId, clientId, appVersion)
       .catch((err) =>
         Logger.debug(`[user:${userId}] touchDevice failed: ${(err as Error)?.message}`),
       );
@@ -863,6 +864,11 @@ export class SyncService {
 
   async deleteStaleDevices(beforeTime: number): Promise<number> {
     return this.deviceService.deleteStaleDevices(beforeTime);
+  }
+
+  /** Checkpoint-gate roll-up for the daily cleanup log (#9962). */
+  async summarizeCheckpointGate(sinceTime: number): Promise<CheckpointGateFleetSummary> {
+    return this.deviceService.summarizeCheckpointGate(sinceTime);
   }
 
   /**

--- a/packages/super-sync-server/tests/checkpoint-gate.spec.ts
+++ b/packages/super-sync-server/tests/checkpoint-gate.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MIN_CHECKPOINT_SAFE_APP_VERSION,
+  isAccountCheckpointSafe,
+  isCheckpointSafeAppVersion,
+  parseAppVersion,
+  summarizeCheckpointGate,
+} from '../src/sync/checkpoint-gate';
+
+describe('checkpoint gate (#9962)', () => {
+  it('pins the cut to the first release with concurrent-safe REPAIR', () => {
+    // 78a459294104 landed the narrower REPAIR semantics; v18.21.2 first shipped it.
+    expect(MIN_CHECKPOINT_SAFE_APP_VERSION).toBe('18.21.2');
+  });
+
+  describe('parseAppVersion', () => {
+    it('accepts a bare semver and an optional prerelease tag', () => {
+      expect(parseAppVersion('18.22.0')).toBe('18.22.0');
+      expect(parseAppVersion('18.23.0-beta.1')).toBe('18.23.0-beta.1');
+    });
+
+    it('drops anything that is not a version instead of storing garbage', () => {
+      expect(parseAppVersion(undefined)).toBeUndefined();
+      expect(parseAppVersion(['18.22.0'])).toBeUndefined();
+      expect(parseAppVersion('')).toBeUndefined();
+      expect(parseAppVersion('18.22')).toBeUndefined();
+      expect(parseAppVersion('v18.22.0')).toBeUndefined();
+      expect(parseAppVersion('18.22.0AI')).toBeUndefined();
+      expect(parseAppVersion('18.22.0-' + 'x'.repeat(40))).toBeUndefined();
+    });
+  });
+
+  describe('isCheckpointSafeAppVersion', () => {
+    it('is safe at and above the cut', () => {
+      expect(isCheckpointSafeAppVersion('18.21.2')).toBe(true);
+      expect(isCheckpointSafeAppVersion('18.21.3')).toBe(true);
+      expect(isCheckpointSafeAppVersion('18.22.0')).toBe(true);
+      expect(isCheckpointSafeAppVersion('19.0.0')).toBe(true);
+      expect(isCheckpointSafeAppVersion('18.22.0-beta.1')).toBe(true);
+    });
+
+    it('is old below the cut, with numeric (not lexical) comparison', () => {
+      expect(isCheckpointSafeAppVersion('18.21.1')).toBe(false);
+      expect(isCheckpointSafeAppVersion('18.14.0')).toBe(false);
+      expect(isCheckpointSafeAppVersion('18.9.9')).toBe(false);
+      expect(isCheckpointSafeAppVersion('9.99.99')).toBe(false);
+    });
+
+    it('treats a prerelease of the cut itself as old (may predate the fix)', () => {
+      expect(isCheckpointSafeAppVersion('18.21.2-beta.1')).toBe(false);
+    });
+
+    it('treats a missing or unparseable version as old', () => {
+      expect(isCheckpointSafeAppVersion(null)).toBe(false);
+      expect(isCheckpointSafeAppVersion(undefined)).toBe(false);
+      expect(isCheckpointSafeAppVersion('')).toBe(false);
+      expect(isCheckpointSafeAppVersion('latest')).toBe(false);
+    });
+  });
+
+  describe('isAccountCheckpointSafe', () => {
+    it('requires every device to be safe', () => {
+      expect(isAccountCheckpointSafe([{ appVersion: '18.22.0' }])).toBe(true);
+      expect(
+        isAccountCheckpointSafe([{ appVersion: '18.22.0' }, { appVersion: '18.21.2' }]),
+      ).toBe(true);
+      expect(
+        isAccountCheckpointSafe([{ appVersion: '18.22.0' }, { appVersion: '18.20.0' }]),
+      ).toBe(false);
+      expect(
+        isAccountCheckpointSafe([{ appVersion: '18.22.0' }, { appVersion: null }]),
+      ).toBe(false);
+    });
+
+    it('is not safe with no devices: nobody to checkpoint, and silence is not consent', () => {
+      expect(isAccountCheckpointSafe([])).toBe(false);
+    });
+  });
+
+  describe('summarizeCheckpointGate', () => {
+    it('rolls devices up per account', () => {
+      expect(
+        summarizeCheckpointGate([
+          { userId: 1, appVersion: '18.22.0' },
+          { userId: 1, appVersion: '18.21.2' },
+          { userId: 2, appVersion: '18.22.0' },
+          { userId: 2, appVersion: null },
+          { userId: 3, appVersion: '18.20.1' },
+          { userId: 4, appVersion: null },
+        ]),
+      ).toEqual({ safeAccounts: 1, totalAccounts: 4, unversionedDevices: 2 });
+    });
+
+    it('reports zeros for an empty window', () => {
+      expect(summarizeCheckpointGate([])).toEqual({
+        safeAccounts: 0,
+        totalAccounts: 0,
+        unversionedDevices: 0,
+      });
+    });
+  });
+});

--- a/packages/super-sync-server/tests/cleanup.spec.ts
+++ b/packages/super-sync-server/tests/cleanup.spec.ts
@@ -21,6 +21,11 @@ const mockSyncService = {
     affectedUserIds: [],
   }),
   deleteStaleDevices: vi.fn().mockResolvedValue(0),
+  summarizeCheckpointGate: vi.fn().mockResolvedValue({
+    safeAccounts: 0,
+    totalAccounts: 0,
+    unversionedDevices: 0,
+  }),
   cleanupExpiredRateLimitCounters: vi.fn().mockReturnValue(0),
   cleanupExpiredRequestDedupEntries: vi.fn().mockReturnValue(0),
   deleteExpiredPendingPasskeyRegistrations: vi.fn().mockResolvedValue(0),
@@ -214,6 +219,37 @@ describe('Cleanup Jobs', () => {
       expect(mockSyncService.deleteStaleDevices).toHaveBeenCalled();
       expect(mockSyncService.cleanupExpiredRateLimitCounters).toHaveBeenCalled();
       expect(mockSyncService.cleanupExpiredRequestDedupEntries).toHaveBeenCalled();
+    });
+
+    it('logs the checkpoint-gate roll-up unconditionally (#9962)', async () => {
+      mockSyncService.summarizeCheckpointGate.mockResolvedValueOnce({
+        safeAccounts: 3,
+        totalAccounts: 10,
+        unversionedDevices: 7,
+      });
+
+      startCleanupJobs();
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      const cutoffCall = mockSyncService.deleteStaleDevices.mock.calls[0][0];
+      expect(mockSyncService.summarizeCheckpointGate).toHaveBeenCalledWith(cutoffCall);
+      expect(Logger.info).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /Cleanup \[checkpoint-gate\]: 3 of 10 account\(s\) .* >= 18\.21\.2; 7 device\(s\) report no version/,
+        ),
+      );
+    });
+
+    it('should continue cleanup even if the checkpoint-gate roll-up fails', async () => {
+      mockSyncService.summarizeCheckpointGate.mockRejectedValueOnce(
+        new Error('DB error'),
+      );
+
+      startCleanupJobs();
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(mockSyncService.cleanupExpiredRateLimitCounters).toHaveBeenCalled();
+      expect(mockSyncService.deleteAbandonedUnverifiedUsers).toHaveBeenCalled();
     });
 
     it('should continue cleanup even if device cleanup fails', async () => {

--- a/packages/super-sync-server/tests/device-touch-sql.pglite.spec.ts
+++ b/packages/super-sync-server/tests/device-touch-sql.pglite.spec.ts
@@ -50,6 +50,7 @@ type Row = {
   user_id: number;
   last_seen_at: bigint | string | number;
   created_at: bigint | string | number;
+  app_version: string | null;
 };
 
 describe('DeviceService.touchDevice (real Postgres)', () => {
@@ -117,6 +118,68 @@ describe('DeviceService.touchDevice (real Postgres)', () => {
     expect(num(rows[0].last_seen_at)).toBe(later);
     // createdAt is the device's first-seen stamp and must survive refreshes.
     expect(num(rows[0].created_at)).toBe(1_000_000);
+  });
+
+  describe('app_version (#9962)', () => {
+    it('stores the reported version on insert and leaves it NULL when none is reported', async () => {
+      vi.setSystemTime(1_000_000);
+      await service.touchDevice(7, 'E_abc123', '18.22.0');
+      await service.touchDevice(7, 'A_xyz789');
+
+      const rows = await readAll();
+      expect(rows.map((r) => [r.client_id, r.app_version])).toEqual([
+        ['A_xyz789', null],
+        ['E_abc123', '18.22.0'],
+      ]);
+    });
+
+    it('never overwrites a known version with NULL (WebSocket heartbeat touches carry none)', async () => {
+      vi.setSystemTime(1_000_000);
+      await service.touchDevice(7, 'E_abc123', '18.22.0');
+
+      const later = 1_000_000 + DEVICE_TOUCH_THROTTLE_MS + 1;
+      vi.setSystemTime(later);
+      await service.touchDevice(7, 'E_abc123');
+
+      const rows = await readAll();
+      expect(rows[0].app_version).toBe('18.22.0');
+      expect(num(rows[0].last_seen_at)).toBe(later);
+    });
+
+    it('records a changed version immediately, bypassing the throttle', async () => {
+      vi.setSystemTime(1_000_000);
+      await service.touchDevice(7, 'E_abc123', '18.21.1');
+
+      const soon = 1_000_000 + 1;
+      vi.setSystemTime(soon);
+      await new DeviceService().touchDevice(7, 'E_abc123', '18.22.0');
+
+      const rows = await readAll();
+      expect(rows[0].app_version).toBe('18.22.0');
+      expect(num(rows[0].last_seen_at)).toBe(soon);
+    });
+
+    it('backfills a version onto a row that had none, bypassing the throttle', async () => {
+      vi.setSystemTime(1_000_000);
+      await service.touchDevice(7, 'E_abc123');
+
+      vi.setSystemTime(1_000_000 + 1);
+      await service.touchDevice(7, 'E_abc123', '18.22.0');
+
+      const rows = await readAll();
+      expect(rows[0].app_version).toBe('18.22.0');
+    });
+
+    it('still writes nothing for an unchanged version inside the throttle window', async () => {
+      vi.setSystemTime(1_000_000);
+      await service.touchDevice(7, 'E_abc123', '18.22.0');
+
+      vi.setSystemTime(1_000_000 + DEVICE_TOUCH_THROTTLE_MS - 1);
+      await service.touchDevice(7, 'E_abc123', '18.22.0');
+
+      const rows = await readAll();
+      expect(num(rows[0].last_seen_at)).toBe(1_000_000);
+    });
   });
 
   it('keeps devices and accounts separate', async () => {

--- a/packages/super-sync-server/tests/migration-sql.spec.ts
+++ b/packages/super-sync-server/tests/migration-sql.spec.ts
@@ -183,6 +183,32 @@ describe('performance migrations', () => {
     expect(migrationSql).not.toMatch(/\bBEGIN\b|\bCOMMIT\b/i);
   });
 
+  it('adds sync_devices.app_version as a nullable catalog-only column (#9962)', () => {
+    const migrationSql = readFileSync(
+      join(
+        currentDir,
+        '../prisma/migrations/20260911000000_add_sync_device_app_version/migration.sql',
+      ),
+      'utf8',
+    );
+
+    // Nullable with no default: pure catalog change, no rewrite, no backfill.
+    // A default would silently mark every pre-reporting device as versioned.
+    // The header comment explains exactly that, so match statements only.
+    const statements = migrationSql
+      .split('\n')
+      .filter((line) => !line.trimStart().startsWith('--'))
+      .join('\n');
+    expect(statements).toMatch(
+      /ALTER TABLE "sync_devices"\s+ADD COLUMN "app_version" TEXT\s*;/i,
+    );
+    expect(statements).not.toMatch(/\bDEFAULT\b/i);
+    expect(statements).not.toMatch(/\bNOT NULL\b/i);
+    expect(statements).not.toMatch(/\bUPDATE\b/i);
+    expect(statements).not.toMatch(/\bCONCURRENTLY\b/i);
+    expect(statements).not.toMatch(/\bBEGIN\b|\bCOMMIT\b/i);
+  });
+
   it('adds the payload_bytes unbackfilled partial index concurrently', () => {
     const migrationSql = readFileSync(
       join(

--- a/packages/super-sync-server/tests/sync-devices-ddl.helper.ts
+++ b/packages/super-sync-server/tests/sync-devices-ddl.helper.ts
@@ -11,6 +11,7 @@ export const SYNC_DEVICES_DDL = `
     user_id        integer NOT NULL,
     device_name    text,
     user_agent     text,
+    app_version    text,
     last_seen_at   bigint NOT NULL,
     last_acked_seq integer NOT NULL DEFAULT 0,
     created_at     bigint NOT NULL,

--- a/packages/sync-providers/src/super-sync/super-sync.ts
+++ b/packages/sync-providers/src/super-sync/super-sync.ts
@@ -101,6 +101,14 @@ export interface SuperSyncDeps {
    * Optional override for tests to avoid real web-request retry waits.
    */
   webRequestRetryDelay?: (ms: number) => Promise<void>;
+  /**
+   * Bare semver of the running app (`18.22.0`, no channel suffix), sent as the
+   * `appVersion` download query parameter so the server can tell which
+   * accounts still have clients that treat REPAIR as a reset (#9962). A query
+   * parameter, not a header: older servers strip it as an unknown key, and a
+   * browser client needs no new CORS allowance. Omitted → not sent.
+   */
+  appVersion?: string;
 }
 
 /**
@@ -293,6 +301,9 @@ export class SuperSyncProvider
     }
     if (limit !== undefined) {
       params.set('limit', String(limit));
+    }
+    if (this._deps.appVersion) {
+      params.set('appVersion', this._deps.appVersion);
     }
 
     const response = await this._fetchApi<unknown>(

--- a/packages/sync-providers/tests/super-sync/super-sync.spec.ts
+++ b/packages/sync-providers/tests/super-sync/super-sync.spec.ts
@@ -168,6 +168,7 @@ const buildProvider = (
     isAndroidWebView: boolean;
     isIosNative: boolean;
     validators: SuperSyncResponseValidators;
+    appVersion: string;
   }>,
 ): BuildProviderResult => {
   const cfgStore = createCredentialStoreMock();
@@ -191,6 +192,7 @@ const buildProvider = (
     responseValidators: validators,
     defaultBaseUrl: SUPER_SYNC_DEFAULT_BASE_URL,
     webRequestRetryDelay: webRequestRetryDelay as (ms: number) => Promise<void>,
+    appVersion: overrides?.appVersion,
   };
   const provider = new SuperSyncProvider(deps);
   return {
@@ -664,6 +666,30 @@ describe('SuperSyncProvider', () => {
       await provider.downloadOps(0);
 
       expect(provider.supportsCausalRepairSnapshots()).toBe(true);
+    });
+
+    it('reports the app version as a query parameter when the host supplies one (#9962)', async () => {
+      const { provider, cfgStore, fetchMock } = buildProvider({ appVersion: '18.22.0' });
+      cfgStore.load.mockResolvedValue(testConfig);
+      fetchMock.mockResolvedValue(okResponse({ ops: [], hasMore: false, latestSeq: 0 }));
+
+      await provider.downloadOps(0, 'client-1');
+
+      const [url] = fetchMock.mock.calls[0] as [string];
+      expect(url).toBe(
+        'https://sync.example.com/api/sync/ops?sinceSeq=0&excludeClient=client-1&appVersion=18.22.0',
+      );
+    });
+
+    it('sends no appVersion parameter when the host supplies none', async () => {
+      const { provider, cfgStore, fetchMock } = buildProvider();
+      cfgStore.load.mockResolvedValue(testConfig);
+      fetchMock.mockResolvedValue(okResponse({ ops: [], hasMore: false, latestSeq: 0 }));
+
+      await provider.downloadOps(0, 'client-1');
+
+      const [url] = fetchMock.mock.calls[0] as [string];
+      expect(url).not.toContain('appVersion');
     });
 
     it('downloads operations successfully', async () => {

--- a/src/app/op-log/sync-providers/super-sync/super-sync.ts
+++ b/src/app/op-log/sync-providers/super-sync/super-sync.ts
@@ -13,6 +13,7 @@ import { SyncCredentialStore } from '../credential-store.service';
 import { APP_PROVIDER_PLATFORM_INFO } from '../platform/app-provider-platform-info';
 import { APP_WEB_FETCH } from '../platform/app-web-fetch';
 import { SyncProviderId } from '../provider.const';
+import { getAppSemver } from '../../../util/get-app-version-str';
 import {
   validateDeleteAllDataResponse,
   validateDevicesResponse,
@@ -98,6 +99,7 @@ export const createSuperSyncProvider = (): PackageSuperSyncProvider => {
     // framework-agnostic and never implicitly assumes the SP-hosted
     // server URL.
     defaultBaseUrl: SUPER_SYNC_DEFAULT_BASE_URL,
+    appVersion: getAppSemver(),
   };
   return new PackageSuperSyncProvider(deps);
 };

--- a/src/app/util/get-app-version-str.spec.ts
+++ b/src/app/util/get-app-version-str.spec.ts
@@ -1,4 +1,10 @@
-import { DistChannel, distChannelSuffix, getAppVersionStr } from './get-app-version-str';
+import {
+  DistChannel,
+  distChannelSuffix,
+  extractSemver,
+  getAppSemver,
+  getAppVersionStr,
+} from './get-app-version-str';
 import { environment } from '../../environments/environment';
 
 describe('distChannelSuffix', () => {
@@ -35,5 +41,27 @@ describe('getAppVersionStr', () => {
   // all false, so the channel resolves to web -> "WB".
   it('appends the web suffix in a browser context', () => {
     expect(getAppVersionStr()).toBe(`${environment.version}WB`);
+  });
+});
+
+describe('extractSemver', () => {
+  it('keeps a bare semver as is', () => {
+    expect(extractSemver('18.22.0')).toBe('18.22.0');
+  });
+
+  it('strips the Android launch-mode marker', () => {
+    expect(extractSemver('18.22.0_L1')).toBe('18.22.0');
+  });
+
+  it('returns undefined when no version leads the string', () => {
+    expect(extractSemver('')).toBeUndefined();
+    expect(extractSemver('dev')).toBeUndefined();
+    expect(extractSemver('v18.22.0')).toBeUndefined();
+  });
+});
+
+describe('getAppSemver', () => {
+  it('reports the bare package version in a browser context, without the channel suffix', () => {
+    expect(getAppSemver()).toBe(environment.version);
   });
 });

--- a/src/app/util/get-app-version-str.ts
+++ b/src/app/util/get-app-version-str.ts
@@ -80,8 +80,23 @@ export const detectChannel = (): DistChannel => {
   return 'web';
 };
 
-export const getAppVersionStr = (): string => {
-  const base =
-    (IS_ANDROID_WEB_VIEW && androidInterface?.getVersion?.()) || environment.version;
-  return `${base}${distChannelSuffix(detectChannel())}`;
-};
+const rawAppVersion = (): string =>
+  (IS_ANDROID_WEB_VIEW && androidInterface?.getVersion?.()) || environment.version;
+
+/**
+ * Leading `MAJOR.MINOR.PATCH` of a build version string, or `undefined` when
+ * there is none. The Android bridge appends a launch-mode marker
+ * (`18.22.0_L1`), which must not leak into anything compared as a version.
+ */
+export const extractSemver = (raw: string): string | undefined =>
+  /^\d+\.\d+\.\d+/.exec(raw)?.[0];
+
+/**
+ * The bare semver of the running build, for machine-to-machine reporting
+ * (SuperSync sends it so the server can gate automatic checkpoints, #9962).
+ * Never carries the display channel suffix.
+ */
+export const getAppSemver = (): string | undefined => extractSemver(rawAppVersion());
+
+export const getAppVersionStr = (): string =>
+  `${rawAppVersion()}${distChannelSuffix(detectChannel())}`;


### PR DESCRIPTION
## Problem

Under mandatory E2EE only a client can create the causal full-state boundary that lets the old-ops sweep prune a user's history, and routine sync never creates one (#9962). An automatic checkpoint cadence would fix that, but every release before v18.21.2 treats a REPAIR op as a full reset and drops offline edits concurrent with it. The server has no way to tell which accounts still have such clients: `sync_devices.user_agent` exists but is never written.

Refs #9962. This is the prerequisite for a cadence; no client uploads checkpoints yet.

## Solution

- Client sends its bare semver as the `appVersion` download query parameter. A query parameter rather than a header, so browser clients need no new CORS allowance and older servers strip it as an unknown key. The Android bridge's launch-mode marker (`18.22.0_L1`) is stripped before sending.
- Server stores it in a new nullable `sync_devices.app_version` column through the existing throttled touch. A changed version bypasses the throttle; a touch without a version (WebSocket heartbeat, pre-reporting clients) never overwrites a known one.
- New pure module `checkpoint-gate.ts` holds the v18.21.2 cut and the rule: an account is checkpoint-safe only when every device seen inside retention is at or above it. A device with no reported version counts as old.
- The daily cleanup logs a fleet roll-up unconditionally as `Cleanup [checkpoint-gate]: N of M account(s) ...`. That line decides when a cadence can be switched on.

Deploy order does not matter and rollback leaves an unused nullable column behind.

## Validation

- Server unit suite: 1321 passed. New PGlite cases for the touch SQL, gate unit tests, cleanup log test, migration shape test.
- `test:integration:postgres` against Postgres 16.15: 17 files, 87 tests passed.
- Migration applied through `scripts/migrate-deploy.sh` on a real Postgres; column verified as `text NULL`, no default.
- sync-providers: 108 passed plus typecheck. shared-schema: 95 passed. Karma spec for the version helper: 19 passed. `checkFile` on every changed file.

Side finding, unrelated to this change: `old-ops-boundary-plan.integration.spec.ts` ("stays index-only against an unvacuumed tail") fails on a schema provisioned through `migrate deploy` (heap fetches 11 instead of 5) and passes on CI's `db push` schema. Production is provisioned by `migrate deploy`, so that test may not measure what production sees. Worth its own issue.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

https://claude.ai/code/session_01RGPjzTjATtCHtMX9AAY3PD
