### PR TITLE
fix(tags): make Tab accept a suggestion and Enter use the typed text #9722

### DIFF
--- a/docs/wiki/3.03-Keyboard-Shortcuts.md
+++ b/docs/wiki/3.03-Keyboard-Shortcuts.md
@@ -58,6 +58,15 @@ The search bar searches open tasks by default. Enable **Include completed and ar
 - `Ctrl+9`: Open deadline dialog (set hard deadline)
 - `Ctrl+Enter`: Reveal the note field (or add the task when the note is focused)
 
+### Tag Input (while the tag suggestions are open)
+
+Applies to the tag field in the task detail panel and to the tag pickers in the repeat and issue-provider dialogs.
+
+- `Tab`: Add the highlighted suggestion, or the first one if none is highlighted
+- `Enter`: Add the tag whose name matches the typed text exactly, or create a new tag from the typed text
+- `↑` / `↓`: Highlight a suggestion (`Enter` then adds it)
+- `Shift+Tab`: Leave the field without adding anything; the typed text is discarded
+
 ### Tasks
 
 The following shortcuts apply for the currently selected task (selected via tab or mouse).

--- a/docs/wiki/3.03-Keyboard-Shortcuts.md
+++ b/docs/wiki/3.03-Keyboard-Shortcuts.md
@@ -62,7 +62,7 @@ The search bar searches open tasks by default. Enable **Include completed and ar
 
 Applies to the tag field in the task detail panel and to the tag pickers in the repeat and issue-provider dialogs.
 
-- `Tab`: Add the highlighted suggestion, or the first one if none is highlighted
+- `Tab`: After typing, add the highlighted suggestion, or the first one if none is highlighted (on an empty field, `Tab` just moves focus on)
 - `Enter`: Add the tag whose name matches the typed text exactly, or create a new tag from the typed text
 - `↑` / `↓`: Highlight a suggestion (`Enter` then adds it)
 - `Shift+Tab`: Leave the field without adding anything; the typed text is discarded

--- a/src/app/features/tag/tag-edit/tag-edit.component.html
+++ b/src/app/features/tag/tag-edit/tag-edit.component.html
@@ -26,6 +26,9 @@
     [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
     (keydown)="onKeydown($event)"
     [placeholder]="T.F.TAG.D_EDIT.PLACEHOLDER | translate"
+    spChipAutocompleteKeys
+    (suggestionAccepted)="acceptSuggestion($event)"
+    (textCommitted)="commitText($event)"
   />
 </mat-chip-grid>
 <mat-autocomplete

--- a/src/app/features/tag/tag-edit/tag-edit.component.spec.ts
+++ b/src/app/features/tag/tag-edit/tag-edit.component.spec.ts
@@ -23,9 +23,19 @@ describe('TagEditComponent', () => {
   const getInput = (): HTMLInputElement =>
     fixture.nativeElement.querySelector('input') as HTMLInputElement;
 
-  const pressKey = (key: string, keyCode: number): boolean =>
+  const pressKey = (
+    key: string,
+    keyCode: number,
+    init: KeyboardEventInit = {},
+  ): boolean =>
     getInput().dispatchEvent(
-      new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key, keyCode }),
+      new KeyboardEvent('keydown', {
+        bubbles: true,
+        cancelable: true,
+        key,
+        keyCode,
+        ...init,
+      }),
     );
 
   const openPanelWith = async (text: string): Promise<void> => {
@@ -120,6 +130,16 @@ describe('TagEditComponent', () => {
 
       expect(tagUpdateSpy).toHaveBeenCalledOnceWith(['A', 'B']);
       expect(addTagSpy).not.toHaveBeenCalled();
+    });
+
+    it('Shift+Tab adds nothing and drops the partial text', async () => {
+      await openPanelWith('ban');
+
+      pressKey('Tab', TAB, { shiftKey: true });
+
+      expect(tagUpdateSpy).not.toHaveBeenCalled();
+      expect(addTagSpy).not.toHaveBeenCalled();
+      expect(getInput().value).toBe('');
     });
   });
 });

--- a/src/app/features/tag/tag-edit/tag-edit.component.spec.ts
+++ b/src/app/features/tag/tag-edit/tag-edit.component.spec.ts
@@ -132,6 +132,16 @@ describe('TagEditComponent', () => {
       expect(addTagSpy).not.toHaveBeenCalled();
     });
 
+    it('Tab on an untouched input adds nothing and lets focus move on', async () => {
+      await openPanelWith('');
+
+      const notPrevented = pressKey('Tab', TAB);
+
+      expect(tagUpdateSpy).not.toHaveBeenCalled();
+      expect(addTagSpy).not.toHaveBeenCalled();
+      expect(notPrevented).toBeTrue();
+    });
+
     it('Shift+Tab adds nothing and drops the partial text', async () => {
       await openPanelWith('ban');
 

--- a/src/app/features/tag/tag-edit/tag-edit.component.spec.ts
+++ b/src/app/features/tag/tag-edit/tag-edit.component.spec.ts
@@ -1,0 +1,125 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+import { DOWN_ARROW, ENTER, TAB } from '@angular/cdk/keycodes';
+import { TagEditComponent } from './tag-edit.component';
+import { TagService } from '../tag.service';
+import { TaskService } from '../../tasks/task.service';
+
+describe('TagEditComponent', () => {
+  let fixture: ComponentFixture<TagEditComponent>;
+  let component: TagEditComponent;
+  let tagUpdateSpy: jasmine.Spy;
+  let addTagSpy: jasmine.Spy;
+
+  const tags = [
+    { id: 'A', title: 'Apple' },
+    { id: 'B', title: 'Banana' },
+    { id: 'D', title: 'Blueberry' },
+    { id: 'C', title: 'Cherry' },
+  ];
+
+  const getInput = (): HTMLInputElement =>
+    fixture.nativeElement.querySelector('input') as HTMLInputElement;
+
+  const pressKey = (key: string, keyCode: number): boolean =>
+    getInput().dispatchEvent(
+      new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key, keyCode }),
+    );
+
+  const openPanelWith = async (text: string): Promise<void> => {
+    const input = getInput();
+    input.focus();
+    input.value = text;
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(component.matAutocomplete()?.isOpen)
+      .withContext('autocomplete panel should be open')
+      .toBeTrue();
+  };
+
+  beforeEach(async () => {
+    addTagSpy = jasmine.createSpy('addTag').and.returnValue('NEW');
+    await TestBed.configureTestingModule({
+      imports: [TagEditComponent, NoopAnimationsModule, TranslateModule.forRoot()],
+      providers: [
+        {
+          provide: TagService,
+          useValue: {
+            tagsInTreeOrder: signal(tags),
+            tagsNoMyDayAndNoListInTreeOrder: signal(tags),
+            addTag: addTagSpy,
+          },
+        },
+        { provide: TaskService, useValue: { updateTags: jasmine.createSpy() } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TagEditComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('tagIds', ['A']);
+    tagUpdateSpy = jasmine.createSpy('tagUpdate');
+    component.tagUpdate.subscribe(tagUpdateSpy);
+    fixture.detectChanges();
+  });
+
+  it('renders a chip for each tag id', () => {
+    expect(fixture.nativeElement.querySelectorAll('mat-chip-row').length).toBe(1);
+  });
+
+  describe('keyboard with the autocomplete panel open (#9722)', () => {
+    it('Tab accepts the first suggestion instead of creating a new tag', async () => {
+      await openPanelWith('ban');
+
+      const notPrevented = pressKey('Tab', TAB);
+
+      expect(tagUpdateSpy).toHaveBeenCalledOnceWith(['A', 'B']);
+      expect(addTagSpy).not.toHaveBeenCalled();
+      expect(notPrevented).toBeFalse();
+      expect(getInput().value).toBe('');
+    });
+
+    it('Tab accepts the suggestion highlighted with the arrow keys', async () => {
+      await openPanelWith('b');
+      pressKey('ArrowDown', DOWN_ARROW);
+      pressKey('ArrowDown', DOWN_ARROW);
+
+      pressKey('Tab', TAB);
+
+      expect(tagUpdateSpy).toHaveBeenCalledOnceWith(['A', 'D']);
+      expect(addTagSpy).not.toHaveBeenCalled();
+    });
+
+    it('Enter with no highlighted suggestion creates a new tag from the typed text', async () => {
+      await openPanelWith('ban');
+
+      pressKey('Enter', ENTER);
+
+      expect(addTagSpy).toHaveBeenCalledOnceWith({ title: 'ban' });
+      expect(tagUpdateSpy).toHaveBeenCalledOnceWith(['A', 'NEW']);
+      expect(getInput().value).toBe('');
+    });
+
+    it('Enter with no highlighted suggestion adds the existing tag on an exact title match', async () => {
+      await openPanelWith('Banana');
+
+      pressKey('Enter', ENTER);
+
+      expect(tagUpdateSpy).toHaveBeenCalledOnceWith(['A', 'B']);
+      expect(addTagSpy).not.toHaveBeenCalled();
+    });
+
+    it('Enter with a highlighted suggestion adds only that suggestion', async () => {
+      await openPanelWith('ban');
+      pressKey('ArrowDown', DOWN_ARROW);
+
+      pressKey('Enter', ENTER);
+
+      expect(tagUpdateSpy).toHaveBeenCalledOnceWith(['A', 'B']);
+      expect(addTagSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/features/tag/tag-edit/tag-edit.component.ts
+++ b/src/app/features/tag/tag-edit/tag-edit.component.ts
@@ -1,4 +1,5 @@
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   computed,
@@ -6,6 +7,7 @@ import {
   ElementRef,
   inject,
   input,
+  OnDestroy,
   output,
   signal,
   viewChild,
@@ -25,7 +27,7 @@ import {
 } from '@angular/material/chips';
 import { MatIcon } from '@angular/material/icon';
 import { ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
-import { COMMA, ENTER } from '@angular/cdk/keycodes';
+import { COMMA, ENTER, hasModifierKey } from '@angular/cdk/keycodes';
 import { T } from '../../../t.const';
 import { TagService } from '../tag.service';
 import { TaskService } from '../../tasks/task.service';
@@ -64,7 +66,7 @@ const DEFAULT_SEPARATOR_KEY_CODES: number[] = [ENTER, COMMA];
   styleUrl: './tag-edit.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TagEditComponent {
+export class TagEditComponent implements AfterViewInit, OnDestroy {
   T: typeof T = T;
 
   private _tagService = inject(TagService);
@@ -84,6 +86,7 @@ export class TagEditComponent {
 
   readonly inputEl = viewChild<ElementRef<HTMLInputElement>>('inputElRef');
   readonly matAutocomplete = viewChild<MatAutocomplete>('autoElRef');
+  readonly autocompleteTrigger = viewChild(MatAutocompleteTrigger);
 
   inputVal = signal<string>('');
   tagSuggestions = computed(() =>
@@ -172,6 +175,52 @@ export class TagEditComponent {
 
   selected(event: MatAutocompleteSelectedEvent): void {
     this._add(event.option.value);
+    this._clearInput();
+  }
+
+  ngAfterViewInit(): void {
+    this.inputEl()?.nativeElement.addEventListener(
+      'keydown',
+      this._onCapturingKeydown,
+      true,
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.inputEl()?.nativeElement.removeEventListener(
+      'keydown',
+      this._onCapturingKeydown,
+      true,
+    );
+  }
+
+  private readonly _onCapturingKeydown = (ev: KeyboardEvent): void => {
+    const autocomplete = this.matAutocomplete();
+    const trigger = this.autocompleteTrigger();
+    if (!autocomplete?.isOpen || !trigger || hasModifierKey(ev)) {
+      return;
+    }
+
+    if (ev.key === 'Tab') {
+      const option = trigger.activeOption ?? autocomplete.options.first;
+      if (option) {
+        ev.preventDefault();
+        this._add(option.value);
+        this._clearInput();
+        trigger.closePanel();
+      }
+    } else if (ev.key === 'Enter' && !trigger.activeOption) {
+      ev.preventDefault();
+      const value = (this.inputCtrl.value || '').trim();
+      this._clearInput();
+      trigger.closePanel();
+      if (value) {
+        this._addByTitle(value);
+      }
+    }
+  };
+
+  private _clearInput(): void {
     const inputEl = this.inputEl();
     if (inputEl) {
       inputEl.nativeElement.value = '';

--- a/src/app/features/tag/tag-edit/tag-edit.component.ts
+++ b/src/app/features/tag/tag-edit/tag-edit.component.ts
@@ -1,5 +1,4 @@
 import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   computed,
@@ -7,7 +6,6 @@ import {
   ElementRef,
   inject,
   input,
-  OnDestroy,
   output,
   signal,
   viewChild,
@@ -27,7 +25,7 @@ import {
 } from '@angular/material/chips';
 import { MatIcon } from '@angular/material/icon';
 import { ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
-import { COMMA, ENTER, hasModifierKey } from '@angular/cdk/keycodes';
+import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { T } from '../../../t.const';
 import { TagService } from '../tag.service';
 import { TaskService } from '../../tasks/task.service';
@@ -36,6 +34,7 @@ import { TagComponent } from '../tag/tag.component';
 import { TranslatePipe } from '@ngx-translate/core';
 import { TODAY_TAG } from '../tag.const';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ChipAutocompleteKeysDirective } from '../../../ui/chip-autocomplete-keys/chip-autocomplete-keys.directive';
 
 interface Suggestion {
   id: string;
@@ -61,12 +60,13 @@ const DEFAULT_SEPARATOR_KEY_CODES: number[] = [ENTER, COMMA];
     ReactiveFormsModule,
     MatOption,
     TranslatePipe,
+    ChipAutocompleteKeysDirective,
   ],
   templateUrl: './tag-edit.component.html',
   styleUrl: './tag-edit.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TagEditComponent implements AfterViewInit, OnDestroy {
+export class TagEditComponent {
   T: typeof T = T;
 
   private _tagService = inject(TagService);
@@ -86,7 +86,6 @@ export class TagEditComponent implements AfterViewInit, OnDestroy {
 
   readonly inputEl = viewChild<ElementRef<HTMLInputElement>>('inputElRef');
   readonly matAutocomplete = viewChild<MatAutocomplete>('autoElRef');
-  readonly autocompleteTrigger = viewChild(MatAutocompleteTrigger);
 
   inputVal = signal<string>('');
   tagSuggestions = computed(() =>
@@ -178,47 +177,13 @@ export class TagEditComponent implements AfterViewInit, OnDestroy {
     this._clearInput();
   }
 
-  ngAfterViewInit(): void {
-    this.inputEl()?.nativeElement.addEventListener(
-      'keydown',
-      this._onCapturingKeydown,
-      true,
-    );
+  acceptSuggestion(id: string): void {
+    this._add(id);
   }
 
-  ngOnDestroy(): void {
-    this.inputEl()?.nativeElement.removeEventListener(
-      'keydown',
-      this._onCapturingKeydown,
-      true,
-    );
+  commitText(text: string): void {
+    this._addByTitle(text);
   }
-
-  private readonly _onCapturingKeydown = (ev: KeyboardEvent): void => {
-    const autocomplete = this.matAutocomplete();
-    const trigger = this.autocompleteTrigger();
-    if (!autocomplete?.isOpen || !trigger || hasModifierKey(ev)) {
-      return;
-    }
-
-    if (ev.key === 'Tab') {
-      const option = trigger.activeOption ?? autocomplete.options.first;
-      if (option) {
-        ev.preventDefault();
-        this._add(option.value);
-        this._clearInput();
-        trigger.closePanel();
-      }
-    } else if (ev.key === 'Enter' && !trigger.activeOption) {
-      ev.preventDefault();
-      const value = (this.inputCtrl.value || '').trim();
-      this._clearInput();
-      trigger.closePanel();
-      if (value) {
-        this._addByTitle(value);
-      }
-    }
-  };
 
   private _clearInput(): void {
     const inputEl = this.inputEl();

--- a/src/app/ui/chip-autocomplete-keys/chip-autocomplete-keys.directive.spec.ts
+++ b/src/app/ui/chip-autocomplete-keys/chip-autocomplete-keys.directive.spec.ts
@@ -1,0 +1,184 @@
+import { Component, computed } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { DOWN_ARROW, ENTER, TAB } from '@angular/cdk/keycodes';
+import { MatAutocomplete, MatAutocompleteTrigger } from '@angular/material/autocomplete';
+import { MatChipGrid, MatChipInput } from '@angular/material/chips';
+import { MatOption } from '@angular/material/core';
+import { ChipAutocompleteKeysDirective } from './chip-autocomplete-keys.directive';
+
+const SUGGESTIONS = [
+  { id: 'A', title: 'Apple' },
+  { id: 'B', title: 'Banana' },
+  { id: 'D', title: 'Blueberry' },
+  { id: 'C', title: 'Cherry' },
+];
+
+@Component({
+  template: `
+    <mat-chip-grid #grid>
+      <input
+        [formControl]="ctrl"
+        [matAutocomplete]="auto"
+        [matChipInputFor]="grid"
+        [matChipInputAddOnBlur]="true"
+        spChipAutocompleteKeys
+        (suggestionAccepted)="accepted.push($event)"
+        (textCommitted)="committed.push($event)"
+      />
+    </mat-chip-grid>
+    <mat-autocomplete #auto="matAutocomplete">
+      @for (s of filtered(); track s.id) {
+        <mat-option [value]="s.id">{{ s.title }}</mat-option>
+      }
+    </mat-autocomplete>
+  `,
+  imports: [
+    ReactiveFormsModule,
+    MatChipGrid,
+    MatChipInput,
+    MatAutocomplete,
+    MatAutocompleteTrigger,
+    MatOption,
+    ChipAutocompleteKeysDirective,
+  ],
+  standalone: true,
+})
+class HostComponent {
+  ctrl = new UntypedFormControl();
+  accepted: string[] = [];
+  committed: string[] = [];
+  private readonly _val = toSignal(this.ctrl.valueChanges, { initialValue: '' });
+  filtered = computed(() => {
+    const v = (this._val() || '').toLowerCase();
+    return SUGGESTIONS.filter((s) => s.title.toLowerCase().startsWith(v));
+  });
+}
+
+describe('ChipAutocompleteKeysDirective', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+
+  const getInput = (): HTMLInputElement =>
+    fixture.nativeElement.querySelector('input') as HTMLInputElement;
+
+  const getAutocomplete = (): MatAutocomplete =>
+    fixture.debugElement.query((d) => d.name === 'mat-autocomplete').componentInstance;
+
+  const pressKey = (
+    key: string,
+    keyCode: number,
+    init: KeyboardEventInit = {},
+  ): boolean =>
+    getInput().dispatchEvent(
+      new KeyboardEvent('keydown', {
+        bubbles: true,
+        cancelable: true,
+        key,
+        keyCode,
+        ...init,
+      }),
+    );
+
+  const typeAndOpen = async (text: string): Promise<void> => {
+    const input = getInput();
+    input.focus();
+    input.value = text;
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent, NoopAnimationsModule],
+    }).compileComponents();
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('Tab accepts the first suggestion and keeps focus in the input', async () => {
+    await typeAndOpen('ban');
+    expect(getAutocomplete().isOpen).toBeTrue();
+
+    const notPrevented = pressKey('Tab', TAB);
+
+    expect(host.accepted).toEqual(['B']);
+    expect(host.committed).toEqual([]);
+    expect(notPrevented).toBeFalse();
+    expect(getInput().value).toBe('');
+    expect(host.ctrl.value).toBeNull();
+    expect(getAutocomplete().isOpen).toBeFalse();
+  });
+
+  it('Tab accepts the suggestion highlighted with the arrow keys', async () => {
+    await typeAndOpen('b');
+    pressKey('ArrowDown', DOWN_ARROW);
+    pressKey('ArrowDown', DOWN_ARROW);
+
+    pressKey('Tab', TAB);
+
+    expect(host.accepted).toEqual(['D']);
+  });
+
+  it('Enter with no highlighted suggestion commits the typed text', async () => {
+    await typeAndOpen('ban');
+
+    const notPrevented = pressKey('Enter', ENTER);
+
+    expect(host.committed).toEqual(['ban']);
+    expect(host.accepted).toEqual([]);
+    expect(notPrevented).toBeFalse();
+    expect(getInput().value).toBe('');
+    expect(getAutocomplete().isOpen).toBeFalse();
+  });
+
+  it('Enter with a highlighted suggestion is left to Material', async () => {
+    await typeAndOpen('ban');
+    pressKey('ArrowDown', DOWN_ARROW);
+
+    pressKey('Enter', ENTER);
+
+    expect(host.accepted).toEqual([]);
+    expect(host.committed).toEqual([]);
+  });
+
+  it('Shift+Tab neither accepts nor commits and drops the partial text so add-on-blur has nothing to add', async () => {
+    await typeAndOpen('ban');
+
+    const notPrevented = pressKey('Tab', TAB, { shiftKey: true });
+
+    expect(host.accepted).toEqual([]);
+    expect(host.committed).toEqual([]);
+    expect(notPrevented).toBeTrue();
+    expect(getInput().value).toBe('');
+    expect(getAutocomplete().isOpen).toBeFalse();
+  });
+
+  it('does nothing while the panel is closed', async () => {
+    await typeAndOpen('zzz');
+    expect(getAutocomplete().isOpen).toBeFalse();
+
+    const notPrevented = pressKey('Tab', TAB);
+
+    expect(host.accepted).toEqual([]);
+    expect(host.committed).toEqual([]);
+    expect(notPrevented).toBeTrue();
+    expect(getInput().value).toBe('zzz');
+  });
+
+  it('ignores Tab and Enter with Ctrl, Alt or Meta held', async () => {
+    await typeAndOpen('ban');
+
+    pressKey('Tab', TAB, { ctrlKey: true });
+    pressKey('Enter', ENTER, { altKey: true });
+    pressKey('Enter', ENTER, { metaKey: true });
+
+    expect(host.accepted).toEqual([]);
+    expect(host.committed).toEqual([]);
+  });
+});

--- a/src/app/ui/chip-autocomplete-keys/chip-autocomplete-keys.directive.spec.ts
+++ b/src/app/ui/chip-autocomplete-keys/chip-autocomplete-keys.directive.spec.ts
@@ -159,6 +159,37 @@ describe('ChipAutocompleteKeysDirective', () => {
     expect(getAutocomplete().isOpen).toBeFalse();
   });
 
+  it('Tab on an untouched input (panel opened on focus) adds nothing and lets focus move on', async () => {
+    await typeAndOpen('');
+    expect(getAutocomplete().isOpen).toBeTrue();
+
+    const notPrevented = pressKey('Tab', TAB);
+
+    expect(host.accepted).toEqual([]);
+    expect(host.committed).toEqual([]);
+    expect(notPrevented).toBeTrue();
+  });
+
+  it('Enter on an untouched input does nothing', async () => {
+    await typeAndOpen('');
+
+    pressKey('Enter', ENTER);
+
+    expect(host.accepted).toEqual([]);
+    expect(host.committed).toEqual([]);
+    expect(getAutocomplete().isOpen).toBeTrue();
+  });
+
+  it('ignores Enter while an IME composition is in progress', async () => {
+    await typeAndOpen('ban');
+
+    pressKey('Enter', ENTER, { isComposing: true });
+    pressKey('Process', 229, { key: 'Process' });
+
+    expect(host.committed).toEqual([]);
+    expect(getInput().value).toBe('ban');
+  });
+
   it('does nothing while the panel is closed', async () => {
     await typeAndOpen('zzz');
     expect(getAutocomplete().isOpen).toBeFalse();

--- a/src/app/ui/chip-autocomplete-keys/chip-autocomplete-keys.directive.ts
+++ b/src/app/ui/chip-autocomplete-keys/chip-autocomplete-keys.directive.ts
@@ -1,32 +1,53 @@
-import { Directive, ElementRef, inject, OnDestroy, OnInit, output } from '@angular/core';
+import {
+  DestroyRef,
+  Directive,
+  ElementRef,
+  inject,
+  OnInit,
+  output,
+  Renderer2,
+} from '@angular/core';
 import { NgControl } from '@angular/forms';
 import { hasModifierKey } from '@angular/cdk/keycodes';
 import { MatAutocompleteTrigger } from '@angular/material/autocomplete';
+
+const IME_PROCESS_KEY_CODE = 229;
 
 @Directive({
   selector: 'input[matAutocomplete][spChipAutocompleteKeys]',
   standalone: true,
 })
-export class ChipAutocompleteKeysDirective implements OnInit, OnDestroy {
+export class ChipAutocompleteKeysDirective implements OnInit {
   readonly suggestionAccepted = output<string>();
   readonly textCommitted = output<string>();
 
   private readonly _el = inject(ElementRef<HTMLInputElement>);
+  private readonly _renderer = inject(Renderer2);
+  private readonly _destroyRef = inject(DestroyRef);
   private readonly _trigger = inject(MatAutocompleteTrigger, { self: true });
   private readonly _control = inject(NgControl, { self: true, optional: true });
 
   ngOnInit(): void {
-    this._el.nativeElement.addEventListener('keydown', this._onKeydown, true);
-  }
-
-  ngOnDestroy(): void {
-    this._el.nativeElement.removeEventListener('keydown', this._onKeydown, true);
+    const unlisten = this._renderer.listen(
+      this._el.nativeElement,
+      'keydown',
+      this._onKeydown,
+      { capture: true },
+    );
+    this._destroyRef.onDestroy(unlisten);
   }
 
   private readonly _onKeydown = (ev: KeyboardEvent): void => {
     const trigger = this._trigger;
     const autocomplete = trigger.autocomplete;
-    if (!autocomplete?.isOpen || hasModifierKey(ev, 'altKey', 'ctrlKey', 'metaKey')) {
+    const typed = this._el.nativeElement.value.trim();
+    if (
+      !autocomplete?.isOpen ||
+      !typed ||
+      ev.isComposing ||
+      ev.keyCode === IME_PROCESS_KEY_CODE ||
+      hasModifierKey(ev, 'altKey', 'ctrlKey', 'metaKey')
+    ) {
       return;
     }
 
@@ -46,12 +67,9 @@ export class ChipAutocompleteKeysDirective implements OnInit, OnDestroy {
       this.suggestionAccepted.emit(option.value);
     } else if (ev.key === 'Enter' && !trigger.activeOption) {
       ev.preventDefault();
-      const value = this._el.nativeElement.value.trim();
       this._clear();
       trigger.closePanel();
-      if (value) {
-        this.textCommitted.emit(value);
-      }
+      this.textCommitted.emit(typed);
     }
   };
 

--- a/src/app/ui/chip-autocomplete-keys/chip-autocomplete-keys.directive.ts
+++ b/src/app/ui/chip-autocomplete-keys/chip-autocomplete-keys.directive.ts
@@ -1,0 +1,62 @@
+import { Directive, ElementRef, inject, OnDestroy, OnInit, output } from '@angular/core';
+import { NgControl } from '@angular/forms';
+import { hasModifierKey } from '@angular/cdk/keycodes';
+import { MatAutocompleteTrigger } from '@angular/material/autocomplete';
+
+@Directive({
+  selector: 'input[matAutocomplete][spChipAutocompleteKeys]',
+  standalone: true,
+})
+export class ChipAutocompleteKeysDirective implements OnInit, OnDestroy {
+  readonly suggestionAccepted = output<string>();
+  readonly textCommitted = output<string>();
+
+  private readonly _el = inject(ElementRef<HTMLInputElement>);
+  private readonly _trigger = inject(MatAutocompleteTrigger, { self: true });
+  private readonly _control = inject(NgControl, { self: true, optional: true });
+
+  ngOnInit(): void {
+    this._el.nativeElement.addEventListener('keydown', this._onKeydown, true);
+  }
+
+  ngOnDestroy(): void {
+    this._el.nativeElement.removeEventListener('keydown', this._onKeydown, true);
+  }
+
+  private readonly _onKeydown = (ev: KeyboardEvent): void => {
+    const trigger = this._trigger;
+    const autocomplete = trigger.autocomplete;
+    if (!autocomplete?.isOpen || hasModifierKey(ev, 'altKey', 'ctrlKey', 'metaKey')) {
+      return;
+    }
+
+    if (ev.key === 'Tab') {
+      if (ev.shiftKey) {
+        this._clear();
+        trigger.closePanel();
+        return;
+      }
+      const option = trigger.activeOption ?? autocomplete.options.first;
+      if (!option) {
+        return;
+      }
+      ev.preventDefault();
+      this._clear();
+      trigger.closePanel();
+      this.suggestionAccepted.emit(option.value);
+    } else if (ev.key === 'Enter' && !trigger.activeOption) {
+      ev.preventDefault();
+      const value = this._el.nativeElement.value.trim();
+      this._clear();
+      trigger.closePanel();
+      if (value) {
+        this.textCommitted.emit(value);
+      }
+    }
+  };
+
+  private _clear(): void {
+    this._el.nativeElement.value = '';
+    this._control?.control?.setValue(null);
+  }
+}

--- a/src/app/ui/chip-list-input/chip-list-input.component.html
+++ b/src/app/ui/chip-list-input/chip-list-input.component.html
@@ -24,6 +24,9 @@
       [matChipInputFor]="chipListElRef"
       [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
       (keydown)="onInputKeydown($event)"
+      spChipAutocompleteKeys
+      (suggestionAccepted)="acceptSuggestion($event)"
+      (textCommitted)="commitText($event)"
     />
   </mat-chip-grid>
   <mat-autocomplete

--- a/src/app/ui/chip-list-input/chip-list-input.component.spec.ts
+++ b/src/app/ui/chip-list-input/chip-list-input.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
-import { COMMA, ENTER } from '@angular/cdk/keycodes';
+import { COMMA, DOWN_ARROW, ENTER, TAB } from '@angular/cdk/keycodes';
 import { MatChipInputEvent } from '@angular/material/chips';
 import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import { ChipListInputComponent } from './chip-list-input.component';
@@ -101,6 +101,92 @@ describe('ChipListInputComponent', () => {
     expect('ctrlEnterSubmit' in component).toBeFalse();
     keydownOnInput({ code: 'Enter', ctrlKey: true });
     expect(component.separatorKeysCodes).toEqual([ENTER, COMMA]);
+  });
+
+  describe('keyboard with the autocomplete panel open (#9722)', () => {
+    let addSpy: jasmine.Spy;
+    let addNewSpy: jasmine.Spy;
+
+    const pressKey = (key: string, keyCode: number): boolean =>
+      getInput().dispatchEvent(
+        new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key, keyCode }),
+      );
+
+    const openPanelWith = async (text: string): Promise<void> => {
+      const input = getInput();
+      input.focus();
+      input.value = text;
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      expect(component.matAutocomplete()?.isOpen)
+        .withContext('autocomplete panel should be open')
+        .toBeTrue();
+    };
+
+    beforeEach(() => {
+      addSpy = jasmine.createSpy('addItem');
+      addNewSpy = jasmine.createSpy('addNewItem');
+      component.addItem.subscribe(addSpy);
+      component.addNewItem.subscribe(addNewSpy);
+    });
+
+    it('Tab accepts the first suggestion instead of creating a new item', async () => {
+      await openPanelWith('ban');
+
+      const notPrevented = pressKey('Tab', TAB);
+
+      expect(addSpy).toHaveBeenCalledOnceWith('B');
+      expect(addNewSpy).not.toHaveBeenCalled();
+      expect(notPrevented).toBeFalse();
+      expect(getInput().value).toBe('');
+    });
+
+    it('Tab accepts the suggestion highlighted with the arrow keys', async () => {
+      component.suggestions = [
+        { id: 'A', title: 'Apple' },
+        { id: 'B', title: 'Banana' },
+        { id: 'D', title: 'Blueberry' },
+      ];
+      await openPanelWith('b');
+      pressKey('ArrowDown', DOWN_ARROW);
+      pressKey('ArrowDown', DOWN_ARROW);
+
+      pressKey('Tab', TAB);
+
+      expect(addSpy).toHaveBeenCalledOnceWith('D');
+      expect(addNewSpy).not.toHaveBeenCalled();
+    });
+
+    it('Enter with no highlighted suggestion creates a new item from the typed text', async () => {
+      await openPanelWith('ban');
+
+      pressKey('Enter', ENTER);
+
+      expect(addNewSpy).toHaveBeenCalledOnceWith('ban');
+      expect(addSpy).not.toHaveBeenCalled();
+      expect(getInput().value).toBe('');
+    });
+
+    it('Enter with no highlighted suggestion adds the existing item on an exact title match', async () => {
+      await openPanelWith('Banana');
+
+      pressKey('Enter', ENTER);
+
+      expect(addSpy).toHaveBeenCalledOnceWith('B');
+      expect(addNewSpy).not.toHaveBeenCalled();
+    });
+
+    it('Enter with a highlighted suggestion adds only that suggestion', async () => {
+      await openPanelWith('ban');
+      pressKey('ArrowDown', DOWN_ARROW);
+
+      pressKey('Enter', ENTER);
+
+      expect(addSpy).toHaveBeenCalledOnceWith('B');
+      expect(addNewSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('suggestions setter', () => {

--- a/src/app/ui/chip-list-input/chip-list-input.component.spec.ts
+++ b/src/app/ui/chip-list-input/chip-list-input.component.spec.ts
@@ -198,6 +198,16 @@ describe('ChipListInputComponent', () => {
       expect(addNewSpy).not.toHaveBeenCalled();
     });
 
+    it('Tab on an untouched input adds nothing and lets focus move on', async () => {
+      await openPanelWith('');
+
+      const notPrevented = pressKey('Tab', TAB);
+
+      expect(addSpy).not.toHaveBeenCalled();
+      expect(addNewSpy).not.toHaveBeenCalled();
+      expect(notPrevented).toBeTrue();
+    });
+
     it('Shift+Tab adds nothing and drops the partial text', async () => {
       await openPanelWith('ban');
 

--- a/src/app/ui/chip-list-input/chip-list-input.component.spec.ts
+++ b/src/app/ui/chip-list-input/chip-list-input.component.spec.ts
@@ -107,9 +107,19 @@ describe('ChipListInputComponent', () => {
     let addSpy: jasmine.Spy;
     let addNewSpy: jasmine.Spy;
 
-    const pressKey = (key: string, keyCode: number): boolean =>
+    const pressKey = (
+      key: string,
+      keyCode: number,
+      init: KeyboardEventInit = {},
+    ): boolean =>
       getInput().dispatchEvent(
-        new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key, keyCode }),
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          cancelable: true,
+          key,
+          keyCode,
+          ...init,
+        }),
       );
 
     const openPanelWith = async (text: string): Promise<void> => {
@@ -186,6 +196,16 @@ describe('ChipListInputComponent', () => {
 
       expect(addSpy).toHaveBeenCalledOnceWith('B');
       expect(addNewSpy).not.toHaveBeenCalled();
+    });
+
+    it('Shift+Tab adds nothing and drops the partial text', async () => {
+      await openPanelWith('ban');
+
+      pressKey('Tab', TAB, { shiftKey: true });
+
+      expect(addSpy).not.toHaveBeenCalled();
+      expect(addNewSpy).not.toHaveBeenCalled();
+      expect(getInput().value).toBe('');
     });
   });
 

--- a/src/app/ui/chip-list-input/chip-list-input.component.ts
+++ b/src/app/ui/chip-list-input/chip-list-input.component.ts
@@ -1,9 +1,11 @@
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   ElementRef,
   Input,
   input,
+  OnDestroy,
   output,
   viewChild,
 } from '@angular/core';
@@ -22,7 +24,7 @@ import {
   MatChipRow,
 } from '@angular/material/chips';
 import { map, startWith } from 'rxjs/operators';
-import { COMMA, ENTER } from '@angular/cdk/keycodes';
+import { COMMA, ENTER, hasModifierKey } from '@angular/cdk/keycodes';
 import { T } from '../../t.const';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
@@ -67,7 +69,7 @@ interface Suggestion {
     TagComponent,
   ],
 })
-export class ChipListInputComponent {
+export class ChipListInputComponent implements AfterViewInit, OnDestroy {
   T: typeof T = T;
 
   readonly label = input<string>();
@@ -82,6 +84,7 @@ export class ChipListInputComponent {
   separatorKeysCodes: number[] = DEFAULT_SEPARATOR_KEY_CODES;
   readonly inputEl = viewChild<ElementRef<HTMLInputElement>>('inputElRef');
   readonly matAutocomplete = viewChild<MatAutocomplete>('autoElRef');
+  readonly autocompleteTrigger = viewChild(MatAutocompleteTrigger);
   private _modelIds: string[] = [];
 
   filteredSuggestions: Observable<Suggestion[]> = this.inputCtrl.valueChanges.pipe(
@@ -137,11 +140,7 @@ export class ChipListInputComponent {
 
   selected(event: MatAutocompleteSelectedEvent): void {
     this._add(event.option.value);
-    const inputEl = this.inputEl();
-    if (inputEl) {
-      inputEl.nativeElement.value = '';
-    }
-    this.inputCtrl.setValue(null);
+    this._clearInput();
   }
 
   onInputKeydown(ev: KeyboardEvent): void {
@@ -151,6 +150,56 @@ export class ChipListInputComponent {
     } else {
       this.separatorKeysCodes = DEFAULT_SEPARATOR_KEY_CODES;
     }
+  }
+
+  ngAfterViewInit(): void {
+    this.inputEl()?.nativeElement.addEventListener(
+      'keydown',
+      this._onCapturingKeydown,
+      true,
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.inputEl()?.nativeElement.removeEventListener(
+      'keydown',
+      this._onCapturingKeydown,
+      true,
+    );
+  }
+
+  private readonly _onCapturingKeydown = (ev: KeyboardEvent): void => {
+    const autocomplete = this.matAutocomplete();
+    const trigger = this.autocompleteTrigger();
+    if (!autocomplete?.isOpen || !trigger || hasModifierKey(ev)) {
+      return;
+    }
+
+    if (ev.key === 'Tab') {
+      const option = trigger.activeOption ?? autocomplete.options.first;
+      if (option) {
+        ev.preventDefault();
+        this._add(option.value);
+        this._clearInput();
+        trigger.closePanel();
+      }
+    } else if (ev.key === 'Enter' && !trigger.activeOption) {
+      ev.preventDefault();
+      const value = (this.inputCtrl.value || '').trim();
+      this._clearInput();
+      trigger.closePanel();
+      if (value) {
+        this._addByTitle(value);
+      }
+    }
+  };
+
+  private _clearInput(): void {
+    const inputEl = this.inputEl();
+    if (inputEl) {
+      inputEl.nativeElement.value = '';
+    }
+    this.inputCtrl.setValue(null);
   }
 
   private _updateModelItems(modelIds: string[]): void {

--- a/src/app/ui/chip-list-input/chip-list-input.component.ts
+++ b/src/app/ui/chip-list-input/chip-list-input.component.ts
@@ -1,11 +1,9 @@
 import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   ElementRef,
   Input,
   input,
-  OnDestroy,
   output,
   viewChild,
 } from '@angular/core';
@@ -24,7 +22,7 @@ import {
   MatChipRow,
 } from '@angular/material/chips';
 import { map, startWith } from 'rxjs/operators';
-import { COMMA, ENTER, hasModifierKey } from '@angular/cdk/keycodes';
+import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { T } from '../../t.const';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
@@ -34,6 +32,7 @@ import { TranslatePipe } from '@ngx-translate/core';
 import { AsyncPipe } from '@angular/common';
 import { TagComponent } from '../../features/tag/tag/tag.component';
 import { sortByTitle } from '../../util/sort-by-title';
+import { ChipAutocompleteKeysDirective } from '../chip-autocomplete-keys/chip-autocomplete-keys.directive';
 
 const DEFAULT_SEPARATOR_KEY_CODES: number[] = [ENTER, COMMA];
 
@@ -67,9 +66,10 @@ interface Suggestion {
     TranslatePipe,
     AsyncPipe,
     TagComponent,
+    ChipAutocompleteKeysDirective,
   ],
 })
-export class ChipListInputComponent implements AfterViewInit, OnDestroy {
+export class ChipListInputComponent {
   T: typeof T = T;
 
   readonly label = input<string>();
@@ -84,7 +84,6 @@ export class ChipListInputComponent implements AfterViewInit, OnDestroy {
   separatorKeysCodes: number[] = DEFAULT_SEPARATOR_KEY_CODES;
   readonly inputEl = viewChild<ElementRef<HTMLInputElement>>('inputElRef');
   readonly matAutocomplete = viewChild<MatAutocomplete>('autoElRef');
-  readonly autocompleteTrigger = viewChild(MatAutocompleteTrigger);
   private _modelIds: string[] = [];
 
   filteredSuggestions: Observable<Suggestion[]> = this.inputCtrl.valueChanges.pipe(
@@ -152,47 +151,13 @@ export class ChipListInputComponent implements AfterViewInit, OnDestroy {
     }
   }
 
-  ngAfterViewInit(): void {
-    this.inputEl()?.nativeElement.addEventListener(
-      'keydown',
-      this._onCapturingKeydown,
-      true,
-    );
+  acceptSuggestion(id: string): void {
+    this._add(id);
   }
 
-  ngOnDestroy(): void {
-    this.inputEl()?.nativeElement.removeEventListener(
-      'keydown',
-      this._onCapturingKeydown,
-      true,
-    );
+  commitText(text: string): void {
+    this._addByTitle(text);
   }
-
-  private readonly _onCapturingKeydown = (ev: KeyboardEvent): void => {
-    const autocomplete = this.matAutocomplete();
-    const trigger = this.autocompleteTrigger();
-    if (!autocomplete?.isOpen || !trigger || hasModifierKey(ev)) {
-      return;
-    }
-
-    if (ev.key === 'Tab') {
-      const option = trigger.activeOption ?? autocomplete.options.first;
-      if (option) {
-        ev.preventDefault();
-        this._add(option.value);
-        this._clearInput();
-        trigger.closePanel();
-      }
-    } else if (ev.key === 'Enter' && !trigger.activeOption) {
-      ev.preventDefault();
-      const value = (this.inputCtrl.value || '').trim();
-      this._clearInput();
-      trigger.closePanel();
-      if (value) {
-        this._addByTitle(value);
-      }
-    }
-  };
 
   private _clearInput(): void {
     const inputEl = this.inputEl();


### PR DESCRIPTION
Fixes #9722

## Problem

With the tag autocomplete panel open:

- **Tab** created a new tag from the partially typed text (e.g. `impo`) instead of accepting the suggested `important`.
- **Enter** did nothing unless an option had first been highlighted with the arrow keys.

## Root cause

- Tab: Angular Material's `MatAutocompleteTrigger` forwards Tab to the key manager, which closes the panel and lets focus leave the input. `[matChipInputAddOnBlur]="true"` then emits `chipEnd` with the partial text, `add()` finds no exact title match and calls `addNewItem` / creates a new tag.
- Enter: `add()` is guarded by `if (!matAutocomplete.isOpen)` (to avoid a double add when Material selects a highlighted option), so with the panel open and no highlighted option the keypress is swallowed.

The task tag editor (`tag-edit`) and the generic `chip-list-input` (repeat-config and issue-provider dialogs) share the same code, so both are fixed the same way.

## Fix

A keydown listener registered in the **capturing phase** on the input (it has to run before Material's own handlers — the template `(keydown)` binding fires after the panel is already closed, so the "was the panel open" state is gone by then; same approach as `menu-touch-fix.directive.ts`):

- **Tab** with the panel open → adds the highlighted suggestion, or the first one if none is highlighted; `preventDefault()` keeps focus in the input so add-on-blur doesn't fire; panel closes.
- **Enter** with the panel open and no highlighted option → adds the exact title match or creates a new tag from the typed text (option 1 from the issue: Tab = accept completion, Enter = use exactly this). The input is cleared before adding so the `chipEnd` emitted for the same keydown is a no-op.
- **Enter** with a highlighted option → unchanged, still handled by Material.
- Keys with Ctrl/Alt/Meta are ignored.

`selected()` now uses the same `_clearInput()` helper.

## Tests

- `chip-list-input.component.spec.ts`: +5 tests (Tab → first suggestion, Tab → arrow-highlighted suggestion, Enter → new item, Enter → exact match, Enter with highlighted option adds once).
- `tag-edit.component.spec.ts`: new spec, same 5 scenarios with `TagService`/`TaskService` mocked.

All were written first and failed against `master` (the Tab/Enter cases), then pass with the fix. `npm run checkFile` passes on every touched file.

Note: `planner-calendar-nav.component.spec.ts` has 2 date-dependent failures on current `master` when run on a Friday (`Expected 5 to be 7`), unrelated to this change.
