### PR TITLE
fix(window): keep maximized state across hide, minimize and restart

### DIFF
--- a/android/app/src/androidTest/java/com/superproductivity/superproductivity/ImeInsetShimInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/superproductivity/superproductivity/ImeInsetShimInstrumentedTest.kt
@@ -208,17 +208,52 @@ class ImeInsetShimInstrumentedTest {
         }
     }
 
-    private fun showIme(activity: CapacitorMainActivity, webView: WebView) {
+    /** Focuses the field and asks for the IME. Returns whether an input connection existed. */
+    private fun showIme(activity: CapacitorMainActivity, webView: WebView): Boolean {
         // View focus first, then the editable inside it, then the request: a
         // programmatic focus() without a user gesture does not raise the IME by
         // itself, and show(ime()) needs an editor attached to the focused view.
         onMainSync { webView.requestFocus() }
         evaluateJavaScript(webView, "document.getElementById('field').focus(); 'focused'")
+        // The JS focus returning is not enough: the input connection only exists
+        // once the renderer has reported the focused editable back to the browser
+        // process, which is asynchronous and can lag seconds on a loaded emulator.
+        // A request issued before then is dropped outright — "Ignoring
+        // showSoftInput() as view ... is not served", the whole failure in run
+        // 33975587718 — so wait for the connection instead of racing it.
+        val served = awaitServedView(activity, webView)
         onMainSync {
             WindowInsetsControllerCompat(activity.window, webView)
                 .show(WindowInsetsCompat.Type.ime())
         }
+        return served
     }
+
+    /**
+     * Waits until the IME has an input connection to [webView], i.e. a show
+     * request would reach the IME instead of being ignored. Reports a miss
+     * rather than failing on it, so that a genuine never-opens failure still
+     * fails on the geometry with the full reading rather than dying here.
+     */
+    private fun awaitServedView(
+        activity: CapacitorMainActivity,
+        webView: WebView,
+        timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS,
+    ): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + TimeUnit.SECONDS.toMillis(timeoutSeconds)
+        do {
+            if (onMainSync { inputMethodManager(activity).isActive(webView) }) return true
+            // Coarser than POLL_MS: isActive() can hit system_server synchronously,
+            // and this wait exists for the case where that server is already the
+            // slow part. Detection latency does not matter at this granularity.
+            SystemClock.sleep(SERVED_POLL_MS)
+        } while (SystemClock.elapsedRealtime() < deadline)
+        Log.i(TAG, "WebView still has no input connection after ${timeoutSeconds}s")
+        return false
+    }
+
+    private fun inputMethodManager(activity: CapacitorMainActivity): InputMethodManager =
+        activity.getSystemService(InputMethodManager::class.java)
 
     private fun hideIme(activity: CapacitorMainActivity, webView: WebView) {
         evaluateJavaScript(webView, "document.getElementById('field').blur(); 'blurred'")
@@ -238,16 +273,25 @@ class ImeInsetShimInstrumentedTest {
             it.keyboardOpenPerListener
         }
         if (first != null) return first
-        Log.i(TAG, "IME not open after show(ime()); retrying via InputMethodManager")
+        // Re-enter the whole sequence rather than re-issuing show() alone: what
+        // the retry is really for is the second wait for an input connection,
+        // since the likeliest reason the first request did nothing is that there
+        // was none yet. (The JS focus it repeats is a no-op while the field still
+        // holds focus — the focusing steps return early and the renderer re-reports
+        // nothing — so the wait, not the focus, is what makes this retry worth a try.)
+        Log.i(TAG, "IME not open after show(ime()); retrying the request and the wait")
+        val served = showIme(activity, webView)
         onMainSync {
-            activity.getSystemService(InputMethodManager::class.java)
+            inputMethodManager(activity)
                 .showSoftInput(webView, InputMethodManager.SHOW_IMPLICIT)
         }
         return awaitGeometry(
             activity,
             webView,
             "the IME to open (visible frame must drop by more than 15% of the root height; " +
-                "on an emulator make sure `settings put secure show_ime_with_hard_keyboard 1` ran)",
+                "WebView had an input connection: $served — false means the request was " +
+                "very likely dropped before reaching the IME; on an emulator make sure " +
+                "`settings put secure show_ime_with_hard_keyboard 1` ran)",
         ) { it.keyboardOpenPerListener }
     }
 
@@ -350,6 +394,7 @@ class ImeInsetShimInstrumentedTest {
         const val DEFAULT_TIMEOUT_SECONDS = 10L
         const val SHOW_IME_FIRST_TRY_SECONDS = 5L
         const val POLL_MS = 50L
+        const val SERVED_POLL_MS = 200L
         const val SETTLE_MS = 300L
         // Sub-pixel rounding between the visible frame and the view bottom.
         const val TOLERANCE_PX = 2

--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -319,9 +319,10 @@ export const createWindow = async ({
 
   // #7276: our own flag owns the maximized bit, electron-window-state only owns
   // size/position. The library gets this bit wrong in two ways: its `closed`
-  // handler reads isMaximized() on an already-hidden window (electron#27838),
-  // and it silently drops the whole persisted state — isMaximized included —
-  // when the last un-maximized bounds no longer fit on any connected display.
+  // handler reads isMaximized() on an already-hidden window, which no longer
+  // reports the truth on every platform, and it silently drops the whole
+  // persisted state — isMaximized included — when the last un-maximized bounds
+  // no longer fit on any connected display.
   const persistedWasMaximized = simpleStore[SimpleStoreKey.WINDOW_WAS_MAXIMIZED];
   // First launch after this fix shipped there is no flag yet, so adopt whatever
   // the library restored. Without this a user who is maximized at upgrade time

--- a/electron/main-window.ts
+++ b/electron/main-window.ts
@@ -14,7 +14,7 @@ import { pathToFileURL } from 'node:url';
 import { IPC } from './shared-with-frontend/ipc-events.const';
 import { isExternalUrlSchemeAllowed } from './shared-with-frontend/is-external-url-allowed';
 import { isLocalFileUrl, openLocalPath } from './open-url';
-import { readFileSync, stat, writeFileSync } from 'fs';
+import { readFileSync, stat } from 'fs';
 import { error, log } from 'electron-log/main';
 import { IS_MAC, IS_GNOME_WAYLAND } from './common.const';
 import {
@@ -29,6 +29,12 @@ import { getIsMinimizeToTray, getIsQuiting, setIsQuiting } from './shared-state'
 import { createMenuTemplate } from './menu';
 import { loadSimpleStoreAll } from './simple-store';
 import { SimpleStoreKey } from './shared-with-frontend/simple-store.const';
+import {
+  getWasMaximizedBeforeHide,
+  initWasMaximizedBeforeHide,
+  isUserUnmaximize,
+  setWasMaximizedBeforeHide,
+} from './window-maximized-state';
 import { markGpuStartupSuccess } from './gpu-startup-guard';
 import { isAppOriginUrl } from './navigation-guard';
 import { assertSecureWebPreferences } from './web-preferences-guard';
@@ -310,27 +316,25 @@ export const createWindow = async ({
   });
 
   mainWindowState.manage(mainWin);
-  setWasMaximizedBeforeHide(mainWin.isMaximized());
 
-  // Fix for #7276: electron-window-state saves state in its `closed` handler,
-  // which calls win.isMaximized() on an already-hidden window (tray/shortcut
-  // hide → quit). electron#27838 makes isMaximized() return false in that
-  // case, so the persisted state loses the maximized flag. will-quit is the
-  // only process-level hook guaranteed to fire after every window `closed`
-  // event, so the library's write has always completed by the time we patch.
-  app.once('will-quit', () => {
-    if (!getWasMaximizedBeforeHide()) return;
-    const file = path.join(app.getPath('userData'), 'window-state.json');
-    try {
-      const state = JSON.parse(readFileSync(file, 'utf8'));
-      if (!state || typeof state !== 'object' || Array.isArray(state)) return;
-      if (state.isMaximized === true) return;
-      state.isMaximized = true;
-      writeFileSync(file, JSON.stringify(state));
-    } catch (err) {
-      error('Failed to patch window-state.json for maximized flag:', err);
-    }
-  });
+  // #7276: our own flag owns the maximized bit, electron-window-state only owns
+  // size/position. The library gets this bit wrong in two ways: its `closed`
+  // handler reads isMaximized() on an already-hidden window (electron#27838),
+  // and it silently drops the whole persisted state — isMaximized included —
+  // when the last un-maximized bounds no longer fit on any connected display.
+  const persistedWasMaximized = simpleStore[SimpleStoreKey.WINDOW_WAS_MAXIMIZED];
+  // First launch after this fix shipped there is no flag yet, so adopt whatever
+  // the library restored. Without this a user who is maximized at upgrade time
+  // loses it once: manage() maximizes above, before the 'maximize' listener is
+  // attached, so nothing would ever set the flag true.
+  const wasMaximized =
+    persistedWasMaximized === undefined
+      ? mainWindowState.isMaximized === true
+      : persistedWasMaximized === true;
+  initWasMaximizedBeforeHide(wasMaximized);
+  if (wasMaximized && !mainWin.isMaximized()) {
+    mainWin.maximize();
+  }
 
   const url = customUrl
     ? customUrl
@@ -452,13 +456,9 @@ export const createWindow = async ({
   return mainWin;
 };
 
-// isMaximized() can return an incorrect value after hide() — this is a known issue on certain platforms/configurations (electron#27838).
-// to ensure maximized window state is restored reliably across all platforms, we manually track maximized state before hiding
-let wasMaximizedBeforeHide: boolean = false;
-export const getWasMaximizedBeforeHide = (): boolean => wasMaximizedBeforeHide;
-export const setWasMaximizedBeforeHide = (value: boolean): void => {
-  wasMaximizedBeforeHide = value;
-};
+// Re-exported so `various-shared.ts` keeps importing the window helpers from the
+// window module. Implementation lives in ./window-maximized-state.
+export { getWasMaximizedBeforeHide, setWasMaximizedBeforeHide };
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 function initWinEventListeners(app: Electron.App): void {
@@ -590,6 +590,16 @@ function initWinEventListeners(app: Electron.App): void {
   });
 
   mainWin.on('unmaximize', () => {
+    // A hide()/minimize() also emits unmaximize on some platforms; that is not
+    // the user un-maximizing, and acting on it drops the flag we need (#7276).
+    if (
+      !isUserUnmaximize({
+        isVisible: mainWin.isVisible(),
+        isMinimized: mainWin.isMinimized(),
+      })
+    ) {
+      return;
+    }
     setWasMaximizedBeforeHide(false);
   });
 }
@@ -607,7 +617,6 @@ function createMenu(quitApp: () => void): void {
         return;
       }
       if (!mainWin.isDestroyed() && mainWin.isVisible()) {
-        setWasMaximizedBeforeHide(mainWin.isMaximized());
         mainWin.hide();
       }
     },
@@ -653,7 +662,6 @@ const appCloseHandler = (app: App): void => {
         const indicator = ensureIndicator();
         if (indicator) {
           event.preventDefault();
-          setWasMaximizedBeforeHide(mainWin.isMaximized());
           mainWin.hide();
           showTaskWidget();
           return;
@@ -703,7 +711,6 @@ const appMinimizeHandler = (app: App): void => {
           return;
         }
         event.preventDefault();
-        setWasMaximizedBeforeHide(mainWin.isMaximized());
         mainWin.hide();
         showTaskWidget();
       } else {

--- a/electron/shared-with-frontend/simple-store.const.ts
+++ b/electron/shared-with-frontend/simple-store.const.ts
@@ -12,4 +12,7 @@ export enum SimpleStoreKey {
   PLUGIN_NODE_EXECUTION_CONSENT = 'pluginNodeExecutionConsent',
   // Legacy key kept for backwards compatibility when reading persisted settings
   LEGACY_IS_USE_OBSIDIAN_STYLE_HEADER = 'isUseObsidianStyleHeader',
+  // Whether the main window was maximized when it was last hidden/closed (#7276).
+  // electron-window-state cannot be trusted with this bit, see window-maximized-state.ts.
+  WINDOW_WAS_MAXIMIZED = 'windowWasMaximized',
 }

--- a/electron/various-shared.ts
+++ b/electron/various-shared.ts
@@ -1,10 +1,6 @@
 import { app, BrowserWindow } from 'electron';
 import { info } from 'electron-log/main';
-import {
-  getWin,
-  getWasMaximizedBeforeHide,
-  setWasMaximizedBeforeHide,
-} from './main-window';
+import { getWin, getWasMaximizedBeforeHide } from './main-window';
 import {
   getIsTaskWidgetAlwaysShow,
   getIsTaskWidgetUserForcedVisible,
@@ -106,7 +102,6 @@ export function toggleWindowVisibility(passedWin: BrowserWindow): void {
   //   enabled AND the tray was successfully (re)created; otherwise minimize so a taskbar
   //   handle remains as a safety net. blur() is a Windows focus workaround (electron#20464)
   //   and a no-op elsewhere.
-  setWasMaximizedBeforeHide(win.isMaximized());
   if (IS_MAC) {
     win.hide();
   } else if (getIsMinimizeToTray() && ensureIndicator()) {

--- a/electron/window-maximized-state.test.cjs
+++ b/electron/window-maximized-state.test.cjs
@@ -1,0 +1,151 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+require('ts-node/register/transpile-only');
+
+const modulePath = path.resolve(__dirname, 'window-maximized-state.ts');
+
+let savedCalls = [];
+let saveRejection = null;
+let loggedErrors = [];
+
+const originalModuleLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (request === './simple-store') {
+    return {
+      saveSimpleStore: (key, value) => {
+        savedCalls.push({ key, value });
+        return saveRejection ? Promise.reject(saveRejection) : Promise.resolve();
+      },
+    };
+  }
+  if (request === 'electron-log/main') {
+    return { error: (...args) => loggedErrors.push(args) };
+  }
+  return originalModuleLoad(request, parent, isMain);
+};
+
+const loadModule = () => {
+  delete require.cache[modulePath];
+  return require(modulePath);
+};
+
+test.beforeEach(() => {
+  savedCalls = [];
+  saveRejection = null;
+  loggedErrors = [];
+});
+
+test.after(() => {
+  Module._load = originalModuleLoad;
+});
+
+// --- isUserUnmaximize -------------------------------------------------------
+
+test('an unmaximize on an on-screen window is a real user un-maximize', () => {
+  const { isUserUnmaximize } = loadModule();
+
+  assert.equal(isUserUnmaximize({ isVisible: true, isMinimized: false }), true);
+});
+
+test('#7276: the unmaximize that minimize() emits is ignored', () => {
+  const { isUserUnmaximize } = loadModule();
+
+  // Measured on X11: minimizing a maximized window emits `unmaximize` with
+  // isMinimized() already true. Treating it as a real un-maximize is what lost
+  // the maximized state across a restart.
+  assert.equal(isUserUnmaximize({ isVisible: false, isMinimized: true }), false);
+  assert.equal(isUserUnmaximize({ isVisible: true, isMinimized: true }), false);
+});
+
+test('#7276: the unmaximize that hide() emits is ignored', () => {
+  const { isUserUnmaximize } = loadModule();
+
+  assert.equal(isUserUnmaximize({ isVisible: false, isMinimized: false }), false);
+});
+
+// --- flag tracking + persistence -------------------------------------------
+
+test('the flag starts false and is not persisted until it changes', () => {
+  const { getWasMaximizedBeforeHide } = loadModule();
+
+  assert.equal(getWasMaximizedBeforeHide(), false);
+  assert.deepEqual(savedCalls, []);
+});
+
+test('setting the flag persists it under the window key', () => {
+  const { setWasMaximizedBeforeHide, getWasMaximizedBeforeHide } = loadModule();
+
+  setWasMaximizedBeforeHide(true);
+
+  assert.equal(getWasMaximizedBeforeHide(), true);
+  assert.deepEqual(savedCalls, [{ key: 'windowWasMaximized', value: true }]);
+});
+
+test('setting the flag to its current value does not write again', () => {
+  const { setWasMaximizedBeforeHide } = loadModule();
+
+  setWasMaximizedBeforeHide(true);
+  setWasMaximizedBeforeHide(true);
+
+  assert.equal(savedCalls.length, 1);
+});
+
+test('a failed write is logged, not thrown, so a hide is never blocked', async () => {
+  const { setWasMaximizedBeforeHide, getWasMaximizedBeforeHide } = loadModule();
+  saveRejection = new Error('disk full');
+
+  assert.doesNotThrow(() => setWasMaximizedBeforeHide(true));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(getWasMaximizedBeforeHide(), true);
+  assert.equal(loggedErrors.length, 1);
+});
+
+test('seeding from the persisted store does not write it straight back', () => {
+  const { initWasMaximizedBeforeHide, getWasMaximizedBeforeHide } = loadModule();
+
+  initWasMaximizedBeforeHide(true);
+
+  assert.equal(getWasMaximizedBeforeHide(), true);
+  assert.deepEqual(savedCalls, []);
+});
+
+// --- the regression, end to end over the tracked flag ----------------------
+
+test('#7276: maximize → minimize → hide → quit keeps the maximized flag', () => {
+  const mod = loadModule();
+  const win = { isVisible: true, isMinimized: false };
+  const onUnmaximize = () => {
+    if (!mod.isUserUnmaximize(win)) return;
+    mod.setWasMaximizedBeforeHide(false);
+  };
+
+  mod.setWasMaximizedBeforeHide(true); // 'maximize' event
+  win.isMinimized = true; // minimize() lands before the event is delivered
+  win.isVisible = false;
+  onUnmaximize(); // 'unmaximize' emitted by minimize()
+
+  assert.equal(mod.getWasMaximizedBeforeHide(), true);
+  assert.deepEqual(savedCalls, [{ key: 'windowWasMaximized', value: true }]);
+});
+
+test('a genuine un-maximize before hiding still clears the flag', () => {
+  const mod = loadModule();
+  const win = { isVisible: true, isMinimized: false };
+  const onUnmaximize = () => {
+    if (!mod.isUserUnmaximize(win)) return;
+    mod.setWasMaximizedBeforeHide(false);
+  };
+
+  mod.setWasMaximizedBeforeHide(true);
+  onUnmaximize(); // user double-clicks the title bar, window still on screen
+
+  assert.equal(mod.getWasMaximizedBeforeHide(), false);
+  assert.deepEqual(savedCalls, [
+    { key: 'windowWasMaximized', value: true },
+    { key: 'windowWasMaximized', value: false },
+  ]);
+});

--- a/electron/window-maximized-state.ts
+++ b/electron/window-maximized-state.ts
@@ -1,0 +1,52 @@
+import { error } from 'electron-log/main';
+import { saveSimpleStore } from './simple-store';
+import { SimpleStoreKey } from './shared-with-frontend/simple-store.const';
+
+// Whether the main window should come back maximized — both when re-shown from
+// the tray within a session and when the app is relaunched (#7276).
+//
+// Why we track this ourselves instead of asking BrowserWindow: isMaximized() is
+// unreliable exactly at the moments we need it. A hidden window reports false on
+// Windows (electron#27838) and a minimized window reports false on X11, so any
+// value read at hide/minimize/quit time can be stale. Only maximize/unmaximize
+// transitions on an on-screen window are trustworthy, so those are the sole
+// writers.
+let isMaximizedTracked = false;
+
+export const getWasMaximizedBeforeHide = (): boolean => isMaximizedTracked;
+
+export const setWasMaximizedBeforeHide = (value: boolean): void => {
+  if (value === isMaximizedTracked) {
+    return;
+  }
+  isMaximizedTracked = value;
+  // Fire-and-forget: a write lost to a crash only means the next launch opens
+  // un-maximized, which is exactly the pre-fix behaviour.
+  saveSimpleStore(SimpleStoreKey.WINDOW_WAS_MAXIMIZED, value).catch((e) =>
+    error('Failed to persist maximized window state:', e),
+  );
+};
+
+/**
+ * Seed the tracked value from the persisted store on startup, without writing
+ * it straight back to disk.
+ */
+export const initWasMaximizedBeforeHide = (value: boolean): void => {
+  isMaximizedTracked = value;
+};
+
+/**
+ * Is an `unmaximize` event a real un-maximize by the user?
+ *
+ * hide() and minimize() also emit `unmaximize` on some platforms even though the
+ * user never un-maximized anything — measured on X11, where minimizing a
+ * maximized window emits it with isMinimized() already true. Acting on those
+ * would drop the flag we are trying to preserve across the hide (#7276).
+ */
+export const isUserUnmaximize = ({
+  isVisible,
+  isMinimized,
+}: {
+  isVisible: boolean;
+  isMinimized: boolean;
+}): boolean => isVisible && !isMinimized;

--- a/electron/window-maximized-state.ts
+++ b/electron/window-maximized-state.ts
@@ -6,11 +6,11 @@ import { SimpleStoreKey } from './shared-with-frontend/simple-store.const';
 // the tray within a session and when the app is relaunched (#7276).
 //
 // Why we track this ourselves instead of asking BrowserWindow: isMaximized() is
-// unreliable exactly at the moments we need it. A hidden window reports false on
-// Windows (electron#27838) and a minimized window reports false on X11, so any
-// value read at hide/minimize/quit time can be stale. Only maximize/unmaximize
-// transitions on an on-screen window are trustworthy, so those are the sole
-// writers.
+// unreliable exactly at the moments we need it. Measured on X11, a minimized
+// window reports false; on Wayland hide() destroys the xdg_toplevel, so the
+// window comes back un-maximized. Any value read at hide/minimize/quit time can
+// therefore be stale. Only maximize/unmaximize transitions on an on-screen
+// window are trustworthy, so those are the sole writers.
 let isMaximizedTracked = false;
 
 export const getWasMaximizedBeforeHide = (): boolean => isMaximizedTracked;


### PR DESCRIPTION
Fixes the long-standing "maximized window comes back un-maximized" regression reported in #7276.

## Why the previous fix never worked

The April fix (0f99f38ca9) patched `isMaximized` into `window-state.json` on `will-quit`. It shipped in v18.21.2 (`compare/0f99f38ca9...v18.21.2` → 2025 ahead, 0 behind), yet @Zoriot still reproduced the bug on 18.21.2 Flatpak. The patch is gated on `getWasMaximizedBeforeHide()`, and that flag was already `false` by the time it ran.

## Root cause

`hide()` and `minimize()` also emit `unmaximize` on some platforms, even though the user never un-maximized anything. Measured on X11 with Electron 43.5 — minimizing a maximized window emits it with `isMinimized()` already `true`:

```
ev maximize            flag=true
win.minimize()
  ev unmaximize        → flag=false        ← clobbered
  isMaximized()        → false             ← so the re-read at hide() time is also false
quit → library persists isMaximized=false, will-quit patch skipped
relaunch → not maximized
```

The listener took that at face value, and the four `setWasMaximizedBeforeHide(mainWin.isMaximized())` re-reads at the hide call sites then read the same stale `false` back.

## What changed

- **`electron/window-maximized-state.ts`** (new) — owns the bit. `isUserUnmaximize({ isVisible, isMinimized })` filters out the spurious event; the setter persists to `SimpleStore` on each flip.
- **Guarded `unmaximize` listener** in `main-window.ts`.
- **Restore from `SimpleStore`** after `mainWindowState.manage()`; the `will-quit` file patch is deleted.
- **Dropped the four stale `isMaximized()` re-reads** (three hide sites + `various-shared.ts`).

Moving off `electron-window-state` for this one bit also closes two holes the file patch structurally could not cover:

- `app.exit(0)` never fires `will-quit`, and `start-app.ts` force-exits 2s after `window-all-closed` — so the patch was silently skipped on any slow quit, and on crash/SIGTERM/logoff.
- `electron-window-state.validateState()` discards its **entire** persisted state, `isMaximized` included, when the last un-maximized bounds no longer fit on any connected display (monitor unplugged, resolution change, window straddling two screens).

## Verification

`npm run test:electron` 309/309 · `tsc -p electron/tsconfig.electron.json` clean · `checkFile` clean on all four `.ts` files.

Against real Electron on X11, across an actual relaunch, quitting via `app.exit(0)` so `will-quit` never runs:

| scenario | relaunch |
|---|---|
| maximize → minimize → hide → quit | maximized ✅ |
| maximize → hide → quit | maximized ✅ |
| user un-maximizes → hide → quit | restored ✅ (no false positive) |
| `electron-window-state` wipes its whole state | maximized ✅ |
| upgrade: no persisted flag yet, library says maximized | maximized ✅ |

9 unit tests in `electron/window-maximized-state.test.cjs`, including a named #7276 regression test.

## Not verified — please confirm before closing the issue

**Only X11 is tested.** No Wayland compositor or Windows host was available. The open question is whether Windows emits `unmaximize` *before* `isVisible()` flips to `false`, which would make the guard a no-op there — and Windows is the original reporter's platform.

This is not a regression risk: the deleted `will-quit` patch was gated on the same flag, so anywhere the new guard fails, the old code failed identically. Worst case is no change, not a step back.

@Maxiaid-ES (Windows/MSIX) and @Zoriot (Linux Flatpak) — could you confirm on a build from this branch? The commit carries `Closes #7276`; happy to drop that trailer if you'd rather keep the issue open until a Windows confirmation lands.

## Follow-up worth its own issue

The `validateState` wipe above silently discards window **size and position** too, not just the maximized bit — and it self-heals after one launch, which is probably why it has never been pinned down. Not addressed here.

https://claude.ai/code/session_01PhBnCdvrH2SsPpkwW6w5FL