### PR TITLE
fix(issue): keep remindAt in step with poll-driven dueWithTime changes

### DIFF
--- a/android/app/src/androidTest/java/com/superproductivity/superproductivity/ImeInsetShimInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/superproductivity/superproductivity/ImeInsetShimInstrumentedTest.kt
@@ -208,17 +208,52 @@ class ImeInsetShimInstrumentedTest {
         }
     }
 
-    private fun showIme(activity: CapacitorMainActivity, webView: WebView) {
+    /** Focuses the field and asks for the IME. Returns whether an input connection existed. */
+    private fun showIme(activity: CapacitorMainActivity, webView: WebView): Boolean {
         // View focus first, then the editable inside it, then the request: a
         // programmatic focus() without a user gesture does not raise the IME by
         // itself, and show(ime()) needs an editor attached to the focused view.
         onMainSync { webView.requestFocus() }
         evaluateJavaScript(webView, "document.getElementById('field').focus(); 'focused'")
+        // The JS focus returning is not enough: the input connection only exists
+        // once the renderer has reported the focused editable back to the browser
+        // process, which is asynchronous and can lag seconds on a loaded emulator.
+        // A request issued before then is dropped outright — "Ignoring
+        // showSoftInput() as view ... is not served", the whole failure in run
+        // 33975587718 — so wait for the connection instead of racing it.
+        val served = awaitServedView(activity, webView)
         onMainSync {
             WindowInsetsControllerCompat(activity.window, webView)
                 .show(WindowInsetsCompat.Type.ime())
         }
+        return served
     }
+
+    /**
+     * Waits until the IME has an input connection to [webView], i.e. a show
+     * request would reach the IME instead of being ignored. Reports a miss
+     * rather than failing on it, so that a genuine never-opens failure still
+     * fails on the geometry with the full reading rather than dying here.
+     */
+    private fun awaitServedView(
+        activity: CapacitorMainActivity,
+        webView: WebView,
+        timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS,
+    ): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + TimeUnit.SECONDS.toMillis(timeoutSeconds)
+        do {
+            if (onMainSync { inputMethodManager(activity).isActive(webView) }) return true
+            // Coarser than POLL_MS: isActive() can hit system_server synchronously,
+            // and this wait exists for the case where that server is already the
+            // slow part. Detection latency does not matter at this granularity.
+            SystemClock.sleep(SERVED_POLL_MS)
+        } while (SystemClock.elapsedRealtime() < deadline)
+        Log.i(TAG, "WebView still has no input connection after ${timeoutSeconds}s")
+        return false
+    }
+
+    private fun inputMethodManager(activity: CapacitorMainActivity): InputMethodManager =
+        activity.getSystemService(InputMethodManager::class.java)
 
     private fun hideIme(activity: CapacitorMainActivity, webView: WebView) {
         evaluateJavaScript(webView, "document.getElementById('field').blur(); 'blurred'")
@@ -238,16 +273,25 @@ class ImeInsetShimInstrumentedTest {
             it.keyboardOpenPerListener
         }
         if (first != null) return first
-        Log.i(TAG, "IME not open after show(ime()); retrying via InputMethodManager")
+        // Re-enter the whole sequence rather than re-issuing show() alone: what
+        // the retry is really for is the second wait for an input connection,
+        // since the likeliest reason the first request did nothing is that there
+        // was none yet. (The JS focus it repeats is a no-op while the field still
+        // holds focus — the focusing steps return early and the renderer re-reports
+        // nothing — so the wait, not the focus, is what makes this retry worth a try.)
+        Log.i(TAG, "IME not open after show(ime()); retrying the request and the wait")
+        val served = showIme(activity, webView)
         onMainSync {
-            activity.getSystemService(InputMethodManager::class.java)
+            inputMethodManager(activity)
                 .showSoftInput(webView, InputMethodManager.SHOW_IMPLICIT)
         }
         return awaitGeometry(
             activity,
             webView,
             "the IME to open (visible frame must drop by more than 15% of the root height; " +
-                "on an emulator make sure `settings put secure show_ime_with_hard_keyboard 1` ran)",
+                "WebView had an input connection: $served — false means the request was " +
+                "very likely dropped before reaching the IME; on an emulator make sure " +
+                "`settings put secure show_ime_with_hard_keyboard 1` ran)",
         ) { it.keyboardOpenPerListener }
     }
 
@@ -350,6 +394,7 @@ class ImeInsetShimInstrumentedTest {
         const val DEFAULT_TIMEOUT_SECONDS = 10L
         const val SHOW_IME_FIRST_TRY_SECONDS = 5L
         const val POLL_MS = 50L
+        const val SERVED_POLL_MS = 200L
         const val SETTLE_MS = 300L
         // Sub-pixel rounding between the visible frame and the view bottom.
         const val TOLERANCE_PX = 2

--- a/e2e/tests/calendar/issue-10047-poll-reschedule-remind-at.spec.ts
+++ b/e2e/tests/calendar/issue-10047-poll-reschedule-remind-at.spec.ts
@@ -80,6 +80,7 @@ test.describe('Calendar #10047', () => {
       route.fulfill({
         status: 200,
         contentType: 'text/calendar',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         headers: { 'Cache-Control': 'no-store' },
         body: buildIcal(),
       }),

--- a/e2e/tests/calendar/issue-10047-poll-reschedule-remind-at.spec.ts
+++ b/e2e/tests/calendar/issue-10047-poll-reschedule-remind-at.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test } from '../../fixtures/test.fixture';
+
+/**
+ * Repro for https://github.com/super-productivity/super-productivity/issues/10047
+ *
+ * When a poll-driven update changes a task's `dueWithTime`, `remindAt` is left
+ * untouched: `issue.service.ts` applies poll results via a plain
+ * `_taskService.update()`, which has no reminder branch in
+ * `task-shared-scheduling.reducer.ts`. Only the import path (`addAndSchedule`)
+ * derives `remindAt` from the reminder default.
+ *
+ * Repro: an all-day calendar event auto-imports as a task with no time, so
+ * it's added via `add()` and never gets a `remindAt` (failure mode 1 in the
+ * issue). The remote event (same UID) then gains a start time. The next poll
+ * pass (`getFreshDataForIssueTasks` -> `_taskService.update()`) applies the
+ * new `dueWithTime`, but `remindAt` stays unset.
+ *
+ * Expected: a task that is rescheduled to a specific time should get a
+ * reminder, same as if it had been imported with that time from the start --
+ * the task row should show the "alarm" icon (`t.remindAt` truthy) once it has
+ * a `dueWithTime`.
+ * Actual: only the plain "schedule"/"wb_sunny" icon shows; no reminder was
+ * ever set, so the task will silently never notify.
+ *
+ * The iCal feed is stubbed via page.route so the test is hermetic. The poll
+ * is triggered by switching work context (dispatches `setActiveWorkContext`,
+ * which `poll-issue-updates.effects.ts` listens for) rather than reloading
+ * the page, since a reload re-subscribes effects and misses the hydration
+ * action that would otherwise kick off the same poll.
+ */
+
+const ICAL_URL = 'https://example.com/sp-10047.ics';
+const EVENT_TITLE = 'E2E-10047 Standup';
+const UID = 'e2e-10047-event';
+
+const PANEL_BTN = '.e2e-toggle-issue-provider-panel';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+const pad = (n: number): string => String(n).padStart(2, '0');
+
+const icalDate = (d: Date): string =>
+  `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}`;
+
+// Toggled by the test once the task has auto-imported, to simulate the event
+// gaining a start time on the remote calendar.
+let icsPhase: 'allDay' | 'timed' = 'allDay';
+
+const buildIcal = (): string => {
+  const now = new Date();
+  const today = icalDate(now);
+  const tomorrow = icalDate(new Date(now.getTime() + ONE_DAY_MS));
+
+  const [dtstart, dtend] =
+    icsPhase === 'allDay'
+      ? [`DTSTART;VALUE=DATE:${today}`, `DTEND;VALUE=DATE:${tomorrow}`]
+      : [`DTSTART:${today}T180000Z`, `DTEND:${today}T190000Z`];
+
+  return [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//SP E2E//EN',
+    'BEGIN:VEVENT',
+    dtstart,
+    dtend,
+    `SUMMARY:${EVENT_TITLE}`,
+    `UID:${UID}`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].join('\r\n');
+};
+
+test.describe('Calendar #10047', () => {
+  test('poll-driven reschedule sets a reminder like import does', async ({
+    page,
+    workViewPage,
+    taskPage,
+  }) => {
+    await page.route(ICAL_URL, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/calendar',
+        headers: { 'Cache-Control': 'no-store' },
+        body: buildIcal(),
+      }),
+    );
+
+    await workViewPage.waitForTaskList();
+
+    // --- Configure a calendar provider with auto-import enabled ---
+    await page.waitForSelector(PANEL_BTN, { state: 'visible' });
+    await page.click(PANEL_BTN);
+    await page.waitForSelector('mat-tab-group', { state: 'visible' });
+    await page.click('mat-tab-group .mat-mdc-tab:last-child');
+    await page.waitForSelector('issue-provider-setup-overview', { state: 'visible' });
+
+    await page.getByRole('button', { name: 'Other (iCal)' }).click();
+    const dialog = page.locator('mat-dialog-container');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    await dialog.locator('input[id*="icalUrl"]').fill(ICAL_URL);
+    await dialog.getByRole('checkbox', { name: /auto import events as tasks/i }).check();
+
+    await dialog.locator('button[type="submit"]').click();
+    await expect(dialog).toBeHidden({ timeout: 5000 });
+
+    await page.keyboard.press('Escape');
+
+    // --- The all-day event auto-imports with no time and (correctly) no
+    // schedule/reminder affordance at all ---
+    const task = taskPage.getTaskByText(EVENT_TITLE);
+    await expect(task).toBeVisible({ timeout: 15000 });
+    await expect(task.locator('.schedule-btn')).toHaveCount(0);
+
+    // --- The remote event now carries a start time (same UID, i.e. a
+    // poll-driven reschedule, not a new event) ---
+    icsPhase = 'timed';
+
+    // --- Switch work context: dispatches `setActiveWorkContext`, which
+    // `poll-issue-updates.effects.ts` listens for to kick off its poll. (Note:
+    // while on Inbox, the task's due-day badge shows regardless of the poll
+    // outcome -- isShowDueDayBtn() only suppresses it on the active Today
+    // list -- so that intermediate state proves nothing; only the check back
+    // on Today, below, is meaningful.) ---
+    await page.getByRole('menuitem', { name: 'Inbox' }).click();
+    await page.getByRole('menuitem', { name: 'Today' }).click();
+
+    // --- Expected: once the poll-driven reschedule lands, the task should
+    // have a reminder, same as if it had been imported with a time from the
+    // start -- the "alarm" icon should show ---
+    await expect(task.locator('mat-icon:text("alarm")')).toBeVisible({
+      timeout: 25000,
+    });
+  });
+});

--- a/src/app/features/issue/issue.service.spec.ts
+++ b/src/app/features/issue/issue.service.spec.ts
@@ -26,6 +26,9 @@ import { RedmineCommonInterfacesService } from './providers/redmine/redmine-comm
 import { CalendarCommonInterfacesService } from './providers/calendar/calendar-common-interfaces.service';
 import { PluginIssueProviderAdapterService } from '../../plugins/issue-provider/plugin-issue-provider-adapter.service';
 import { PluginIssueProviderRegistryService } from '../../plugins/issue-provider/plugin-issue-provider-registry.service';
+import { GlobalConfigService } from '../config/global-config.service';
+import { IssueProvider } from './issue.model';
+import { TaskReminderOptionId } from '../tasks/task.model';
 
 describe('IssueService', () => {
   let service: IssueService;
@@ -41,6 +44,10 @@ describe('IssueService', () => {
   let navigateToTaskServiceSpy: jasmine.SpyObj<NavigateToTaskService>;
   let pluginAdapterSpy: jasmine.SpyObj<PluginIssueProviderAdapterService>;
   let pluginRegistrySpy: jasmine.SpyObj<PluginIssueProviderRegistryService>;
+  let commonInterfaceServiceSpy: jasmine.SpyObj<{
+    getFreshDataForIssueTask: () => unknown;
+    getFreshDataForIssueTasks: () => unknown;
+  }>;
 
   const createMockTask = (overrides: Partial<Task> = {}): Task =>
     ({
@@ -139,7 +146,10 @@ describe('IssueService', () => {
     const mockCommonInterfaceService = jasmine.createSpyObj('CommonInterfaceService', [
       'isEnabled',
       'getAddTaskData',
+      'getFreshDataForIssueTask',
+      'getFreshDataForIssueTasks',
     ]);
+    commonInterfaceServiceSpy = mockCommonInterfaceService;
 
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -169,6 +179,14 @@ describe('IssueService', () => {
         },
         { provide: PluginIssueProviderAdapterService, useValue: pluginAdapterSpy },
         { provide: PluginIssueProviderRegistryService, useValue: pluginRegistrySpy },
+        {
+          provide: GlobalConfigService,
+          useValue: {
+            cfg: () => ({
+              reminder: { defaultTaskRemindOption: TaskReminderOptionId.AtStart },
+            }),
+          },
+        },
       ],
     });
     service = TestBed.inject(IssueService);
@@ -785,6 +803,116 @@ describe('IssueService', () => {
           msg: T.F.TASK.S.FOUND_MOVE_FROM_BACKLOG,
         }),
       );
+    });
+  });
+  describe('poll-driven reschedule keeps remindAt in step with dueWithTime (#10047)', () => {
+    const MIN_10 = 10 * 60 * 1000;
+    const oldDue = new Date('2025-01-20T14:00:00Z').getTime();
+    const newDue = new Date('2025-01-21T09:00:00Z').getTime();
+    const caldavProvider = {
+      id: 'caldav-provider-1',
+      issueProviderKey: 'CALDAV',
+    } as IssueProvider;
+    const createCaldavTask = (overrides: Partial<Task> = {}): Task =>
+      createMockTask({
+        id: 'caldav-task-1',
+        issueId: 'caldav-issue-1',
+        issueProviderId: 'caldav-provider-1',
+        issueType: 'CALDAV',
+        dueWithTime: undefined,
+        remindAt: undefined,
+        ...overrides,
+      });
+    const changesOfLastUpdate = (): Partial<Task> =>
+      taskServiceSpy.update.calls.mostRecent().args[1];
+
+    it('bulk poll: a task scheduled remotely for the first time gets the default reminder', async () => {
+      const task = createCaldavTask();
+      commonInterfaceServiceSpy.getFreshDataForIssueTasks.and.returnValue(
+        Promise.resolve([
+          {
+            task,
+            taskChanges: { dueWithTime: newDue, issueWasUpdated: true },
+            issue: {},
+          },
+        ]),
+      );
+
+      await service.refreshIssueTasks([task], caldavProvider);
+
+      expect(taskServiceSpy.update).toHaveBeenCalledTimes(1);
+      expect(changesOfLastUpdate().dueWithTime).toBe(newDue);
+      expect(changesOfLastUpdate().remindAt).toBe(newDue);
+    });
+
+    it('bulk poll: a remote reschedule moves the reminder and keeps its offset', async () => {
+      const task = createCaldavTask({ dueWithTime: oldDue, remindAt: oldDue - MIN_10 });
+      commonInterfaceServiceSpy.getFreshDataForIssueTasks.and.returnValue(
+        Promise.resolve([
+          {
+            task,
+            taskChanges: { dueWithTime: newDue, issueWasUpdated: true },
+            issue: {},
+          },
+        ]),
+      );
+
+      await service.refreshIssueTasks([task], caldavProvider);
+
+      expect(changesOfLastUpdate().remindAt).toBe(newDue - MIN_10);
+    });
+
+    it('bulk poll: a remote unschedule clears the reminder', async () => {
+      const task = createCaldavTask({ dueWithTime: oldDue, remindAt: oldDue });
+      commonInterfaceServiceSpy.getFreshDataForIssueTasks.and.returnValue(
+        Promise.resolve([
+          {
+            task,
+            taskChanges: { dueWithTime: null, dueDay: null, issueWasUpdated: true },
+            issue: {},
+          },
+        ]),
+      );
+
+      await service.refreshIssueTasks([task], caldavProvider);
+
+      const changes = changesOfLastUpdate();
+      expect(Object.prototype.hasOwnProperty.call(changes, 'remindAt')).toBeTrue();
+      expect(changes.remindAt).toBeUndefined();
+    });
+
+    it('bulk poll: an unchanged schedule leaves remindAt alone', async () => {
+      const task = createCaldavTask({ dueWithTime: oldDue, remindAt: undefined });
+      commonInterfaceServiceSpy.getFreshDataForIssueTasks.and.returnValue(
+        Promise.resolve([
+          {
+            task,
+            taskChanges: { dueWithTime: oldDue, title: 'renamed', issueWasUpdated: true },
+            issue: {},
+          },
+        ]),
+      );
+
+      await service.refreshIssueTasks([task], caldavProvider);
+
+      expect(
+        Object.prototype.hasOwnProperty.call(changesOfLastUpdate(), 'remindAt'),
+      ).toBeFalse();
+    });
+
+    it('single refresh: a remote reschedule moves the reminder too', async () => {
+      const task = createCaldavTask({ dueWithTime: oldDue, remindAt: oldDue });
+      commonInterfaceServiceSpy.getFreshDataForIssueTask.and.returnValue(
+        Promise.resolve({
+          taskChanges: { dueWithTime: newDue, issueWasUpdated: true },
+          issue: {},
+          issueTitle: 'x',
+        }),
+      );
+
+      await service.refreshIssueTask(task, false, false);
+
+      expect(changesOfLastUpdate().remindAt).toBe(newDue);
     });
   });
 });

--- a/src/app/features/issue/issue.service.ts
+++ b/src/app/features/issue/issue.service.ts
@@ -30,6 +30,9 @@ import {
 } from './issue.const';
 import { TaskService } from '../tasks/task.service';
 import { IssueTask, Task, TaskCopy } from '../tasks/task.model';
+import { GlobalConfigService } from '../config/global-config.service';
+import { DEFAULT_GLOBAL_CONFIG } from '../config/default-global-config.const';
+import { withRemindAtForDueChange } from '../tasks/util/with-remind-at-for-due-change';
 import { IssueServiceInterface } from './issue-service-interface';
 import { JiraCommonInterfacesService } from './providers/jira/jira-common-interfaces.service';
 // Trello is now a plugin — no built-in service needed
@@ -94,6 +97,7 @@ export class IssueService {
   private _navigateToTaskService = inject(NavigateToTaskService);
   private _pluginAdapter = inject(PluginIssueProviderAdapterService);
   private _pluginRegistry = inject(PluginIssueProviderRegistryService);
+  private _globalConfigService = inject(GlobalConfigService);
 
   ISSUE_SERVICE_MAP: { [key: string]: IssueServiceInterface } = {
     [GITLAB_TYPE]: this._gitlabCommonInterfacesService,
@@ -350,7 +354,7 @@ export class IssueService {
       if (this.ISSUE_REFRESH_MAP[issueProviderId]?.[issueId]) {
         this.ISSUE_REFRESH_MAP[issueProviderId][issueId].next(update.issue);
       }
-      this._taskService.update(task.id, update.taskChanges);
+      this._taskService.update(task.id, this._withRemindAt(task, update.taskChanges));
 
       if (isNotifySuccess) {
         this._snackService.open({
@@ -435,7 +439,10 @@ export class IssueService {
               update.issue,
             );
           }
-          this._taskService.update(update.task.id, update.taskChanges);
+          this._taskService.update(
+            update.task.id,
+            this._withRemindAt(update.task, update.taskChanges),
+          );
         }
 
         if (updates.length === 1) {
@@ -850,6 +857,20 @@ export class IssueService {
     }
 
     return false;
+  }
+
+  /**
+   * A poll result is applied as one plain `updateTask`, which never touches
+   * `remindAt`. Derive it here so a remote (re)schedule or unschedule lands with
+   * its reminder in the same op (#10047) — same default the import path uses.
+   */
+  private _withRemindAt(task: Task, taskChanges: Partial<Task>): Partial<Task> {
+    return withRemindAtForDueChange(
+      task,
+      taskChanges,
+      this._globalConfigService.cfg()?.reminder.defaultTaskRemindOption ??
+        DEFAULT_GLOBAL_CONFIG.reminder.defaultTaskRemindOption!,
+    );
   }
 
   private _getService(key: IssueProviderKey): IssueServiceInterface | undefined {

--- a/src/app/features/tasks/util/with-remind-at-for-due-change.spec.ts
+++ b/src/app/features/tasks/util/with-remind-at-for-due-change.spec.ts
@@ -1,0 +1,108 @@
+import { withRemindAtForDueChange } from './with-remind-at-for-due-change';
+import { TaskReminderOptionId } from '../task.model';
+
+describe('withRemindAtForDueChange', () => {
+  const MIN_10 = 10 * 60 * 1000;
+  const MIN_30 = 30 * 60 * 1000;
+  const MIN_60 = 60 * 60 * 1000;
+  const oldDue = new Date('2025-01-20T14:00:00Z').getTime();
+  const newDue = new Date('2025-01-21T09:00:00Z').getTime();
+  const hasRemindAt = (changes: object): boolean =>
+    Object.prototype.hasOwnProperty.call(changes, 'remindAt');
+
+  it('leaves changes alone when dueWithTime is not part of them', () => {
+    const changes = { title: 'renamed' };
+    const res = withRemindAtForDueChange(
+      { dueWithTime: oldDue, remindAt: oldDue },
+      changes,
+      TaskReminderOptionId.AtStart,
+    );
+    expect(res).toBe(changes);
+  });
+
+  it('leaves remindAt alone when dueWithTime is unchanged', () => {
+    const res = withRemindAtForDueChange(
+      { dueWithTime: oldDue, remindAt: undefined },
+      { dueWithTime: oldDue, title: 'renamed' },
+      TaskReminderOptionId.AtStart,
+    );
+    expect(hasRemindAt(res)).toBeFalse();
+  });
+
+  it('uses the default remind option when the task had no reminder', () => {
+    const res = withRemindAtForDueChange(
+      { dueWithTime: undefined, remindAt: undefined },
+      { dueWithTime: newDue },
+      TaskReminderOptionId.m10,
+    );
+    expect(res.remindAt).toBe(newDue - MIN_10);
+  });
+
+  it('keeps the existing reminder offset on a reschedule', () => {
+    const res = withRemindAtForDueChange(
+      { dueWithTime: oldDue, remindAt: oldDue - MIN_30 },
+      { dueWithTime: newDue },
+      TaskReminderOptionId.AtStart,
+    );
+    expect(res.remindAt).toBe(newDue - MIN_30);
+  });
+
+  it('falls back to the default when the task had a reminder but no dueWithTime', () => {
+    const res = withRemindAtForDueChange(
+      { dueWithTime: undefined, remindAt: oldDue },
+      { dueWithTime: newDue },
+      TaskReminderOptionId.h1,
+    );
+    expect(res.remindAt).toBe(newDue - MIN_60);
+  });
+
+  it('sets no reminder when the default is DoNotRemind', () => {
+    const res = withRemindAtForDueChange(
+      { dueWithTime: undefined, remindAt: undefined },
+      { dueWithTime: newDue },
+      TaskReminderOptionId.DoNotRemind,
+    );
+    expect(hasRemindAt(res)).toBeTrue();
+    expect(res.remindAt).toBeUndefined();
+  });
+
+  it('clears remindAt when dueWithTime is cleared with undefined', () => {
+    const res = withRemindAtForDueChange(
+      { dueWithTime: oldDue, remindAt: oldDue },
+      { dueWithTime: undefined },
+      TaskReminderOptionId.AtStart,
+    );
+    expect(hasRemindAt(res)).toBeTrue();
+    expect(res.remindAt).toBeUndefined();
+  });
+
+  it('clears remindAt when dueWithTime is cleared with null (CalDAV shape)', () => {
+    const res = withRemindAtForDueChange(
+      { dueWithTime: oldDue, remindAt: oldDue },
+      { dueWithTime: null, dueDay: null },
+      TaskReminderOptionId.AtStart,
+    );
+    expect(hasRemindAt(res)).toBeTrue();
+    expect(res.remindAt).toBeUndefined();
+  });
+
+  it('does not add a remindAt key when clearing a task that had no reminder', () => {
+    const changes = { dueWithTime: null };
+    const res = withRemindAtForDueChange(
+      { dueWithTime: oldDue, remindAt: undefined },
+      changes,
+      TaskReminderOptionId.AtStart,
+    );
+    expect(res).toBe(changes);
+  });
+
+  it('does not mutate the input changes', () => {
+    const changes = { dueWithTime: newDue };
+    withRemindAtForDueChange(
+      { dueWithTime: undefined, remindAt: undefined },
+      changes,
+      TaskReminderOptionId.AtStart,
+    );
+    expect(hasRemindAt(changes)).toBeFalse();
+  });
+});

--- a/src/app/features/tasks/util/with-remind-at-for-due-change.ts
+++ b/src/app/features/tasks/util/with-remind-at-for-due-change.ts
@@ -1,0 +1,43 @@
+import { Task, TaskReminderOptionId } from '../task.model';
+import {
+  millisecondsDiffToRemindOption,
+  remindOptionToMilliseconds,
+} from './remind-option-to-milliseconds';
+
+/**
+ * Keeps `remindAt` in step with a `dueWithTime` change that bypasses the
+ * schedule actions (e.g. an issue-provider poll writing a remote reschedule via
+ * a plain `updateTask`). Reminders fire strictly off `remindAt`, so a moved or
+ * cleared `dueWithTime` must carry the reminder along in the same change.
+ *
+ * - unchanged or absent `dueWithTime` → changes returned as-is
+ * - `dueWithTime` cleared → `remindAt` cleared (when one was set)
+ * - moved, with an existing reminder → the reminder keeps its offset
+ * - set for the first time → `defaultRemindCfg` decides, like the import path
+ *
+ * Computed at dispatch time on purpose: deriving it inside a reducer from the
+ * replaying device's config would break replay determinism (sync rule 4).
+ */
+export const withRemindAtForDueChange = (
+  task: Pick<Task, 'dueWithTime' | 'remindAt'>,
+  changes: Partial<Task>,
+  defaultRemindCfg: TaskReminderOptionId,
+): Partial<Task> => {
+  if (!Object.prototype.hasOwnProperty.call(changes, 'dueWithTime')) {
+    return changes;
+  }
+  const newDue = changes.dueWithTime;
+  if (typeof newDue !== 'number') {
+    return typeof task.remindAt === 'number'
+      ? { ...changes, remindAt: undefined }
+      : changes;
+  }
+  if (newDue === task.dueWithTime) {
+    return changes;
+  }
+  const remindCfg =
+    typeof task.dueWithTime === 'number' && typeof task.remindAt === 'number'
+      ? millisecondsDiffToRemindOption(task.dueWithTime, task.remindAt)
+      : defaultRemindCfg;
+  return { ...changes, remindAt: remindOptionToMilliseconds(newDue, remindCfg) };
+};


### PR DESCRIPTION
Closes #10047

## Problem

An issue-provider poll applies remote changes through a plain `updateTask`, which never touches `remindAt`. A task scheduled or rescheduled remotely (Plainspace, CalDAV, Calendar) therefore kept no reminder or a stale one, and a remotely unscheduled task kept its reminder. Shipped in v18.21.2 and v18.22.0.

## Fix

`withRemindAtForDueChange` (new pure helper in `src/app/features/tasks/util/`) derives `remindAt` from a `dueWithTime` change at dispatch time and puts it into the same change, so one poll result stays one op:

- existing reminder → keeps its offset (`millisecondsDiffToRemindOption`)
- first schedule → global `defaultTaskRemindOption`, same as the import path
- `dueWithTime` cleared (`null` or `undefined`) → `remindAt` cleared
- unchanged `dueWithTime` or none in the change → untouched

Both poll paths in `IssueService` (`refreshIssueTask`, `refreshIssueTasks`) run through it. No reducer, action, or setting added; nothing is derived inside a reducer, so replay stays deterministic.

## Repro first

- `test(e2e): reproduce #10047` — cherry-picked from the automated repro branch. Calendar event gains a start time remotely, poll applies it, alarm icon never appears. Red on master, green here.
- 5 new cases in `issue.service.spec.ts` (bulk + single refresh: first schedule, reschedule keeps offset, unschedule clears, unchanged leaves alone). 4 of 5 red on master.
- 10 cases for the helper.

## Verification

| Check | Result |
|---|---|
| `issue.service.spec.ts` + helper spec | 36/36 |
| all `features/issue` specs + reminder effects | 505/505 |
| E2E `issue-10047-poll-reschedule-remind-at.spec.ts` | passed |
| `checkFile` on all touched files | clean |

## Known gap (pre-existing, out of scope)

`TaskSharedActions.updateTask` does not list cleared fields (#9776 treatment), so `remindAt: undefined` will not replay on other devices. The shipped Plainspace `dueWithTime: undefined` poll unschedule has the same gap. Belongs in its own sync issue with a replay test.

## Notes for review

- Plugin providers are unaffected on poll: the adapter deletes due fields before applying a refresh.
- A remote due time already in the past yields an overdue reminder, matching what importing the same event does today.

https://claude.ai/code/session_01KNUKEMZ9BT3JjSGaX72q9n
