### PR TITLE
test(e2e): scope the calendar next-month locator to the calendar header

### DIFF
--- a/e2e/tests/planner/planner-subtask-scheduled-visibility.spec.ts
+++ b/e2e/tests/planner/planner-subtask-scheduled-visibility.spec.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from '@playwright/test';
 import { expect, test } from '../../fixtures/test.fixture';
+import { calendarNextMonthBtn } from '../../utils/element-helpers';
 
 /**
  * Schedule a task for an exact day (day-only, no time) via the keyboard
@@ -31,7 +32,7 @@ const scheduleTaskForDay = async (
     targetDate.getMonth() !== today.getMonth() ||
     targetDate.getFullYear() !== today.getFullYear()
   ) {
-    await scheduleDialog.getByRole('button', { name: /next month/i }).click();
+    await calendarNextMonthBtn(scheduleDialog).click();
   }
 
   const targetDay = scheduleDialog

--- a/e2e/tests/recurring/recurring-future-start-date-bug-6856.spec.ts
+++ b/e2e/tests/recurring/recurring-future-start-date-bug-6856.spec.ts
@@ -4,6 +4,7 @@ import {
   openRecurScheduleDialog,
   saveRecurDialog,
 } from '../../utils/recurring-task-helpers';
+import { calendarNextMonthBtn } from '../../utils/element-helpers';
 
 /**
  * Bug: https://github.com/super-productivity/super-productivity/issues/6856
@@ -47,7 +48,7 @@ test.describe('Recurring Task - Future Start Date (#6856)', () => {
     await expect(calendar).toBeVisible({ timeout: 5000 });
 
     // Navigate to next month to ensure the date is in the future
-    const nextMonthBtn = scheduleDialog.getByRole('button', { name: /next month/i });
+    const nextMonthBtn = calendarNextMonthBtn(scheduleDialog);
     await nextMonthBtn.click();
 
     // Select the first available day in next month

--- a/e2e/tests/recurring/recurring-start-date-epoch-bug-6860.spec.ts
+++ b/e2e/tests/recurring/recurring-start-date-epoch-bug-6860.spec.ts
@@ -5,6 +5,7 @@ import {
   saveRecurDialog,
   setRecurStartDate,
 } from '../../utils/recurring-task-helpers';
+import { calendarNextMonthBtn } from '../../utils/element-helpers';
 
 /**
  * Bug: https://github.com/super-productivity/super-productivity/issues/6860
@@ -55,7 +56,7 @@ test.describe('Recurring Task - Start Date Epoch Bug (#6860)', () => {
     await expect(calendar).toBeVisible({ timeout: 5000 });
 
     // Navigate to next month and select the first available day
-    const nextMonthBtn = scheduleDialog.getByRole('button', { name: /next month/i });
+    const nextMonthBtn = calendarNextMonthBtn(scheduleDialog);
     await nextMonthBtn.click();
 
     const firstDay = scheduleDialog

--- a/e2e/utils/element-helpers.ts
+++ b/e2e/utils/element-helpers.ts
@@ -56,3 +56,16 @@ export const ensureGlobalAddTaskBarOpen = async (page: Page): Promise<Locator> =
   await addTaskInput.waitFor({ state: 'visible', timeout: 10000 });
   return addTaskInput;
 };
+
+/**
+ * The calendar header's "next month" arrow inside a scope (usually a dialog).
+ *
+ * Do not reach for this by role: the datetime picker's quick-access row has its
+ * own "Next month" shortcut, so `getByRole('button', { name: /next month/i })`
+ * matches two elements and fails on strict mode.
+ *
+ * @param scope - Locator to search within, e.g. the schedule dialog
+ * @returns Locator - The calendar's next-month navigation button
+ */
+export const calendarNextMonthBtn = (scope: Locator): Locator =>
+  scope.locator('.mat-calendar-next-button');


### PR DESCRIPTION
Fixes the e2e failures introduced by #10057, which merged with the Tests check red.

### The problem

#10057 gave the datetime picker's quick-access shortcuts visible labels, so "Next month" became the accessible name of **two** buttons in the schedule dialog — the calendar header's nav arrow (`aria-label="Next month"`, from Material) and the new quick-access shortcut. Three e2e call sites used `getByRole('button', { name: /next month/i })`, which now matches both and fails on strict mode:

```
Error: strict mode violation: ... getByRole('button', { name: /next month/i }) resolved to 2 elements
```

| Call site | Behavior on master |
| --- | --- |
| `recurring-start-date-epoch-bug-6860.spec.ts:58` | fails every run |
| `recurring-future-start-date-bug-6856.spec.ts:50` | fails every run |
| `planner-subtask-scheduled-visibility.spec.ts:34` | latent — only navigates months when today+1 lands in the next one, so it would fail on the last two days of a month and pass everywhere else |

### The fix

New `calendarNextMonthBtn(scope)` helper in `e2e/utils/element-helpers.ts` targeting `.mat-calendar-next-button`, matching how the rest of the suite already reaches calendar internals (`.mat-calendar-period-button`, `.mat-calendar-body-cell`). Its JSDoc records why `getByRole` is the wrong tool here, so the trap doesn't come back.

These tests always meant "the calendar's next-month arrow" — the label collision just exposed that they were asking for something looser.

The two page-object call sites that pass the exact name `'Next month'` (`dialog.page.ts:187`, `task-detail.spec.ts:73`) drive the plain Material datepicker popup, which has no quick-access row. Unaffected, left alone.

### Verification

- Reproduced `6860` failing on master first, then green after the change
- `recurring-start-date-epoch-bug-6860` 2/2, `recurring-future-start-date-bug-6856` 1/1, `planner-subtask-scheduled-visibility` 1/1
- The planner spec's cross-month branch doesn't execute today (Sep 11), so it was exercised by temporarily widening the day offsets to +20/+21 to land in October: the calendar navigation succeeded and the test then failed only on the planner not rendering a day 20 days out, confirming the branch works. Offsets restored.
- `npm run checkFile` clean on all four files

### Not fixed here

Two buttons in the dialog still share the accessible name "Next month". It's not a WCAG failure and the two sit in visibly distinct groups, but it is mildly ambiguous for screen-reader and voice-control users. Every fix costs more than the problem — re-labeling Material's nav arrow via `MatDatepickerIntl` is app-wide and makes the correct label worse, and renaming the shortcut means new wording across 27 locales. If an a11y report ever comes in, a `role="group"` + `aria-label` on the quick-access row is the cheapest honest improvement.

https://claude.ai/code/session_01G9Q3ozRVHem8j3L8azLc1e