### PR TITLE
ci(ios): add public TestFlight builds for labeled PRs

### DIFF
--- a/.github/actions/setup-ios-signing/action.yml
+++ b/.github/actions/setup-ios-signing/action.yml
@@ -1,0 +1,117 @@
+name: 'Setup iOS Signing'
+description: >
+  Shared iOS code-signing setup for the App Store release and the TestFlight
+  workflows: select Xcode, trust Apple's WWDR intermediate, import the
+  distribution certificate into a temporary keychain, install the provisioning
+  profile, and export PROVISIONING_PROFILE_UUID for ExportOptions.plist.
+
+inputs:
+  mac_certs:
+    description: 'base64-encoded "Apple Distribution" .p12 (shared with macOS)'
+    required: true
+  mac_certs_password:
+    description: 'Password for mac_certs'
+    required: true
+  ios_provision_profile:
+    description: 'base64-encoded .mobileprovision for com.super-productivity.app'
+    required: true
+  xcode_path:
+    description: 'Full path of the Xcode.app to select'
+    required: false
+    default: '/Applications/Xcode_26.2.app'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Select Xcode
+      shell: bash
+      # SDKROOT pin: the macos-26 image (2026-08) resolves the default SDK for
+      # bare `xcrun` calls to /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk,
+      # which doesn't exist there, so `xcrun --show-sdk-version`, `xcrun agvtool`
+      # and xcrun-based tool lookups fail ("SDK ... cannot be located") even with
+      # full Xcode selected. Pointing SDKROOT at the selected Xcode's macOS SDK
+      # overrides that resolution for all later steps. It cannot leak into the
+      # iOS archive: the app project pins SDKROOT = iphoneos in its build
+      # settings, which takes precedence over the environment.
+      run: |
+        sudo xcode-select -s '${{ inputs.xcode_path }}'
+        echo "SDKROOT=$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk" >> "$GITHUB_ENV"
+
+    - name: Verify Xcode and SDK version
+      shell: bash
+      run: |
+        echo "=== Xcode Version ==="
+        xcodebuild -version
+        echo ""
+        echo "=== SDK Information ==="
+        xcrun --show-sdk-version
+        xcodebuild -showsdks | grep -E "(iOS|iphoneos)"
+
+    - name: Install Apple WWDR intermediate certificate
+      shell: bash
+      run: |
+        curl -fsSL https://www.apple.com/certificateauthority/AppleWWDRCAG4.cer -o "$RUNNER_TEMP/AppleWWDRCAG4.cer"
+        sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$RUNNER_TEMP/AppleWWDRCAG4.cer"
+
+    - name: Configure signing keychain
+      shell: bash
+      env:
+        # Reuse mac_certs - "Apple Distribution" certificate works for both macOS and iOS
+        MAC_CERTS: ${{ inputs.mac_certs }}
+        MAC_CERTS_PASSWORD: ${{ inputs.mac_certs_password }}
+      run: |
+        CERT_PATH="$RUNNER_TEMP/dist-cert.p12"
+        KEYCHAIN_NAME="build.keychain"
+        KEYCHAIN_PATH="$HOME/Library/Keychains/${KEYCHAIN_NAME}-db"
+        echo "$MAC_CERTS" | base64 --decode > "$CERT_PATH"
+        echo "=== DIAGNOSTIC: Decoded .p12 SHA256 ==="
+        shasum -a 256 "$CERT_PATH"
+        echo "========================================"
+        security create-keychain -p "" "$KEYCHAIN_NAME"
+        security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+        security unlock-keychain -p "" "$KEYCHAIN_PATH"
+        security import "$RUNNER_TEMP/AppleWWDRCAG4.cer" -k "$KEYCHAIN_PATH" -T /usr/bin/codesign
+        security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$MAC_CERTS_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+        security list-keychains -s "$KEYCHAIN_PATH" "$HOME/Library/Keychains/login.keychain-db"
+        security default-keychain -s "$KEYCHAIN_PATH"
+        security set-key-partition-list -S apple-tool:,apple: -k "" "$KEYCHAIN_PATH"
+        security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+    - name: List available signing identities
+      shell: bash
+      run: security find-identity -v -p codesigning
+
+    - name: Install provisioning profile
+      shell: bash
+      env:
+        IOS_PROVISION_PROFILE: ${{ inputs.ios_provision_profile }}
+      run: |
+        PROFILE_PATH="$RUNNER_TEMP/ios-provisioning.mobileprovision"
+        echo "$IOS_PROVISION_PROFILE" | base64 --decode > "$PROFILE_PATH"
+        # Get the UUID from the provisioning profile
+        PROFILE_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< $(security cms -D -i "$PROFILE_PATH"))
+        echo "Profile UUID: $PROFILE_UUID"
+        # Create the provisioning profiles directory if it doesn't exist
+        mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+        # Copy the profile with its UUID as the filename
+        cp "$PROFILE_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles/${PROFILE_UUID}.mobileprovision"
+        echo "PROVISIONING_PROFILE_UUID=$PROFILE_UUID" >> "$GITHUB_ENV"
+
+    - name: Verify provisioning profile
+      shell: bash
+      run: |
+        security cms -D -i "$HOME/Library/MobileDevice/Provisioning Profiles/${PROVISIONING_PROFILE_UUID}.mobileprovision" > /tmp/profile.plist
+        echo "=== PROVISIONING PROFILE INFO ==="
+        echo "Name: $(/usr/libexec/PlistBuddy -c "Print Name" /tmp/profile.plist)"
+        echo "Team: $(/usr/libexec/PlistBuddy -c "Print TeamIdentifier:0" /tmp/profile.plist)"
+        PROFILE_APP_ID=$(/usr/libexec/PlistBuddy -c "Print Entitlements:application-identifier" /tmp/profile.plist | sed 's/^[A-Z0-9]*\.//')
+        echo "App ID: $PROFILE_APP_ID"
+        echo "=================================="
+        # Verify bundle ID matches
+        EXPECTED_BUNDLE_ID="com.super-productivity.app"
+        if [ "$PROFILE_APP_ID" != "$EXPECTED_BUNDLE_ID" ]; then
+          echo "ERROR: Provisioning profile app ID ($PROFILE_APP_ID) does not match expected bundle ID ($EXPECTED_BUNDLE_ID)"
+          echo "Please create a new provisioning profile with the correct bundle ID"
+          exit 1
+        fi
+        echo "Bundle ID verification passed!"

--- a/.github/actions/setup-ios-signing/action.yml
+++ b/.github/actions/setup-ios-signing/action.yml
@@ -2,8 +2,9 @@ name: 'Setup iOS Signing'
 description: >
   Shared iOS code-signing setup for the App Store release and the TestFlight
   workflows: select Xcode, trust Apple's WWDR intermediate, import the
-  distribution certificate into a temporary keychain, install the provisioning
-  profile, and export PROVISIONING_PROFILE_UUID for ExportOptions.plist.
+  distribution certificate into a temporary keychain, install the app and
+  optional share-extension provisioning profiles, and export their UUIDs for
+  ExportOptions.plist.
 
 inputs:
   mac_certs:
@@ -15,6 +16,10 @@ inputs:
   ios_provision_profile:
     description: 'base64-encoded .mobileprovision for com.super-productivity.app'
     required: true
+  ios_share_provision_profile:
+    description: 'base64-encoded .mobileprovision for the optional ShareExtension target'
+    required: false
+    default: ''
   xcode_path:
     description: 'Full path of the Xcode.app to select'
     required: false
@@ -115,3 +120,26 @@ runs:
           exit 1
         fi
         echo "Bundle ID verification passed!"
+
+    - name: Install share extension provisioning profile
+      if: inputs.ios_share_provision_profile != ''
+      shell: bash
+      env:
+        IOS_SHARE_PROVISION_PROFILE: ${{ inputs.ios_share_provision_profile }}
+      run: |
+        PROFILE_PATH="$RUNNER_TEMP/ios-share.mobileprovision"
+        PROFILE_PLIST="$RUNNER_TEMP/ios-share-profile.plist"
+        echo "$IOS_SHARE_PROVISION_PROFILE" | base64 --decode > "$PROFILE_PATH"
+        security cms -D -i "$PROFILE_PATH" > "$PROFILE_PLIST"
+
+        PROFILE_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" "$PROFILE_PLIST")
+        PROFILE_APP_ID=$(/usr/libexec/PlistBuddy -c "Print Entitlements:application-identifier" "$PROFILE_PLIST" | sed 's/^[A-Z0-9]*\.//')
+        EXPECTED_BUNDLE_ID="com.super-productivity.app.ShareExtension"
+        if [ "$PROFILE_APP_ID" != "$EXPECTED_BUNDLE_ID" ]; then
+          echo "ERROR: Share profile app ID ($PROFILE_APP_ID) does not match expected bundle ID ($EXPECTED_BUNDLE_ID)"
+          exit 1
+        fi
+
+        cp "$PROFILE_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles/${PROFILE_UUID}.mobileprovision"
+        echo "SHARE_PROVISIONING_PROFILE_UUID=$PROFILE_UUID" >> "$GITHUB_ENV"
+        echo "Share extension profile installed: $PROFILE_UUID"

--- a/.github/workflows/build-ios-testflight.yml
+++ b/.github/workflows/build-ios-testflight.yml
@@ -40,7 +40,8 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  # `gh pr comment` and the label-delete API call both go through the Issues
+  # API (PRs are issues); no `pull-requests: write` is needed.
   issues: write
 
 concurrency:
@@ -212,6 +213,9 @@ jobs:
           ASC_KEY_ID: ${{ secrets.mac_api_key_id }}
           ASC_ISSUER_ID: ${{ secrets.mac_api_key_issuer_id }}
           ASC_KEY_CONTENT: ${{ secrets.mac_api_key }}
+          # Optional repo variable; the Fastfile falls back to "Public Testers"
+          # when unset.
+          TESTFLIGHT_GROUP: ${{ vars.TESTFLIGHT_GROUP }}
         run: |
           set -euo pipefail
           shopt -s nullglob

--- a/.github/workflows/build-ios-testflight.yml
+++ b/.github/workflows/build-ios-testflight.yml
@@ -1,95 +1,84 @@
-name: iOS TestFlight on Label
+name: iOS TestFlight Build on Label
 
-# A maintainer applies the `ios-test-flight` label to a same-repo PR and this
-# builds the PR head and uploads it to the external TestFlight group whose Public
-# Link is posted back on the PR. This lets people without a Mac/Xcode try a
-# feature branch on a real device.
-#
-# Why the guards:
-#   - `pull_request` (not `pull_request_target`) so the checked-out tree is the
-#     PR head. Combined with Apple signing secrets in the job, that is only safe
-#     for same-repo PRs, hence the `head.repo.full_name == github.repository`
-#     check. Fork PRs must be pushed to a branch in this repo first (the
-#     share-extension PR was handled this way).
-#   - Local actions and the Fastfile resolve from the checked-out tree, so if
-#     the head branch predates these CI helpers, the workflow falls back to the
-#     base branch for them (step "Ensure TestFlight CI helpers are available").
-#
-# One-time setup (cannot be automated):
-#   1. Create the `ios-test-flight` label, then merge this workflow to the
-#      default branch before labeling old branches.
-#   2. In App Store Connect create an External Testing group (default name
-#      "Public Testers" — see fastlane/Fastfile) and enable its Public Link.
-#      Each build is submitted for Beta App Review; the first is reviewed by
-#      Apple and later builds usually auto-approve.
-#   3. Add the group's Public Link as the repository variable
-#      TESTFLIGHT_PUBLIC_LINK (a variable, not a secret — it is meant to be
-#      shared).
-#
-# The label is removed at the end so re-applying it starts a fresh build. Uploads
-# only, never an App Store review submission.
-#
-# Permission note: applying labels needs triage access or higher, but the build
-# only ever uses same-repo branch code, which only users with write access can
-# create — so a labeler cannot introduce code the write-access holders have not
-# already put on a branch in this repo.
+# This is the untrusted half of the public TestFlight pipeline. It intentionally
+# receives no Apple credentials: PR-controlled npm scripts, CocoaPods, Xcode
+# project files, and build phases execute here and only produce an unsigned
+# archive. publish-ios-testflight.yml runs from the default branch, validates the
+# archive, waits for protected-environment approval, then signs and uploads it.
 
 on:
   pull_request:
+    branches: [master]
     types: [labeled]
 
 permissions:
   contents: read
-  # `gh pr comment` and the label-delete API call both go through the Issues
-  # API (PRs are issues); no `pull-requests: write` is needed.
-  issues: write
 
 concurrency:
-  group: ios-testflight-${{ github.event.pull_request.number }}
-  # Not `cancel-in-progress`: the PR-build lane uploads to TestFlight, and we
-  # want the cleanup step (label removal + comment) to run deterministically.
+  group: ios-testflight-build-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
-  testflight:
+  build-unsigned-archive:
     if: >
       github.event.label.name == 'ios-test-flight' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: macos-26
-    timeout-minutes: 90
-    env:
-      UNSPLASH_KEY: ${{ secrets.UNSPLASH_KEY }}
-      UNSPLASH_CLIENT_ID: ${{ secrets.UNSPLASH_CLIENT_ID }}
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    timeout-minutes: 60
 
     steps:
+      - name: Record TestFlight request
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/request"
+          jq -n \
+            --argjson pr_number "$PR_NUMBER" \
+            --arg head_sha "$HEAD_SHA" \
+            --arg base_sha "$BASE_SHA" \
+            --argjson run_id "$GITHUB_RUN_ID" \
+            --argjson run_number "$GITHUB_RUN_NUMBER" \
+            --argjson run_attempt "$GITHUB_RUN_ATTEMPT" \
+            '{pr_number: $pr_number, head_sha: $head_sha, base_sha: $base_sha,
+              run_id: $run_id, run_number: $run_number, run_attempt: $run_attempt}' \
+            > "$RUNNER_TEMP/request/metadata.json"
+
+      - name: Upload request metadata
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ios-testflight-request-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/request/metadata.json
+          if-no-files-found: error
+          retention-days: 7
+
       - name: Check out PR head
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
-          ref: ${{ env.HEAD_SHA }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
           persist-credentials: false
 
-      - name: Ensure TestFlight CI helpers are available
-        # Older feature branches can predate both the shared signing action and
-        # the TestFlight Fastlane lane. Prefer the PR versions when present;
-        # otherwise copy only the missing helpers from the trusted base branch.
+      - name: Restore trusted version helper
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          ACTION=.github/actions/setup-ios-signing/action.yml
-          MISSING_ACTION=false
-          MISSING_LANE=false
-          [ -f "$ACTION" ] || MISSING_ACTION=true
-          grep -q '^  lane :testflight do' fastlane/Fastfile || MISSING_LANE=true
+          # Old PR branches predate the helper. Use the exact base commit from
+          # the label event, never a moving branch name or a PR-provided copy.
+          git checkout "$BASE_SHA" -- tools/ios-testflight-version.js
+          git show "$BASE_SHA:package.json" > "$RUNNER_TEMP/base-package.json"
 
-          if [ "$MISSING_ACTION" = true ] || [ "$MISSING_LANE" = true ]; then
-            git fetch --depth=1 origin "${{ github.event.pull_request.base.ref }}"
-          fi
-          if [ "$MISSING_ACTION" = true ]; then
-            git checkout FETCH_HEAD -- .github/actions/setup-ios-signing
-          fi
-          if [ "$MISSING_LANE" = true ]; then
-            git checkout FETCH_HEAD -- fastlane/Fastfile
-          fi
+      - name: Select Xcode 26.2
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.2.app
+          echo "SDKROOT=$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk" >> "$GITHUB_ENV"
+
+      - name: Verify Xcode and SDK version
+        run: |
+          xcodebuild -version
+          xcrun --show-sdk-version
+          xcodebuild -showsdks | grep -E "(iOS|iphoneos)"
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
@@ -101,53 +90,34 @@ jobs:
           git config --global url."https://github.com/".insteadOf
           ssh://git@github.com/
 
-      - name: Configure iOS signing
-        uses: ./.github/actions/setup-ios-signing
-        with:
-          mac_certs: ${{ secrets.mac_certs }}
-          mac_certs_password: ${{ secrets.mac_certs_password }}
-          ios_provision_profile: ${{ secrets.IOS_PROVISION_PROFILE }}
-          ios_share_provision_profile: ${{ secrets.IOS_SHARE_PROVISION_PROFILE }}
-
       - name: Get npm cache directory
         id: npm-cache-dir
-        run: |
-          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
-        id: npm-cache
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node22-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node22-
 
-      - name: Install npm Packages
+      - name: Install npm packages
         run: npm i
 
       - name: Generate environment
         run: npm run env
 
-      - name: Set iOS version from package.json
+      - name: Set TestFlight version
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          FULL_VERSION=$(node -p "require('./package.json').version")
-          # Strip pre-release suffix (e.g., "17.0.0-RC.3" -> "17.0.0")
-          # App Store Connect requires X.Y.Z; the build number differentiates
-          # uploads. Run number + attempt keep same-minute runs and reruns unique
-          # (see docs/plans/2026-07-14-ios-testflight-master-builds.md).
-          VERSION=$(echo "$FULL_VERSION" | sed 's/-.*//')
-          BUILD_NUMBER="$(date -u +%Y%m%d%H%M).${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
-          echo "Setting iOS version to $VERSION (build $BUILD_NUMBER) [from $FULL_VERSION]"
+          VERSION=$(node tools/ios-testflight-version.js "$RUNNER_TEMP/base-package.json" "$BASE_SHA")
+          BUILD_NUMBER="${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+          echo "Setting iOS TestFlight version to $VERSION (build $BUILD_NUMBER)"
 
           cd ios/App
-          if ! xcrun agvtool new-marketing-version "$VERSION"; then
-            echo "Error: Failed to set marketing version to $VERSION"
-            exit 1
-          fi
-          if ! xcrun agvtool new-version -all "$BUILD_NUMBER"; then
-            echo "Error: Failed to set build number to $BUILD_NUMBER"
-            exit 1
-          fi
+          xcrun agvtool new-marketing-version "$VERSION"
+          xcrun agvtool new-version -all "$BUILD_NUMBER"
 
       - name: Build Angular frontend
         run: npm run buildFrontend:prodWeb
@@ -156,15 +126,12 @@ jobs:
         run: npm run sync:ios
 
       - name: Install CocoaPods
-        run: |
-          cd ios/App
-          pod install
+        working-directory: ios/App
+        run: pod install
 
-      - name: Archive iOS app
+      - name: Archive iOS app without signing
+        working-directory: ios/App
         run: |
-          cd ios/App
-          # Archive without code signing - signing is handled during export
-          # This avoids conflicts with CocoaPods frameworks
           xcodebuild archive \
             -workspace App.xcworkspace \
             -scheme App \
@@ -174,106 +141,16 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO
 
-      - name: Create ExportOptions.plist
+      - name: Pack unsigned archive
         run: |
-          cat > "$RUNNER_TEMP/ExportOptions.plist" << EOF
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-              <key>method</key>
-              <string>app-store-connect</string>
-              <key>teamID</key>
-              <string>${{ secrets.APPLE_TEAM_ID }}</string>
-              <key>uploadSymbols</key>
-              <true/>
-              <key>signingStyle</key>
-              <string>manual</string>
-              <key>provisioningProfiles</key>
-              <dict>
-                  <key>com.super-productivity.app</key>
-                  <string>${{ env.PROVISIONING_PROFILE_UUID }}</string>
-              </dict>
-          </dict>
-          </plist>
-          EOF
+          test -f "$RUNNER_TEMP/App.xcarchive/Info.plist"
+          tar -czf "$RUNNER_TEMP/App.xcarchive.tar.gz" \
+            -C "$RUNNER_TEMP" App.xcarchive
 
-          if [ -f ios/App/ShareExtension/Info.plist ]; then
-            if [ -z "${SHARE_PROVISIONING_PROFILE_UUID:-}" ]; then
-              echo "ERROR: ShareExtension target requires IOS_SHARE_PROVISION_PROFILE"
-              exit 1
-            fi
-            /usr/libexec/PlistBuddy -c \
-              "Add :provisioningProfiles:com.super-productivity.app.ShareExtension string $SHARE_PROVISIONING_PROFILE_UUID" \
-              "$RUNNER_TEMP/ExportOptions.plist"
-          fi
-
-      - name: Export IPA
-        run: |
-          xcodebuild -exportArchive \
-            -archivePath "$RUNNER_TEMP/App.xcarchive" \
-            -exportPath "$RUNNER_TEMP/ipa-output" \
-            -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist"
-
-      - name: List exported files
-        run: ls -la "$RUNNER_TEMP/ipa-output"
-
-      - name: Set up Ruby and fastlane
-        # Pinned by SHA per repo policy. ruby-version is required: with no
-        # .ruby-version file in the repo the action errors out rather than
-        # using system Ruby. bundler-cache runs `bundle install` and caches the
-        # ~210-gem fastlane tree so it isn't reinstalled each run.
-        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+      - name: Upload unsigned archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          ruby-version: '3.3'
-          bundler-cache: true
-
-      - name: Upload to TestFlight
-        env:
-          ASC_KEY_ID: ${{ secrets.mac_api_key_id }}
-          ASC_ISSUER_ID: ${{ secrets.mac_api_key_issuer_id }}
-          ASC_KEY_CONTENT: ${{ secrets.mac_api_key }}
-          # Optional repo variable; the Fastfile falls back to "Public Testers"
-          # when unset.
-          TESTFLIGHT_GROUP: ${{ vars.TESTFLIGHT_GROUP }}
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          export CHANGELOG="Test build from PR #${PR_NUMBER} (${HEAD_SHA:0:7})"
-          ipas=("$RUNNER_TEMP"/ipa-output/*.ipa)
-          if [ ${#ipas[@]} -ne 1 ]; then
-            echo "Expected exactly 1 .ipa, found ${#ipas[@]}: ${ipas[*]:-none}"
-            exit 1
-          fi
-          export IPA_PATH="${ipas[0]}"
-          echo "Uploading $IPA_PATH to TestFlight ($CHANGELOG)"
-          bundle exec fastlane ios testflight
-
-      - name: Report result and clear the label
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PUBLIC_LINK: ${{ vars.TESTFLIGHT_PUBLIC_LINK }}
-          JOB_STATUS: ${{ job.status }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          if [ "$JOB_STATUS" = "success" ]; then
-            status_line="✅ TestFlight build for \`${HEAD_SHA:0:7}\` uploaded."
-          else
-            status_line="❌ TestFlight build for \`${HEAD_SHA:0:7}\` failed — see the [run]($RUN_URL)."
-          fi
-          if [ -n "$PUBLIC_LINK" ]; then
-            link_line="Join the beta: $PUBLIC_LINK"
-          else
-            link_line="_No \`TESTFLIGHT_PUBLIC_LINK\` repository variable is set._"
-          fi
-          printf -v body '%s\n\n%s\n\n_The `ios-test-flight` label has been removed; re-apply it to build again._' \
-            "$status_line" "$link_line"
-          # Best-effort: a transient comment failure must not mark a successful
-          # upload as failed, and must not skip the label cleanup below.
-          gh pr comment "$PR_NUMBER" --body "$body" || echo "Failed to comment on the PR."
-
-          # Remove the label so re-applying it starts a fresh build.
-          gh api -X DELETE \
-            "repos/${{ github.repository }}/issues/$PR_NUMBER/labels/ios-test-flight" \
-            || echo "Label already removed."
+          name: ios-testflight-unsigned-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/App.xcarchive.tar.gz
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/build-ios-testflight.yml
+++ b/.github/workflows/build-ios-testflight.yml
@@ -1,0 +1,255 @@
+name: iOS TestFlight on Label
+
+# A maintainer applies the `ios-test-flight` label to a same-repo PR and this
+# builds the PR head and uploads it to the external TestFlight group whose Public
+# Link is posted back on the PR. This lets people without a Mac/Xcode try a
+# feature branch on a real device.
+#
+# Why the guards:
+#   - `pull_request` (not `pull_request_target`) so the checked-out tree is the
+#     PR head. Combined with Apple signing secrets in the job, that is only safe
+#     for same-repo PRs, hence the `head.repo.full_name == github.repository`
+#     check. Fork PRs must be pushed to a branch in this repo first (the
+#     share-extension PR was handled this way).
+#   - Local actions resolve from the checked-out tree, so if the head branch
+#     predates the shared signing action, the workflow falls back to the base
+#     branch for it (step "Ensure signing action is available").
+#
+# One-time setup (cannot be automated):
+#   1. Create the `ios-test-flight` label, then merge this workflow to the
+#      default branch before labeling old branches.
+#   2. In App Store Connect create an External Testing group (default name
+#      "Public Testers" — see fastlane/Fastfile) and enable its Public Link.
+#      Each build is submitted for Beta App Review; the first is reviewed by
+#      Apple and later builds usually auto-approve.
+#   3. Add the group's Public Link as the repository variable
+#      TESTFLIGHT_PUBLIC_LINK (a variable, not a secret — it is meant to be
+#      shared).
+#
+# The label is removed at the end so re-applying it starts a fresh build. Uploads
+# only, never an App Store review submission.
+#
+# Permission note: applying labels needs triage access or higher, but the build
+# only ever uses same-repo branch code, which only users with write access can
+# create — so a labeler cannot introduce code the write-access holders have not
+# already put on a branch in this repo.
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: ios-testflight-${{ github.event.pull_request.number }}
+  # Not `cancel-in-progress`: the PR-build lane uploads to TestFlight, and we
+  # want the cleanup step (label removal + comment) to run deterministically.
+  cancel-in-progress: false
+
+jobs:
+  testflight:
+    if: >
+      github.event.label.name == 'ios-test-flight' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: macos-26
+    timeout-minutes: 90
+    env:
+      UNSPLASH_KEY: ${{ secrets.UNSPLASH_KEY }}
+      UNSPLASH_CLIENT_ID: ${{ secrets.UNSPLASH_CLIENT_ID }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+    steps:
+      - name: Check out PR head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ env.HEAD_SHA }}
+          persist-credentials: false
+
+      - name: Ensure signing action is available
+        # Local actions resolve from the checked-out tree, so a feature branch
+        # that predates the shared signing action would have nothing to call.
+        # Fall back to the base branch, but prefer the PR head when it already
+        # carries the action (e.g. while developing the action itself).
+        run: |
+          ACTION=.github/actions/setup-ios-signing/action.yml
+          if [ ! -f "$ACTION" ]; then
+            git fetch --depth=1 origin "${{ github.event.pull_request.base.ref }}"
+            git checkout FETCH_HEAD -- .github/actions/setup-ios-signing
+          fi
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: 22
+
+      # work around for npm installs from git+https://github.com/johannesjo/J2M.git
+      - name: Reconfigure git to use HTTP authentication
+        run: >
+          git config --global url."https://github.com/".insteadOf
+          ssh://git@github.com/
+
+      - name: Configure iOS signing
+        uses: ./.github/actions/setup-ios-signing
+        with:
+          mac_certs: ${{ secrets.mac_certs }}
+          mac_certs_password: ${{ secrets.mac_certs_password }}
+          ios_provision_profile: ${{ secrets.IOS_PROVISION_PROFILE }}
+
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        run: |
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        id: npm-cache
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-node22-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node22-
+
+      - name: Install npm Packages
+        run: npm i
+
+      - name: Generate environment
+        run: npm run env
+
+      - name: Set iOS version from package.json
+        run: |
+          FULL_VERSION=$(node -p "require('./package.json').version")
+          # Strip pre-release suffix (e.g., "17.0.0-RC.3" -> "17.0.0")
+          # App Store Connect requires X.Y.Z; the build number differentiates
+          # uploads. Run number + attempt keep same-minute runs and reruns unique
+          # (see docs/plans/2026-07-14-ios-testflight-master-builds.md).
+          VERSION=$(echo "$FULL_VERSION" | sed 's/-.*//')
+          BUILD_NUMBER="$(date -u +%Y%m%d%H%M).${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+          echo "Setting iOS version to $VERSION (build $BUILD_NUMBER) [from $FULL_VERSION]"
+
+          cd ios/App
+          if ! xcrun agvtool new-marketing-version "$VERSION"; then
+            echo "Error: Failed to set marketing version to $VERSION"
+            exit 1
+          fi
+          if ! xcrun agvtool new-version -all "$BUILD_NUMBER"; then
+            echo "Error: Failed to set build number to $BUILD_NUMBER"
+            exit 1
+          fi
+
+      - name: Build Angular frontend
+        run: npm run buildFrontend:prodWeb
+
+      - name: Sync Capacitor iOS
+        run: npm run sync:ios
+
+      - name: Install CocoaPods
+        run: |
+          cd ios/App
+          pod install
+
+      - name: Archive iOS app
+        run: |
+          cd ios/App
+          # Archive without code signing - signing is handled during export
+          # This avoids conflicts with CocoaPods frameworks
+          xcodebuild archive \
+            -workspace App.xcworkspace \
+            -scheme App \
+            -configuration Release \
+            -archivePath "$RUNNER_TEMP/App.xcarchive" \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Create ExportOptions.plist
+        run: |
+          cat > "$RUNNER_TEMP/ExportOptions.plist" << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>method</key>
+              <string>app-store-connect</string>
+              <key>teamID</key>
+              <string>${{ secrets.APPLE_TEAM_ID }}</string>
+              <key>uploadSymbols</key>
+              <true/>
+              <key>signingStyle</key>
+              <string>manual</string>
+              <key>provisioningProfiles</key>
+              <dict>
+                  <key>com.super-productivity.app</key>
+                  <string>${{ env.PROVISIONING_PROFILE_UUID }}</string>
+              </dict>
+          </dict>
+          </plist>
+          EOF
+
+      - name: Export IPA
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/App.xcarchive" \
+            -exportPath "$RUNNER_TEMP/ipa-output" \
+            -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist"
+
+      - name: List exported files
+        run: ls -la "$RUNNER_TEMP/ipa-output"
+
+      - name: Set up Ruby and fastlane
+        # Pinned by SHA per repo policy. ruby-version is required: with no
+        # .ruby-version file in the repo the action errors out rather than
+        # using system Ruby. bundler-cache runs `bundle install` and caches the
+        # ~210-gem fastlane tree so it isn't reinstalled each run.
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Upload to TestFlight
+        env:
+          ASC_KEY_ID: ${{ secrets.mac_api_key_id }}
+          ASC_ISSUER_ID: ${{ secrets.mac_api_key_issuer_id }}
+          ASC_KEY_CONTENT: ${{ secrets.mac_api_key }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          export CHANGELOG="Test build from PR #${PR_NUMBER} (${HEAD_SHA:0:7})"
+          ipas=("$RUNNER_TEMP"/ipa-output/*.ipa)
+          if [ ${#ipas[@]} -ne 1 ]; then
+            echo "Expected exactly 1 .ipa, found ${#ipas[@]}: ${ipas[*]:-none}"
+            exit 1
+          fi
+          export IPA_PATH="${ipas[0]}"
+          echo "Uploading $IPA_PATH to TestFlight ($CHANGELOG)"
+          bundle exec fastlane ios testflight
+
+      - name: Report result and clear the label
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLIC_LINK: ${{ vars.TESTFLIGHT_PUBLIC_LINK }}
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ "$JOB_STATUS" = "success" ]; then
+            status_line="✅ TestFlight build for \`${HEAD_SHA:0:7}\` uploaded."
+          else
+            status_line="❌ TestFlight build for \`${HEAD_SHA:0:7}\` failed — see the [run]($RUN_URL)."
+          fi
+          if [ -n "$PUBLIC_LINK" ]; then
+            link_line="Join the beta: $PUBLIC_LINK"
+          else
+            link_line="_No \`TESTFLIGHT_PUBLIC_LINK\` repository variable is set._"
+          fi
+          printf -v body '%s\n\n%s\n\n_The `ios-test-flight` label has been removed; re-apply it to build again._' \
+            "$status_line" "$link_line"
+          # Best-effort: a transient comment failure must not mark a successful
+          # upload as failed, and must not skip the label cleanup below.
+          gh pr comment "$PR_NUMBER" --body "$body" || echo "Failed to comment on the PR."
+
+          # Remove the label so re-applying it starts a fresh build.
+          gh api -X DELETE \
+            "repos/${{ github.repository }}/issues/$PR_NUMBER/labels/ios-test-flight" \
+            || echo "Label already removed."

--- a/.github/workflows/build-ios-testflight.yml
+++ b/.github/workflows/build-ios-testflight.yml
@@ -61,13 +61,18 @@ jobs:
           persist-credentials: false
 
       - name: Restore trusted version helper
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          # Old PR branches predate the helper. Use the exact base commit from
-          # the label event, never a moving branch name or a PR-provided copy.
-          git checkout "$BASE_SHA" -- tools/ios-testflight-version.js
-          git show "$BASE_SHA:package.json" > "$RUNNER_TEMP/base-package.json"
+          # The PR's frozen base commit can predate this helper, and the PR's own
+          # copy is untrusted. Take the helper and the version inputs from the
+          # default branch, which is where this workflow is defined.
+          if ! TRUSTED_SHA=$(git rev-parse --verify --quiet origin/master); then
+            git fetch --force --tags origin master
+            TRUSTED_SHA=$(git rev-parse FETCH_HEAD)
+          fi
+          git cat-file -e "$TRUSTED_SHA:tools/ios-testflight-version.js"
+          git checkout "$TRUSTED_SHA" -- tools/ios-testflight-version.js
+          git show "$TRUSTED_SHA:package.json" > "$RUNNER_TEMP/trusted-package.json"
+          echo "TRUSTED_SHA=$TRUSTED_SHA" >> "$GITHUB_ENV"
 
       - name: Select Xcode 26.2
         run: |
@@ -108,10 +113,8 @@ jobs:
         run: npm run env
 
       - name: Set TestFlight version
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          VERSION=$(node tools/ios-testflight-version.js "$RUNNER_TEMP/base-package.json" "$BASE_SHA")
+          VERSION=$(node tools/ios-testflight-version.js "$RUNNER_TEMP/trusted-package.json" "$TRUSTED_SHA")
           BUILD_NUMBER="${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
           echo "Setting iOS TestFlight version to $VERSION (build $BUILD_NUMBER)"
 

--- a/.github/workflows/build-ios-testflight.yml
+++ b/.github/workflows/build-ios-testflight.yml
@@ -11,9 +11,9 @@ name: iOS TestFlight on Label
 #     for same-repo PRs, hence the `head.repo.full_name == github.repository`
 #     check. Fork PRs must be pushed to a branch in this repo first (the
 #     share-extension PR was handled this way).
-#   - Local actions resolve from the checked-out tree, so if the head branch
-#     predates the shared signing action, the workflow falls back to the base
-#     branch for it (step "Ensure signing action is available").
+#   - Local actions and the Fastfile resolve from the checked-out tree, so if
+#     the head branch predates these CI helpers, the workflow falls back to the
+#     base branch for them (step "Ensure TestFlight CI helpers are available").
 #
 # One-time setup (cannot be automated):
 #   1. Create the `ios-test-flight` label, then merge this workflow to the
@@ -70,16 +70,25 @@ jobs:
           ref: ${{ env.HEAD_SHA }}
           persist-credentials: false
 
-      - name: Ensure signing action is available
-        # Local actions resolve from the checked-out tree, so a feature branch
-        # that predates the shared signing action would have nothing to call.
-        # Fall back to the base branch, but prefer the PR head when it already
-        # carries the action (e.g. while developing the action itself).
+      - name: Ensure TestFlight CI helpers are available
+        # Older feature branches can predate both the shared signing action and
+        # the TestFlight Fastlane lane. Prefer the PR versions when present;
+        # otherwise copy only the missing helpers from the trusted base branch.
         run: |
           ACTION=.github/actions/setup-ios-signing/action.yml
-          if [ ! -f "$ACTION" ]; then
+          MISSING_ACTION=false
+          MISSING_LANE=false
+          [ -f "$ACTION" ] || MISSING_ACTION=true
+          grep -q '^  lane :testflight do' fastlane/Fastfile || MISSING_LANE=true
+
+          if [ "$MISSING_ACTION" = true ] || [ "$MISSING_LANE" = true ]; then
             git fetch --depth=1 origin "${{ github.event.pull_request.base.ref }}"
+          fi
+          if [ "$MISSING_ACTION" = true ]; then
             git checkout FETCH_HEAD -- .github/actions/setup-ios-signing
+          fi
+          if [ "$MISSING_LANE" = true ]; then
+            git checkout FETCH_HEAD -- fastlane/Fastfile
           fi
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
@@ -98,6 +107,7 @@ jobs:
           mac_certs: ${{ secrets.mac_certs }}
           mac_certs_password: ${{ secrets.mac_certs_password }}
           ios_provision_profile: ${{ secrets.IOS_PROVISION_PROFILE }}
+          ios_share_provision_profile: ${{ secrets.IOS_SHARE_PROVISION_PROFILE }}
 
       - name: Get npm cache directory
         id: npm-cache-dir
@@ -187,6 +197,16 @@ jobs:
           </dict>
           </plist>
           EOF
+
+          if [ -f ios/App/ShareExtension/Info.plist ]; then
+            if [ -z "${SHARE_PROVISIONING_PROFILE_UUID:-}" ]; then
+              echo "ERROR: ShareExtension target requires IOS_SHARE_PROVISION_PROFILE"
+              exit 1
+            fi
+            /usr/libexec/PlistBuddy -c \
+              "Add :provisioningProfiles:com.super-productivity.app.ShareExtension string $SHARE_PROVISIONING_PROFILE_UUID" \
+              "$RUNNER_TEMP/ExportOptions.plist"
+          fi
 
       - name: Export IPA
         run: |

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -22,98 +22,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Select Xcode 26.2
-        # SDKROOT pin: the macos-26 image (2026-08) resolves the default SDK for
-        # bare `xcrun` calls to /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk,
-        # which doesn't exist there, so `xcrun --show-sdk-version`, `xcrun agvtool`
-        # and xcrun-based tool lookups fail ("SDK ... cannot be located") even with
-        # full Xcode selected. Pointing SDKROOT at the selected Xcode's macOS SDK
-        # overrides that resolution for all later steps. It cannot leak into the
-        # iOS archive: the app project pins SDKROOT = iphoneos in its build
-        # settings, which takes precedence over the environment.
-        run: |
-          sudo xcode-select -s /Applications/Xcode_26.2.app
-          echo "SDKROOT=$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk" >> "$GITHUB_ENV"
-
-      - name: Verify Xcode and SDK version
-        run: |
-          echo "=== Xcode Version ==="
-          xcodebuild -version
-          echo ""
-          echo "=== SDK Information ==="
-          xcrun --show-sdk-version
-          xcodebuild -showsdks | grep -E "(iOS|iphoneos)"
-
       # work around for npm installs from git+https://github.com/johannesjo/J2M.git
       - name: Reconfigure git to use HTTP authentication
         run: >
           git config --global url."https://github.com/".insteadOf
           ssh://git@github.com/
 
-      - name: Install Apple WWDR intermediate certificate
-        run: |
-          curl -fsSL https://www.apple.com/certificateauthority/AppleWWDRCAG4.cer -o /tmp/AppleWWDRCAG4.cer
-          sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /tmp/AppleWWDRCAG4.cer
-
-      - name: Configure signing keychain
-        env:
-          # Reuse mac_certs - "Apple Distribution" certificate works for both macOS and iOS
-          MAC_CERTS: ${{ secrets.mac_certs }}
-          MAC_CERTS_PASSWORD: ${{ secrets.mac_certs_password }}
-        run: |
-          CERT_PATH="$RUNNER_TEMP/dist-cert.p12"
-          KEYCHAIN_NAME="build.keychain"
-          KEYCHAIN_PATH="$HOME/Library/Keychains/${KEYCHAIN_NAME}-db"
-          echo "$MAC_CERTS" | base64 --decode > "$CERT_PATH"
-          echo "=== DIAGNOSTIC: Decoded .p12 SHA256 ==="
-          shasum -a 256 "$CERT_PATH"
-          echo "========================================"
-          security create-keychain -p "" "$KEYCHAIN_NAME"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "" "$KEYCHAIN_PATH"
-          curl -fsSL https://www.apple.com/certificateauthority/AppleWWDRCAG4.cer -o "$RUNNER_TEMP/AppleWWDRCAG4.cer"
-          security import "$RUNNER_TEMP/AppleWWDRCAG4.cer" -k "$KEYCHAIN_PATH" -T /usr/bin/codesign
-          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$MAC_CERTS_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
-          security list-keychains -s "$KEYCHAIN_PATH" "$HOME/Library/Keychains/login.keychain-db"
-          security default-keychain -s "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple: -k "" "$KEYCHAIN_PATH"
-          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
-
-      - name: List available signing identities
-        run: security find-identity -v -p codesigning
-
-      - name: Install provisioning profile
-        env:
-          IOS_PROVISION_PROFILE: ${{ secrets.IOS_PROVISION_PROFILE }}
-        run: |
-          PROFILE_PATH="$RUNNER_TEMP/ios-provisioning.mobileprovision"
-          echo "$IOS_PROVISION_PROFILE" | base64 --decode > "$PROFILE_PATH"
-          # Get the UUID from the provisioning profile
-          PROFILE_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< $(security cms -D -i "$PROFILE_PATH"))
-          echo "Profile UUID: $PROFILE_UUID"
-          # Create the provisioning profiles directory if it doesn't exist
-          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
-          # Copy the profile with its UUID as the filename
-          cp "$PROFILE_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles/${PROFILE_UUID}.mobileprovision"
-          echo "PROVISIONING_PROFILE_UUID=$PROFILE_UUID" >> "$GITHUB_ENV"
-
-      - name: Verify provisioning profile
-        run: |
-          security cms -D -i "$HOME/Library/MobileDevice/Provisioning Profiles/${PROVISIONING_PROFILE_UUID}.mobileprovision" > /tmp/profile.plist
-          echo "=== PROVISIONING PROFILE INFO ==="
-          echo "Name: $(/usr/libexec/PlistBuddy -c "Print Name" /tmp/profile.plist)"
-          echo "Team: $(/usr/libexec/PlistBuddy -c "Print TeamIdentifier:0" /tmp/profile.plist)"
-          PROFILE_APP_ID=$(/usr/libexec/PlistBuddy -c "Print Entitlements:application-identifier" /tmp/profile.plist | sed 's/^[A-Z0-9]*\.//')
-          echo "App ID: $PROFILE_APP_ID"
-          echo "=================================="
-          # Verify bundle ID matches
-          EXPECTED_BUNDLE_ID="com.super-productivity.app"
-          if [ "$PROFILE_APP_ID" != "$EXPECTED_BUNDLE_ID" ]; then
-            echo "ERROR: Provisioning profile app ID ($PROFILE_APP_ID) does not match expected bundle ID ($EXPECTED_BUNDLE_ID)"
-            echo "Please create a new provisioning profile with the correct bundle ID"
-            exit 1
-          fi
-          echo "Bundle ID verification passed!"
+      - name: Configure iOS signing
+        uses: ./.github/actions/setup-ios-signing
+        with:
+          mac_certs: ${{ secrets.mac_certs }}
+          mac_certs_password: ${{ secrets.mac_certs_password }}
+          ios_provision_profile: ${{ secrets.IOS_PROVISION_PROFILE }}
 
       - name: Get npm cache directory
         id: npm-cache-dir

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -34,6 +34,7 @@ jobs:
           mac_certs: ${{ secrets.mac_certs }}
           mac_certs_password: ${{ secrets.mac_certs_password }}
           ios_provision_profile: ${{ secrets.IOS_PROVISION_PROFILE }}
+          ios_share_provision_profile: ${{ secrets.IOS_SHARE_PROVISION_PROFILE }}
 
       - name: Get npm cache directory
         id: npm-cache-dir
@@ -121,6 +122,16 @@ jobs:
           </dict>
           </plist>
           EOF
+
+          if [ -f ios/App/ShareExtension/Info.plist ]; then
+            if [ -z "${SHARE_PROVISIONING_PROFILE_UUID:-}" ]; then
+              echo "ERROR: ShareExtension target requires IOS_SHARE_PROVISION_PROFILE"
+              exit 1
+            fi
+            /usr/libexec/PlistBuddy -c \
+              "Add :provisioningProfiles:com.super-productivity.app.ShareExtension string $SHARE_PROVISIONING_PROFILE_UUID" \
+              "$RUNNER_TEMP/ExportOptions.plist"
+          fi
 
       - name: Export IPA
         run: |

--- a/.github/workflows/publish-ios-testflight.yml
+++ b/.github/workflows/publish-ios-testflight.yml
@@ -1,0 +1,403 @@
+name: iOS TestFlight Publish
+
+# Security boundary: workflow_run executes this file from the default branch,
+# not from the PR. PR code only produces an unsigned archive. A credential-free
+# job validates and repacks that archive before the protected `ios-testflight`
+# environment can expose signing credentials to the publish job.
+
+on:
+  workflow_run:
+    workflows: ['iOS TestFlight Build on Label']
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  discover:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    outputs:
+      requested: ${{ steps.request.outputs.requested }}
+      pr_number: ${{ steps.source.outputs.pr_number }}
+      head_sha: ${{ steps.source.outputs.head_sha }}
+      base_sha: ${{ steps.source.outputs.base_sha }}
+
+    steps:
+      - name: Check out trusted publisher code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Discover TestFlight request
+        id: request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+          SOURCE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          NAME="ios-testflight-request-${SOURCE_RUN_ID}-${SOURCE_RUN_ATTEMPT}"
+          COUNT=$(gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID/artifacts" \
+            --jq "[.artifacts[] | select(.name == \"$NAME\")] | length")
+          if [ "$COUNT" = 0 ]; then
+            echo "requested=false" >> "$GITHUB_OUTPUT"
+            echo "No TestFlight request artifact; ignoring this label event."
+            exit 0
+          fi
+          test "$COUNT" = 1
+          echo "requested=true" >> "$GITHUB_OUTPUT"
+
+      - name: Download request metadata
+        if: steps.request.outputs.requested == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        with:
+          name: ios-testflight-request-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+          path: ${{ runner.temp }}/request
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate source run and PR
+        if: steps.request.outputs.requested == 'true'
+        id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+          SOURCE_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          SOURCE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          EVENT_HEAD_SHA: ${{ github.event.workflow_run.pull_requests[0].head.sha }}
+        run: |
+          set -euo pipefail
+          RUN_JSON=$(gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID")
+
+          test "$(jq -r '.event' <<< "$RUN_JSON")" = pull_request
+          test "$(jq -r '.path' <<< "$RUN_JSON")" = .github/workflows/build-ios-testflight.yml
+          test "$(jq -r '.head_repository.full_name' <<< "$RUN_JSON")" = "$REPO"
+
+          PR_NUMBER=$(jq -r '.pull_requests[0].number // empty' <<< "$RUN_JSON")
+          HEAD_SHA=$(jq -r '.pull_requests[0].head.sha // empty' <<< "$RUN_JSON")
+          BASE_SHA=$(jq -r '.pull_requests[0].base.sha // empty' <<< "$RUN_JSON")
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || [ "$HEAD_SHA" != "$EVENT_HEAD_SHA" ]; then
+            echo "::error::Source run is not bound to the expected PR head"
+            exit 1
+          fi
+          if ! [[ "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]] || ! git merge-base --is-ancestor "$BASE_SHA" "${{ github.sha }}"; then
+            echo "::error::Source run base is not a trusted master ancestor"
+            exit 1
+          fi
+
+          PR_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER")
+          test "$(jq -r '.state' <<< "$PR_JSON")" = open
+          test "$(jq -r '.base.ref' <<< "$PR_JSON")" = master
+          test "$(jq -r '.head.repo.full_name' <<< "$PR_JSON")" = "$REPO"
+          test "$(jq -r '.head.sha' <<< "$PR_JSON")" = "$HEAD_SHA"
+          jq -e '.labels | map(.name) | index("ios-test-flight") != null' \
+            <<< "$PR_JSON" > /dev/null
+
+          jq -e \
+            --argjson pr "$PR_NUMBER" \
+            --arg head "$HEAD_SHA" \
+            --arg base "$BASE_SHA" \
+            --argjson run_id "$SOURCE_RUN_ID" \
+            --argjson run_number "$SOURCE_RUN_NUMBER" \
+            --argjson run_attempt "$SOURCE_RUN_ATTEMPT" \
+            '.pr_number == $pr and .head_sha == $head and .base_sha == $base and .run_id == $run_id and
+             .run_number == $run_number and .run_attempt == $run_attempt' \
+            "$RUNNER_TEMP/request/metadata.json" > /dev/null
+
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+
+  validate:
+    needs: discover
+    if: >
+      needs.discover.outputs.requested == 'true' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: macos-26
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      validated: ${{ steps.archive.outputs.validated }}
+      version: ${{ steps.archive.outputs.version }}
+      build_number: ${{ steps.archive.outputs.build_number }}
+      archive_sha256: ${{ steps.archive.outputs.archive_sha256 }}
+
+    steps:
+      - name: Check out trusted publisher code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download unsigned archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        with:
+          name: ios-testflight-unsigned-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+          path: ${{ runner.temp }}/raw
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate and repack archive
+        id: archive
+        env:
+          SOURCE_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          SOURCE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          EXPECTED_BASE_SHA: ${{ needs.discover.outputs.base_sha }}
+        run: |
+          set -euo pipefail
+          RAW="$RUNNER_TEMP/raw"
+          test -f "$RAW/App.xcarchive.tar.gz"
+          test "$(find "$RAW" -type f | wc -l | tr -d ' ')" = 1
+
+          mkdir -p "$RUNNER_TEMP/validated"
+          RAW_TAR="$RAW/App.xcarchive.tar.gz" python3 - <<'PY'
+          import os
+          import posixpath
+          import tarfile
+
+          with tarfile.open(os.environ['RAW_TAR'], 'r:gz') as archive:
+              for member in archive.getmembers():
+                  normalized = posixpath.normpath(member.name)
+                  if member.name.startswith('/') or normalized == '..' or normalized.startswith('../'):
+                      raise SystemExit(f'Unsafe archive path: {member.name}')
+                  if member.islnk() or not (member.isfile() or member.isdir() or member.issym()):
+                      raise SystemExit(f'Unsupported archive entry: {member.name}')
+                  if member.issym():
+                      target = posixpath.normpath(posixpath.join(posixpath.dirname(normalized), member.linkname))
+                      if member.linkname.startswith('/') or target == '..' or target.startswith('../'):
+                          raise SystemExit(f'Unsafe archive symlink: {member.name} -> {member.linkname}')
+          PY
+          tar -xzf "$RAW/App.xcarchive.tar.gz" -C "$RUNNER_TEMP/validated"
+
+          ARCHIVE="$RUNNER_TEMP/validated/App.xcarchive"
+          APP_PLIST="$ARCHIVE/Products/Applications/App.app/Info.plist"
+          test -f "$ARCHIVE/Info.plist"
+          test -f "$APP_PLIST"
+
+          ARCHIVE="$ARCHIVE" python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ['ARCHIVE']).resolve()
+          for path in root.rglob('*'):
+              if path.is_symlink():
+                  target = (path.parent / os.readlink(path)).resolve(strict=False)
+                  if root not in (target, *target.parents):
+                      raise SystemExit(f'Unsafe archive symlink: {path} -> {target}')
+          PY
+
+          git show "$EXPECTED_BASE_SHA:package.json" > "$RUNNER_TEMP/base-package.json"
+          EXPECTED_VERSION=$(node tools/ios-testflight-version.js "$RUNNER_TEMP/base-package.json" "$EXPECTED_BASE_SHA")
+          EXPECTED_BUILD="${SOURCE_RUN_NUMBER}.${SOURCE_RUN_ATTEMPT}"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$APP_PLIST")" = com.super-productivity.app
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP_PLIST")" = "$EXPECTED_VERSION"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$APP_PLIST")" = "$EXPECTED_BUILD"
+
+          EXTENSION_PLIST="$ARCHIVE/Products/Applications/App.app/PlugIns/ShareExtension.appex/Info.plist"
+          if [ -f "$EXTENSION_PLIST" ]; then
+            test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$EXTENSION_PLIST")" = com.super-productivity.app.ShareExtension
+            test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$EXTENSION_PLIST")" = "$EXPECTED_VERSION"
+            test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$EXTENSION_PLIST")" = "$EXPECTED_BUILD"
+          fi
+
+          SANITIZED="$RUNNER_TEMP/App.xcarchive.tar.gz"
+          tar -czf "$SANITIZED" -C "$RUNNER_TEMP/validated" App.xcarchive
+          ARCHIVE_SHA256=$(shasum -a 256 "$SANITIZED" | cut -d ' ' -f 1)
+          echo "version=$EXPECTED_VERSION" >> "$GITHUB_OUTPUT"
+          echo "build_number=$EXPECTED_BUILD" >> "$GITHUB_OUTPUT"
+          echo "archive_sha256=$ARCHIVE_SHA256" >> "$GITHUB_OUTPUT"
+          echo "validated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Upload validated archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ios-testflight-validated-${{ github.run_id }}
+          path: ${{ runner.temp }}/App.xcarchive.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: 'Publish PR #${{ needs.discover.outputs.pr_number }} (${{ needs.discover.outputs.head_sha }})'
+    needs: [discover, validate]
+    if: needs.validate.outputs.validated == 'true'
+    runs-on: macos-26
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      contents: read
+    environment:
+      name: ios-testflight
+      url: ${{ vars.TESTFLIGHT_PUBLIC_LINK }}
+    concurrency:
+      group: ios-testflight-publish-${{ needs.discover.outputs.pr_number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Verify protected environment configuration
+        env:
+          ENVIRONMENT_READY: ${{ secrets.IOS_TESTFLIGHT_ENV_READY }}
+        run: |
+          if [ "$ENVIRONMENT_READY" != configured ]; then
+            echo "::error::Configure the protected ios-testflight environment before publishing"
+            exit 1
+          fi
+
+      - name: Check out trusted publisher code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Download validated archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        with:
+          name: ios-testflight-validated-${{ github.run_id }}
+          path: ${{ runner.temp }}/validated
+
+      - name: Verify and unpack validated archive
+        env:
+          EXPECTED_SHA256: ${{ needs.validate.outputs.archive_sha256 }}
+        run: |
+          ARCHIVE_TAR="$RUNNER_TEMP/validated/App.xcarchive.tar.gz"
+          test "$(shasum -a 256 "$ARCHIVE_TAR" | cut -d ' ' -f 1)" = "$EXPECTED_SHA256"
+          tar -xzf "$ARCHIVE_TAR" -C "$RUNNER_TEMP"
+
+      - name: Configure iOS signing
+        uses: ./.github/actions/setup-ios-signing
+        with:
+          mac_certs: ${{ secrets.mac_certs }}
+          mac_certs_password: ${{ secrets.mac_certs_password }}
+          ios_provision_profile: ${{ secrets.IOS_PROVISION_PROFILE }}
+          ios_share_provision_profile: ${{ secrets.IOS_SHARE_PROVISION_PROFILE }}
+
+      - name: Create ExportOptions.plist
+        run: |
+          cat > "$RUNNER_TEMP/ExportOptions.plist" << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>method</key>
+              <string>app-store-connect</string>
+              <key>teamID</key>
+              <string>${{ secrets.APPLE_TEAM_ID }}</string>
+              <key>uploadSymbols</key>
+              <true/>
+              <key>signingStyle</key>
+              <string>manual</string>
+              <key>provisioningProfiles</key>
+              <dict>
+                  <key>com.super-productivity.app</key>
+                  <string>${{ env.PROVISIONING_PROFILE_UUID }}</string>
+              </dict>
+          </dict>
+          </plist>
+          EOF
+
+          EXTENSION_PLIST="$RUNNER_TEMP/App.xcarchive/Products/Applications/App.app/PlugIns/ShareExtension.appex/Info.plist"
+          if [ -f "$EXTENSION_PLIST" ]; then
+            if [ -z "${SHARE_PROVISIONING_PROFILE_UUID:-}" ]; then
+              echo "::error::ShareExtension requires IOS_SHARE_PROVISION_PROFILE"
+              exit 1
+            fi
+            /usr/libexec/PlistBuddy -c \
+              "Add :provisioningProfiles:com.super-productivity.app.ShareExtension string $SHARE_PROVISIONING_PROFILE_UUID" \
+              "$RUNNER_TEMP/ExportOptions.plist"
+          fi
+
+      - name: Export IPA
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/App.xcarchive" \
+            -exportPath "$RUNNER_TEMP/ipa-output" \
+            -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist"
+
+      - name: Set up Ruby and fastlane
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Upload to TestFlight
+        env:
+          ASC_KEY_ID: ${{ secrets.mac_api_key_id }}
+          ASC_ISSUER_ID: ${{ secrets.mac_api_key_issuer_id }}
+          ASC_KEY_CONTENT: ${{ secrets.mac_api_key }}
+          TESTFLIGHT_GROUP: ${{ vars.TESTFLIGHT_GROUP }}
+          PR_NUMBER: ${{ needs.discover.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.discover.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          ipas=("$RUNNER_TEMP"/ipa-output/*.ipa)
+          if [ ${#ipas[@]} -ne 1 ]; then
+            echo "Expected exactly 1 .ipa, found ${#ipas[@]}: ${ipas[*]:-none}"
+            exit 1
+          fi
+          export IPA_PATH="${ipas[0]}"
+          export CHANGELOG="Test build from PR #$PR_NUMBER (${HEAD_SHA:0:7})"
+          bundle exec fastlane ios testflight
+
+  report:
+    needs: [discover, validate, publish]
+    if: always() && needs.discover.outputs.requested == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+      pull-requests: read
+
+    steps:
+      - name: Report result and clear label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          VALIDATED_PR_NUMBER: ${{ needs.discover.outputs.pr_number }}
+          HEAD_SHA: ${{ github.event.workflow_run.pull_requests[0].head.sha }}
+          SOURCE_RESULT: ${{ github.event.workflow_run.conclusion }}
+          DISCOVER_RESULT: ${{ needs.discover.result }}
+          VALIDATE_RESULT: ${{ needs.validate.result }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+          PUBLIC_LINK: ${{ vars.TESTFLIGHT_PUBLIC_LINK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          PR_NUMBER="${VALIDATED_PR_NUMBER:-$EVENT_PR_NUMBER}"
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "No associated PR; nothing to report."
+            exit 0
+          fi
+
+          if [ "$PUBLISH_RESULT" = success ]; then
+            status_line="TestFlight build for \`${HEAD_SHA:0:7}\` uploaded."
+            link_line="Join the beta: $PUBLIC_LINK"
+          elif [ "$SOURCE_RESULT" != success ]; then
+            status_line="Unsigned iOS build for \`${HEAD_SHA:0:7}\` failed."
+            link_line="See the [workflow run]($RUN_URL)."
+          elif [ "$DISCOVER_RESULT" != success ] || [ "$VALIDATE_RESULT" != success ]; then
+            status_line="TestFlight validation for \`${HEAD_SHA:0:7}\` failed."
+            link_line="The PR may have changed or the archive was invalid. See the [workflow run]($RUN_URL)."
+          else
+            status_line="TestFlight publish for \`${HEAD_SHA:0:7}\` did not complete."
+            link_line="See the [workflow run]($RUN_URL)."
+          fi
+
+          printf -v body '%s\n\n%s\n\n_The `ios-test-flight` label has been removed; re-apply it to build again._' \
+            "$status_line" "$link_line"
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body" \
+            || echo "Failed to comment on the PR."
+          gh api -X DELETE "repos/$REPO/issues/$PR_NUMBER/labels/ios-test-flight" \
+            || echo "Label already removed."

--- a/.github/workflows/publish-ios-testflight.yml
+++ b/.github/workflows/publish-ios-testflight.yml
@@ -27,7 +27,6 @@ jobs:
       requested: ${{ steps.request.outputs.requested }}
       pr_number: ${{ steps.source.outputs.pr_number }}
       head_sha: ${{ steps.source.outputs.head_sha }}
-      base_sha: ${{ steps.source.outputs.base_sha }}
 
     steps:
       - name: Check out trusted publisher code
@@ -116,7 +115,6 @@ jobs:
 
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
-          echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
 
   validate:
     needs: discover
@@ -155,7 +153,6 @@ jobs:
         env:
           SOURCE_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
           SOURCE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
-          EXPECTED_BASE_SHA: ${{ needs.discover.outputs.base_sha }}
         run: |
           set -euo pipefail
           RAW="$RUNNER_TEMP/raw"
@@ -199,8 +196,11 @@ jobs:
                       raise SystemExit(f'Unsafe archive symlink: {path} -> {target}')
           PY
 
-          git show "$EXPECTED_BASE_SHA:package.json" > "$RUNNER_TEMP/base-package.json"
-          EXPECTED_VERSION=$(node tools/ios-testflight-version.js "$RUNNER_TEMP/base-package.json" "$EXPECTED_BASE_SHA")
+          # Recompute from this trusted default-branch checkout, never from
+          # PR-controlled or frozen-base data. A newer master that changes the
+          # version train intentionally fails validation so a stale build is
+          # never signed.
+          EXPECTED_VERSION=$(node tools/ios-testflight-version.js package.json HEAD)
           EXPECTED_BUILD="${SOURCE_RUN_NUMBER}.${SOURCE_RUN_ATTEMPT}"
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$APP_PLIST")" = com.super-productivity.app
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP_PLIST")" = "$EXPECTED_VERSION"
@@ -224,7 +224,7 @@ jobs:
       - name: Upload validated archive
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ios-testflight-validated-${{ github.run_id }}
+          name: ios-testflight-validated-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/App.xcarchive.tar.gz
           if-no-files-found: error
           retention-days: 7
@@ -264,7 +264,7 @@ jobs:
       - name: Download validated archive
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
-          name: ios-testflight-validated-${{ github.run_id }}
+          name: ios-testflight-validated-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/validated
 
       - name: Verify and unpack validated archive

--- a/docs/apple-release-automation.md
+++ b/docs/apple-release-automation.md
@@ -71,7 +71,8 @@ Guards:
 - **Same-repo PRs only** (`head.repo.full_name == github.repository`). The job
   handles Apple signing secrets, so a fork PR must be pushed to a branch in this
   repo first. This is why the workflow uses `pull_request` (the PR head is built)
-  rather than `pull_request_target`.
+  rather than `pull_request_target`. Labeling a fork PR is silently skipped (no
+  comment, label stays on) — remove the label by hand in that case.
 - **Upload only** — it never submits the app for App Store review.
 - The signing setup is shared with `build-ios.yml` through
   `.github/actions/setup-ios-signing`. Both reuse the same App Distribution
@@ -84,8 +85,10 @@ One-time setup (Apple's side cannot be automated):
 2. Merge this workflow to the default branch before labeling older branches —
    for a branch that predates the shared signing action, the workflow falls back
    to the base branch for that action.
-3. In App Store Connect create an External Testing group, enable its Public Link,
-   and let the first build clear Beta App Review. Later builds usually auto-approve.
+3. In App Store Connect create an External Testing group named exactly
+   `Public Testers` (or set the repository variable `TESTFLIGHT_GROUP` to match
+   a different name), enable its Public Link, and let the first build clear
+   Beta App Review. Later builds usually auto-approve.
 4. Add the group's Public Link as the repository variable
    `TESTFLIGHT_PUBLIC_LINK` (a variable, not a secret — it is meant to be shared).
    Without it the PR comment still reports success/failure but prints no link.

--- a/docs/apple-release-automation.md
+++ b/docs/apple-release-automation.md
@@ -190,15 +190,16 @@ the description “Build and distribute this PR through public iOS TestFlight.�
 1. Create and protect the `ios-testflight` environment before merging the
    workflows.
 2. Merge the workflows to `master`. Old feature branches do not need to contain
-   them: the unsigned builder restores the version helper from its exact trusted
-   base commit, and the publisher always runs from the default branch.
+   them: the unsigned builder takes the version helper and version inputs from
+   `master`, and the publisher always runs from the default branch.
 3. Apply `ios-test-flight` to a same-repo PR targeting `master`.
 4. Wait for **iOS TestFlight Build on Label** to produce the unsigned archive.
 5. Open **iOS TestFlight Publish**. Its validation job recomputes the expected
-   marketing version from the greater of the trusted base package version and
-   stable tags merged into that base, then increments the patch. The build number
+   marketing version from the greater of `master`'s `package.json` version and
+   stable tags merged into `master`, then increments the patch. The build number
    is the source workflow's `run_number.run_attempt` and is checked in both app
-   targets.
+   targets. A newer `master` that changes this version train fails validation, so
+   a stale build is never signed.
 6. Review the PR and exact SHA shown in the protected publish job name, then
    approve the `ios-testflight` deployment.
 7. Follow the build under App Store Connect → TestFlight. After upload, the

--- a/docs/apple-release-automation.md
+++ b/docs/apple-release-automation.md
@@ -13,6 +13,7 @@ review.
 | Target                                               | Workflow                                                      | Output                         |
 | ---------------------------------------------------- | ------------------------------------------------------------- | ------------------------------ |
 | iOS App Store                                        | `.github/workflows/build-ios.yml`                             | `.ipa` → App Store Connect     |
+| iOS TestFlight (public testers, label-triggered)     | `.github/workflows/build-ios-testflight.yml`                  | `.ipa` → TestFlight (external) |
 | Mac App Store                                        | `.github/workflows/build-publish-to-mac-store-on-release.yml` | MAS `.pkg` → App Store Connect |
 | Mac direct download (notarized DMG/zip, auto-update) | `.github/workflows/build.yml` (`mac-bin`)                     | GitHub release asset           |
 
@@ -52,6 +53,46 @@ commit lands before tagging.
 > `alpha`, because GitHub Actions `contains()` is case-sensitive and this repo's
 > RC tags are predominantly **lowercase** `-rc.N`. Every pre-release tag in the
 > repo's history contains `-`; no final tag does.
+
+## Public TestFlight builds (label-triggered)
+
+A maintainer who wants outside testers to try a feature branch — e.g. one that
+touches native iOS code and so cannot be exercised in the web preview — applies
+the `ios-test-flight` label to a same-repo PR.
+`.github/workflows/build-ios-testflight.yml` then builds the PR head, exports an
+App Store Connect IPA, and runs the `fastlane ios testflight` lane, which uploads
+to the external TestFlight group (default name `Public Testers`, override with
+the `TESTFLIGHT_GROUP` variable) and submits it for Beta App Review. The workflow
+posts the group's Public Link back on the PR and removes the label so re-applying
+it starts a fresh build.
+
+Guards:
+
+- **Same-repo PRs only** (`head.repo.full_name == github.repository`). The job
+  handles Apple signing secrets, so a fork PR must be pushed to a branch in this
+  repo first. This is why the workflow uses `pull_request` (the PR head is built)
+  rather than `pull_request_target`.
+- **Upload only** — it never submits the app for App Store review.
+- The signing setup is shared with `build-ios.yml` through
+  `.github/actions/setup-ios-signing`. Both reuse the same App Distribution
+  certificate and App Manager API key, so this workflow carries the same
+  credential exposure as the release path.
+
+One-time setup (Apple's side cannot be automated):
+
+1. Create the `ios-test-flight` label.
+2. Merge this workflow to the default branch before labeling older branches —
+   for a branch that predates the shared signing action, the workflow falls back
+   to the base branch for that action.
+3. In App Store Connect create an External Testing group, enable its Public Link,
+   and let the first build clear Beta App Review. Later builds usually auto-approve.
+4. Add the group's Public Link as the repository variable
+   `TESTFLIGHT_PUBLIC_LINK` (a variable, not a secret — it is meant to be shared).
+   Without it the PR comment still reports success/failure but prints no link.
+
+The internal-`master` beta path proposed in
+[`docs/plans/2026-07-14-ios-testflight-master-builds.md`](plans/2026-07-14-ios-testflight-master-builds.md)
+is separate and not implemented here.
 
 ## Required secrets
 

--- a/docs/apple-release-automation.md
+++ b/docs/apple-release-automation.md
@@ -13,7 +13,7 @@ review.
 | Target                                               | Workflow                                                      | Output                         |
 | ---------------------------------------------------- | ------------------------------------------------------------- | ------------------------------ |
 | iOS App Store                                        | `.github/workflows/build-ios.yml`                             | `.ipa` → App Store Connect     |
-| iOS TestFlight (public testers, label-triggered)     | `.github/workflows/build-ios-testflight.yml`                  | `.ipa` → TestFlight (external) |
+| iOS TestFlight (public testers, label-triggered)     | `build-ios-testflight.yml` → `publish-ios-testflight.yml`     | `.ipa` → TestFlight (external) |
 | Mac App Store                                        | `.github/workflows/build-publish-to-mac-store-on-release.yml` | MAS `.pkg` → App Store Connect |
 | Mac direct download (notarized DMG/zip, auto-update) | `.github/workflows/build.yml` (`mac-bin`)                     | GitHub release asset           |
 
@@ -59,20 +59,30 @@ commit lands before tagging.
 A maintainer who wants outside testers to try a feature branch — e.g. one that
 touches native iOS code and so cannot be exercised in the web preview — applies
 the `ios-test-flight` label to a same-repo PR.
-`.github/workflows/build-ios-testflight.yml` then builds the PR head, exports an
-App Store Connect IPA, and runs the `fastlane ios testflight` lane, which uploads
-to the external TestFlight group (default name `Public Testers`, override with
-the `TESTFLIGHT_GROUP` variable) and submits it for Beta App Review. The workflow
-posts the group's Public Link back on the PR and removes the label so re-applying
-it starts a fresh build.
+`.github/workflows/build-ios-testflight.yml` builds an **unsigned** archive with
+no Apple credentials. After it completes,
+`.github/workflows/publish-ios-testflight.yml` runs trusted code from `master`,
+validates and repacks the archive without credentials, waits for approval through
+the protected `ios-testflight` environment, then signs and runs the
+`fastlane ios testflight` lane. The lane verifies the external group and Public
+Link, uploads the build, and submits it for Beta App Review. The publisher then
+comments on the PR and removes the label so re-applying it starts a fresh build.
 
 ### Security boundary
 
-- **Same-repo PRs only** (`head.repo.full_name == github.repository`). The job
-  handles Apple signing secrets, so a fork PR must be pushed to a branch in this
-  repo first. This is why the workflow uses `pull_request` (the PR head is built)
-  rather than `pull_request_target`. Labeling a fork PR is silently skipped (no
-  comment, label stays on) — remove the label by hand in that case.
+- **Same-repo PRs targeting `master` only.** A fork PR must be pushed to a branch
+  in this repo first. Labeling a fork PR is silently skipped (no comment, label
+  stays on) — remove the label by hand in that case.
+- **PR code never receives Apple credentials.** npm lifecycle scripts, CocoaPods,
+  Xcode project files, and build phases run only in the unsigned build workflow.
+- **Trusted publisher.** `workflow_run` loads the publisher from the default
+  branch. Its credential-free validation job confirms the source workflow path,
+  associated open PR, same-repo head, current head SHA, `master` base, label,
+  metadata, app IDs, versions, build numbers, archive paths, and symlinks. It
+  repacks the validated archive before the credentialed job downloads it.
+- **Human signing gate.** The publish job is bound to the protected
+  `ios-testflight` environment. Approve only when its job name shows the intended
+  PR number and full head SHA. No Apple secret is available before this gate.
 - **Upload only** — it never submits the app for App Store review.
 - The signing setup is shared with `build-ios.yml` through
   `.github/actions/setup-ios-signing`. Both reuse the same App Distribution
@@ -120,15 +130,33 @@ In **App Store Connect → Apps → Super Productivity → TestFlight**:
    value.
 3. Enable the group's **Public Link** and initially use a conservative tester
    limit (for example, 100).
-4. Copy the public join URL. The workflow submits each uploaded build for Beta
-   App Review; Apple reviews the first build and later builds usually approve
-   faster. A successful workflow means upload/distribution setup succeeded, not
-   necessarily that Apple has already approved the build for external testers.
+4. Copy the public join URL. The Fastlane lane fails closed unless exactly one
+   matching external group exists and its Public Link is enabled.
+
+The workflow submits each uploaded build for Beta App Review; Apple reviews the
+first build and later builds usually approve faster. A successful workflow means
+upload/distribution setup succeeded, not necessarily that Apple has already
+approved the build for external testers.
 
 ### One-time GitHub setup
 
+Before merging or applying the label, create the environment under
+**Settings → Environments → New environment**:
+
+1. Name it exactly `ios-testflight`.
+2. Add only trusted release maintainers as **Required reviewers**. If more than
+   one release maintainer is available, enable **Prevent self-review**.
+3. Restrict deployment branches to `master`.
+4. Add the environment secret `IOS_TESTFLIGHT_ENV_READY` with the exact value
+   `configured`. This fail-closed marker is deliberately not a repository secret.
+5. Save and verify the protection rules. A missing environment may be created
+   automatically without protection, but without this environment-only marker
+   the publish job stops before checkout or signing.
+
 Under **Settings → Secrets and variables → Actions**, verify the existing iOS
-release secrets and add the extension profile:
+release secrets and add the extension profile. They may remain repository
+secrets because only the protected publisher job references them; the unsigned
+PR workflow references none:
 
 | Secret                        | Purpose                                                     |
 | ----------------------------- | ----------------------------------------------------------- |
@@ -143,10 +171,9 @@ release secrets and add the extension profile:
 | `UNSPLASH_KEY`                | Existing frontend build-time Unsplash key                   |
 | `UNSPLASH_CLIENT_ID`          | Existing frontend build-time Unsplash client ID             |
 
-These names currently refer to repository secrets, like `build-ios.yml`. If the
-Apple credentials move to an environment, both iOS workflows must declare that
-environment before they can read them. The API key needs the **App Manager** role
-to manage external TestFlight distribution and Beta App Review.
+The API key needs the **App Manager** role to manage external TestFlight
+distribution and Beta App Review. The automatic `GITHUB_TOKEN` is not a setup
+secret; jobs receive only the explicit read/write permissions in their workflow.
 
 Create these repository variables:
 
@@ -160,14 +187,23 @@ the description “Build and distribute this PR through public iOS TestFlight.�
 
 ### Activate and operate
 
-1. Merge this workflow to the default branch before labeling older branches —
-   for a branch that predates the shared signing action or TestFlight Fastlane
-   lane, the workflow falls back to the base branch for those CI helpers.
-2. Apply `ios-test-flight` to the same-repo PR to build its current head commit.
-3. Follow the Actions run and then the build under App Store Connect → TestFlight.
-4. After upload, the workflow comments with the stable public link and removes
-   the label. Remove and re-apply the label after new commits to request another
-   build.
+1. Create and protect the `ios-testflight` environment before merging the
+   workflows.
+2. Merge the workflows to `master`. Old feature branches do not need to contain
+   them: the unsigned builder restores the version helper from its exact trusted
+   base commit, and the publisher always runs from the default branch.
+3. Apply `ios-test-flight` to a same-repo PR targeting `master`.
+4. Wait for **iOS TestFlight Build on Label** to produce the unsigned archive.
+5. Open **iOS TestFlight Publish**. Its validation job recomputes the expected
+   marketing version from the greater of the trusted base package version and
+   stable tags merged into that base, then increments the patch. The build number
+   is the source workflow's `run_number.run_attempt` and is checked in both app
+   targets.
+6. Review the PR and exact SHA shown in the protected publish job name, then
+   approve the `ios-testflight` deployment.
+7. Follow the build under App Store Connect → TestFlight. After upload, the
+   publisher comments with the stable public link and removes the label. Remove
+   and re-apply the label after new commits to request another build.
 
 Testers only need an iPhone or iPad, the TestFlight app, and the public link.
 They do not need a Mac, Xcode, or an Apple Developer account.
@@ -180,6 +216,12 @@ They do not need a Mac, Xcode, or an Apple Developer account.
   TestFlight slot.
 - If export reports a missing or mismatched profile, check both App IDs, their
   App Group assignment, the profile certificate, and the two profile secrets.
+- If validation reports a stale head or base, remove/re-apply the label to build
+  the current PR state. Validation intentionally refuses to sign an archive after
+  the PR head changes.
+- Source build failures, validation failures, and normal publish failures are
+  reported on the PR and remove the label. A hard cancellation of the publisher
+  can prevent reporting; remove the label manually in that case.
 - To stop distributing a bad build, use **Expire Build** in App Store Connect.
 - To disable public PR builds, remove the `ios-test-flight` label and disable or
   remove `.github/workflows/build-ios-testflight.yml`. Installed builds are not

--- a/docs/apple-release-automation.md
+++ b/docs/apple-release-automation.md
@@ -66,7 +66,7 @@ the `TESTFLIGHT_GROUP` variable) and submits it for Beta App Review. The workflo
 posts the group's Public Link back on the PR and removes the label so re-applying
 it starts a fresh build.
 
-Guards:
+### Security boundary
 
 - **Same-repo PRs only** (`head.repo.full_name == github.repository`). The job
   handles Apple signing secrets, so a fork PR must be pushed to a branch in this
@@ -79,19 +79,111 @@ Guards:
   certificate and App Manager API key, so this workflow carries the same
   credential exposure as the release path.
 
-One-time setup (Apple's side cannot be automated):
+### One-time Apple Developer setup
 
-1. Create the `ios-test-flight` label.
-2. Merge this workflow to the default branch before labeling older branches —
-   for a branch that predates the shared signing action, the workflow falls back
-   to the base branch for that action.
-3. In App Store Connect create an External Testing group named exactly
-   `Public Testers` (or set the repository variable `TESTFLIGHT_GROUP` to match
-   a different name), enable its Public Link, and let the first build clear
-   Beta App Review. Later builds usually auto-approve.
-4. Add the group's Public Link as the repository variable
-   `TESTFLIGHT_PUBLIC_LINK` (a variable, not a secret — it is meant to be shared).
-   Without it the PR comment still reports success/failure but prints no link.
+The share extension in [PR #10033](https://github.com/super-productivity/super-productivity/pull/10033)
+has its own bundle ID and profile. In
+[Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/):
+
+1. Register the App Group `group.com.super-productivity.app`.
+2. Edit the existing App ID `com.super-productivity.app`, enable **App Groups**,
+   and assign that group.
+3. Register the explicit App ID `com.super-productivity.app.ShareExtension`,
+   enable **App Groups**, and assign the same group.
+4. Regenerate the main app's App Store distribution provisioning profile using
+   the existing Apple Distribution certificate. The regenerated profile must
+   contain the App Group entitlement.
+5. Create an App Store distribution provisioning profile for
+   `com.super-productivity.app.ShareExtension` using the same certificate.
+
+Encode each downloaded profile as a single base64 line before adding it to
+GitHub:
+
+```bash
+openssl base64 -A -in MainApp.mobileprovision
+openssl base64 -A -in ShareExtension.mobileprovision
+```
+
+The shared signing action treats the extension profile as optional for branches
+without the extension. If `ios/App/ShareExtension/Info.plist` exists, both the
+release and TestFlight workflows fail before export unless the extension profile
+is available, then map both bundle IDs into `ExportOptions.plist`.
+
+### One-time App Store Connect setup
+
+In **App Store Connect → Apps → Super Productivity → TestFlight**:
+
+1. Complete the beta test information (description, feedback email, contact
+   information, review notes, and demo credentials if sign-in is required).
+2. Create an **External Testing** group named exactly `Public Testers`. To use a
+   different name, set the `TESTFLIGHT_GROUP` repository variable to that exact
+   value.
+3. Enable the group's **Public Link** and initially use a conservative tester
+   limit (for example, 100).
+4. Copy the public join URL. The workflow submits each uploaded build for Beta
+   App Review; Apple reviews the first build and later builds usually approve
+   faster. A successful workflow means upload/distribution setup succeeded, not
+   necessarily that Apple has already approved the build for external testers.
+
+### One-time GitHub setup
+
+Under **Settings → Secrets and variables → Actions**, verify the existing iOS
+release secrets and add the extension profile:
+
+| Secret                        | Purpose                                                     |
+| ----------------------------- | ----------------------------------------------------------- |
+| `APPLE_TEAM_ID`               | Team used in `ExportOptions.plist`                          |
+| `mac_certs`                   | Base64-encoded Apple Distribution `.p12`                    |
+| `mac_certs_password`          | Password for `mac_certs`                                    |
+| `IOS_PROVISION_PROFILE`       | Regenerated main-app profile with the App Group entitlement |
+| `IOS_SHARE_PROVISION_PROFILE` | Share-extension distribution profile                        |
+| `mac_api_key`                 | Raw App Store Connect API `.p8` contents                    |
+| `mac_api_key_id`              | App Store Connect API key ID                                |
+| `mac_api_key_issuer_id`       | App Store Connect API issuer ID                             |
+| `UNSPLASH_KEY`                | Existing frontend build-time Unsplash key                   |
+| `UNSPLASH_CLIENT_ID`          | Existing frontend build-time Unsplash client ID             |
+
+These names currently refer to repository secrets, like `build-ios.yml`. If the
+Apple credentials move to an environment, both iOS workflows must declare that
+environment before they can read them. The API key needs the **App Manager** role
+to manage external TestFlight distribution and Beta App Review.
+
+Create these repository variables:
+
+| Variable                 | Required | Value                                             |
+| ------------------------ | -------- | ------------------------------------------------- |
+| `TESTFLIGHT_PUBLIC_LINK` | Yes      | `https://testflight.apple.com/join/...`           |
+| `TESTFLIGHT_GROUP`       | No       | External group name; defaults to `Public Testers` |
+
+Finally, create the exact repository label `ios-test-flight`, for example with
+the description “Build and distribute this PR through public iOS TestFlight.”
+
+### Activate and operate
+
+1. Merge this workflow to the default branch before labeling older branches —
+   for a branch that predates the shared signing action or TestFlight Fastlane
+   lane, the workflow falls back to the base branch for those CI helpers.
+2. Apply `ios-test-flight` to the same-repo PR to build its current head commit.
+3. Follow the Actions run and then the build under App Store Connect → TestFlight.
+4. After upload, the workflow comments with the stable public link and removes
+   the label. Remove and re-apply the label after new commits to request another
+   build.
+
+Testers only need an iPhone or iPad, the TestFlight app, and the public link.
+They do not need a Mac, Xcode, or an Apple Developer account.
+
+### Failure and rollback
+
+- If fastlane times out after upload, inspect App Store Connect before retrying;
+  Apple may still be processing or reviewing the build. A re-applied label uses
+  a new build number, but an unnecessary upload creates noise and consumes a
+  TestFlight slot.
+- If export reports a missing or mismatched profile, check both App IDs, their
+  App Group assignment, the profile certificate, and the two profile secrets.
+- To stop distributing a bad build, use **Expire Build** in App Store Connect.
+- To disable public PR builds, remove the `ios-test-flight` label and disable or
+  remove `.github/workflows/build-ios-testflight.yml`. Installed builds are not
+  remotely removed; expiring a build prevents new installs.
 
 The internal-`master` beta path proposed in
 [`docs/plans/2026-07-14-ios-testflight-master-builds.md`](plans/2026-07-14-ios-testflight-master-builds.md)

--- a/docs/release-and-publishing.md
+++ b/docs/release-and-publishing.md
@@ -75,8 +75,9 @@ Apple's detailed submission behavior, API-key requirements, and recovery cases
 are in [Apple release automation](apple-release-automation.md).
 
 Feature-branch builds for outside testers are separate from releases: applying
-the `ios-test-flight` label to a same-repo PR uploads it to the public TestFlight
-group (`build-ios-testflight.yml`). See
+the `ios-test-flight` label to a same-repo PR creates an unsigned archive; a
+protected publisher then signs and uploads it to the public TestFlight group
+(`build-ios-testflight.yml` → `publish-ios-testflight.yml`). See
 [Apple release automation](apple-release-automation.md#public-testflight-builds-label-triggered).
 
 The desktop workflow's draft/prerelease flag detection does not use exactly the

--- a/docs/release-and-publishing.md
+++ b/docs/release-and-publishing.md
@@ -74,6 +74,11 @@ git push --atomic origin HEAD "vX.Y.Z"
 Apple's detailed submission behavior, API-key requirements, and recovery cases
 are in [Apple release automation](apple-release-automation.md).
 
+Feature-branch builds for outside testers are separate from releases: applying
+the `ios-test-flight` label to a same-repo PR uploads it to the public TestFlight
+group (`build-ios-testflight.yml`). See
+[Apple release automation](apple-release-automation.md#public-testflight-builds-label-triggered).
+
 The desktop workflow's draft/prerelease flag detection does not use exactly the
 same rule as the Apple workflows. Before publishing a pre-release, explicitly
 confirm that GitHub marks the draft as a pre-release.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -166,11 +166,11 @@ platform :ios do
   end
 
   desc 'Upload the prebuilt iOS .ipa to TestFlight for public testers'
-  # Used by .github/workflows/build-ios-testflight.yml when a maintainer applies
-  # the `ios-test-flight` label. Unlike `release`, this never submits the app for
-  # App Store review; it distributes to the external TestFlight group whose
-  # Public Link is shared on the PR. (External builds do go through Beta App
-  # Review, which `submit_beta_review` handles.)
+  # Used by the protected publish-ios-testflight.yml workflow after a maintainer
+  # applies the `ios-test-flight` label. Unlike `release`, this never submits the
+  # app for App Store review; it distributes to the external TestFlight group
+  # whose Public Link is shared on the PR. (External builds do go through Beta
+  # App Review, which `submit_beta_review` handles.)
   #
   # One-time Apple-side setup: an External Testing group (name from
   # TESTFLIGHT_GROUP, default "Public Testers") with a Public Link. The first
@@ -185,8 +185,21 @@ platform :ios do
     # always sets TESTFLIGHT_GROUP (from an optional repo variable), so an
     # unset variable arrives here as "" rather than a missing key.
     group = ENV['TESTFLIGHT_GROUP'].to_s.empty? ? 'Public Testers' : ENV['TESTFLIGHT_GROUP']
+    api_key = asc_api_key
+    app = Spaceship::ConnectAPI::App.find(APP_IDENTIFIER)
+    UI.user_error!("App Store Connect app not found: #{APP_IDENTIFIER}") unless app
+
+    matching_groups = app.get_beta_groups.select { |candidate| candidate.name == group }
+    unless matching_groups.one?
+      UI.user_error!("Expected exactly one TestFlight group named '#{group}', found #{matching_groups.length}")
+    end
+    beta_group = matching_groups.first
+    if beta_group.is_internal_group || !beta_group.public_link_enabled
+      UI.user_error!("TestFlight group '#{group}' must be external with its Public Link enabled")
+    end
+
     upload_to_testflight(
-      api_key: asc_api_key,
+      api_key: api_key,
       app_identifier: APP_IDENTIFIER,
       ipa: ENV.fetch('IPA_PATH'),
       groups: [group],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -164,6 +164,38 @@ platform :ios do
   lane :release do
     submit_to_app_store(platform: 'ios', ipa: ENV.fetch('IPA_PATH'))
   end
+
+  desc 'Upload the prebuilt iOS .ipa to TestFlight for public testers'
+  # Used by .github/workflows/build-ios-testflight.yml when a maintainer applies
+  # the `ios-test-flight` label. Unlike `release`, this never submits the app for
+  # App Store review; it distributes to the external TestFlight group whose
+  # Public Link is shared on the PR. (External builds do go through Beta App
+  # Review, which `submit_beta_review` handles.)
+  #
+  # One-time Apple-side setup: an External Testing group (name from
+  # TESTFLIGHT_GROUP, default "Public Testers") with a Public Link. The first
+  # build is reviewed by Apple; later builds usually auto-approve.
+  #
+  # TESTFLIGHT_GROUP and CHANGELOG are optional. Note this lane shares the
+  # ASC_* credentials with `release`; the App Manager role is required (see
+  # header). See docs/plans/2026-07-14-ios-testflight-master-builds.md for the
+  # separate internal-master beta path.
+  lane :testflight do
+    upload_to_testflight(
+      api_key: asc_api_key,
+      app_identifier: APP_IDENTIFIER,
+      ipa: ENV.fetch('IPA_PATH'),
+      groups: [ENV.fetch('TESTFLIGHT_GROUP', 'Public Testers')],
+      distribute_external: true,
+      submit_beta_review: true,
+      changelog: ENV.fetch('CHANGELOG', 'Test build'),
+      # Wait for Apple's processing so the build actually reaches the external
+      # group. (`skip_waiting_for_build_processing: true` can exit before the
+      # external distribution step runs, leaving testers without the build.)
+      skip_waiting_for_build_processing: false,
+      wait_processing_timeout_duration: 1800,
+    )
+  end
 end
 
 platform :mac do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -181,11 +181,15 @@ platform :ios do
   # header). See docs/plans/2026-07-14-ios-testflight-master-builds.md for the
   # separate internal-master beta path.
   lane :testflight do
+    # ENV.fetch's default only applies when the key is absent; the workflow
+    # always sets TESTFLIGHT_GROUP (from an optional repo variable), so an
+    # unset variable arrives here as "" rather than a missing key.
+    group = ENV['TESTFLIGHT_GROUP'].to_s.empty? ? 'Public Testers' : ENV['TESTFLIGHT_GROUP']
     upload_to_testflight(
       api_key: asc_api_key,
       app_identifier: APP_IDENTIFIER,
       ipa: ENV.fetch('IPA_PATH'),
-      groups: [ENV.fetch('TESTFLIGHT_GROUP', 'Public Testers')],
+      groups: [group],
       distribute_external: true,
       submit_beta_review: true,
       changelog: ENV.fetch('CHANGELOG', 'Test build'),

--- a/tools/ios-testflight-version.js
+++ b/tools/ios-testflight-version.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const fs = require('node:fs');
+const { execFileSync } = require('node:child_process');
+
+const parsePackageVersion = (value) => {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(value);
+  if (!match) {
+    throw new Error(`Invalid package version: ${value}`);
+  }
+  return match.slice(1).map(Number);
+};
+
+const parseStableTag = (tag) => {
+  const match = /^v(\d+)\.(\d+)\.(\d+)$/.exec(tag);
+  return match ? match.slice(1).map(Number) : null;
+};
+
+const compareVersions = (a, b) => {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) {
+      return a[i] - b[i];
+    }
+  }
+  return 0;
+};
+
+const computeNextTestflightVersion = (packageVersion, tags) => {
+  let latest = parsePackageVersion(packageVersion);
+  for (const tag of tags) {
+    const parsed = parseStableTag(tag);
+    if (parsed && compareVersions(parsed, latest) > 0) {
+      latest = parsed;
+    }
+  }
+
+  const nextPatch = latest[2] + 1;
+  if (!Number.isSafeInteger(nextPatch)) {
+    throw new Error('TestFlight patch version exceeds the safe integer range');
+  }
+  return `${latest[0]}.${latest[1]}.${nextPatch}`;
+};
+
+const main = () => {
+  const packagePath = process.argv[2] || 'package.json';
+  const mergedRef = process.argv[3];
+  const packageVersion = JSON.parse(fs.readFileSync(packagePath, 'utf8')).version;
+  const tagArgs = ['tag'];
+  if (mergedRef) {
+    tagArgs.push('--merged', mergedRef);
+  }
+  tagArgs.push('--list', 'v*');
+  const tags = execFileSync('git', tagArgs, { encoding: 'utf8' })
+    .split('\n')
+    .filter(Boolean);
+  process.stdout.write(`${computeNextTestflightVersion(packageVersion, tags)}\n`);
+};
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { computeNextTestflightVersion };

--- a/tools/ios-testflight-version.test.js
+++ b/tools/ios-testflight-version.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { computeNextTestflightVersion } = require('./ios-testflight-version');
+
+test('increments the trusted package patch when it is newest', () => {
+  assert.equal(
+    computeNextTestflightVersion('18.22.0', ['v18.21.2', 'v18.22.0']),
+    '18.22.1',
+  );
+});
+
+test('increments the highest stable tag when it is newer than the package', () => {
+  assert.equal(
+    computeNextTestflightVersion('18.21.2', ['v18.22.0', 'v18.21.3']),
+    '18.22.1',
+  );
+});
+
+test('strips package prerelease suffix and compares numeric components', () => {
+  assert.equal(
+    computeNextTestflightVersion('18.9.0-RC.1', ['v18.10.0', 'v18.11.0-beta.1']),
+    '18.10.1',
+  );
+});
+
+test('ignores non-stable and malformed tags', () => {
+  assert.equal(
+    computeNextTestflightVersion('18.22.0', ['v18.22.1-rc.0', 'not-a-version']),
+    '18.22.1',
+  );
+});
+
+test('rejects a malformed package version', () => {
+  assert.throws(() => computeNextTestflightVersion('18.22', ['v18.22.0']), /package/);
+});


### PR DESCRIPTION
## Summary

- add `ios-test-flight` label-triggered public TestFlight builds for same-repo PRs targeting `master`
- isolate PR-controlled code in an unsigned build workflow with no Apple credentials
- add a trusted default-branch `workflow_run` publisher that validates and repacks the archive before signing
- require approval through a protected `ios-testflight` GitHub environment, tied to the PR number and exact head SHA shown in the publish job name
- support both `com.super-productivity.app` and the optional `com.super-productivity.app.ShareExtension` profile required by #10033
- compute a future TestFlight marketing version from trusted `master` metadata and stable tags and verify app + extension versions before signing
- fail closed unless exactly one matching external TestFlight group exists and its Public Link is enabled
- document the complete Apple Developer, App Store Connect, GitHub, activation, approval, retry, and rollback setup in `docs/apple-release-automation.md`

## Trust boundary

`build-ios-testflight.yml` executes PR npm scripts, CocoaPods, Xcode project files, and build phases, but receives no Apple secrets and outputs only an unsigned archive.

`publish-ios-testflight.yml` is loaded from `master` via `workflow_run`. A credential-free validation job verifies the source workflow path, associated open PR, same-repo/current head SHA, trusted base SHA, request metadata, archive paths/symlinks, bundle IDs, marketing version, and build number. It then repacks the archive.

The signing/upload job cannot start until a trusted reviewer approves the protected `ios-testflight` environment. An environment-only `IOS_TESTFLIGHT_ENV_READY=configured` marker makes an accidentally auto-created, unprotected environment fail before checkout or signing.

## Required setup before first use

The complete runbook is in `docs/apple-release-automation.md#public-testflight-builds-label-triggered`. In short:

1. Create and protect the `ios-testflight` environment before merging: required release-maintainer reviewers, `master` deployment restriction, and environment-only `IOS_TESTFLIGHT_ENV_READY=configured`.
2. Register `group.com.super-productivity.app`, enable it for the main app and `com.super-productivity.app.ShareExtension`, regenerate the main profile, and create the extension profile.
3. Add/update `IOS_PROVISION_PROFILE` and `IOS_SHARE_PROVISION_PROFILE` plus the existing Apple signing/API secrets.
4. Create an external group named `Public Testers` (or set `TESTFLIGHT_GROUP`), enable its Public Link, and set `TESTFLIGHT_PUBLIC_LINK`.
5. Create the exact `ios-test-flight` repository label.
6. After this PR merges, apply the label to #10033; approve the publish deployment only after checking the displayed PR/SHA.

## Validation

- `node --test tools/ios-testflight-version.test.js`
- `npx prettier --check` for all changed YAML, Markdown, and JS files
- YAML parse of all changed workflows/actions
- `ruby -c fastlane/Fastfile`
- repository documentation link checker
- `git diff --check`

A live archive/export/upload remains intentionally untested until the protected environment, Apple identifiers/profiles, external group, secrets, and variables from the runbook are configured.

Related: https://github.com/super-productivity/super-productivity/discussions/9948#discussioncomment-18402484