### PR TITLE
fix: resolve findings from the 2026-09-11 change review

### DIFF
--- a/.github/workflows/build-publish-to-snap-on-release.yml
+++ b/.github/workflows/build-publish-to-snap-on-release.yml
@@ -42,6 +42,12 @@ jobs:
 
           mv .tmp/snap-release/*.snap .tmp/snap-release/sp.snap
 
+      # Pulled in its own step so the image download (~10s, occasionally much
+      # worse) is not charged against the upload step's store-review budget.
+      - name: Pull snapcraft image
+        timeout-minutes: 10
+        run: docker pull ghcr.io/canonical/snapcraft:8_core24
+
       # Run snapcraft from Canonical's official container so we don't depend on
       # `sudo snap install snapcraft --classic` working on the runner.
       # `--entrypoint /bin/snapcraft` skips the image's pebble wrapper and its

--- a/src/app/core-ui/work-context-menu/work-context-menu.component.spec.ts
+++ b/src/app/core-ui/work-context-menu/work-context-menu.component.spec.ts
@@ -14,6 +14,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { WorkContextType } from '../../features/work-context/work-context.model';
 import { DialogCompleteResolveTasksComponent } from '../../features/project/dialog-complete-resolve-tasks/dialog-complete-resolve-tasks.component';
 import { DialogConfirmComponent } from '../../ui/dialog-confirm/dialog-confirm.component';
+import { DialogPromptComponent } from '../../ui/dialog-prompt/dialog-prompt.component';
 import { DateService } from '../../core/date/date.service';
 import { DialogProjectCompleteComponent } from '../../features/project/dialog-project-complete/dialog-project-complete.component';
 import { PlainspaceShareService } from '../../features/issue/providers/plainspace/plainspace-share.service';
@@ -22,11 +23,13 @@ describe('WorkContextMenuComponent', () => {
   let component: WorkContextMenuComponent;
   let fixture: ComponentFixture<WorkContextMenuComponent>;
   let mockProjectService: jasmine.SpyObj<ProjectService>;
+  let mockTagService: jasmine.SpyObj<TagService>;
   let mockWorkContextService: { activeWorkContextId: string | undefined };
   let mockMatDialog: jasmine.SpyObj<MatDialog>;
   let mockPlainspaceShareService: jasmine.SpyObj<PlainspaceShareService>;
   let resolveResult$: any;
   let confirmResult$: any;
+  let promptResult$: any;
   let isSharedOnPlainspace$: any;
   let router: Router;
   const logicalDoneOn = new Date(2026, 5, 5, 1, 0, 0).getTime();
@@ -49,6 +52,7 @@ describe('WorkContextMenuComponent', () => {
       'markTasksDone',
       'getByIdOnce$',
       'getByIdLive$',
+      'update',
     ]);
     mockProjectService.getByIdOnce$.and.returnValue(
       of({ id: 'project-123', title: 'Demo project' } as any),
@@ -68,6 +72,10 @@ describe('WorkContextMenuComponent', () => {
       of({ id: 'project-123', title: 'Demo project' } as any),
     );
     mockWorkContextService = { activeWorkContextId: undefined };
+    mockTagService = jasmine.createSpyObj('TagService', ['getTagById$', 'updateTag']);
+    mockTagService.getTagById$.and.returnValue(
+      of({ id: 'tag-1', title: 'Demo tag' } as any),
+    );
 
     const mockShareService = jasmine.createSpyObj('ShareService', ['getShareSupport']);
     mockShareService.getShareSupport.and.returnValue(Promise.resolve('none'));
@@ -87,7 +95,11 @@ describe('WorkContextMenuComponent', () => {
     mockMatDialog = jasmine.createSpyObj('MatDialog', ['open']);
     resolveResult$ = of(undefined);
     confirmResult$ = of(true);
+    promptResult$ = of(undefined);
     mockMatDialog.open.and.callFake((componentOrTemplateRef) => {
+      if (componentOrTemplateRef === DialogPromptComponent) {
+        return { afterClosed: () => promptResult$ } as MatDialogRef<unknown>;
+      }
       if (componentOrTemplateRef === DialogCompleteResolveTasksComponent) {
         return { afterClosed: () => resolveResult$ } as MatDialogRef<unknown>;
       }
@@ -105,10 +117,7 @@ describe('WorkContextMenuComponent', () => {
         { provide: WorkContextService, useValue: mockWorkContextService },
         { provide: SnackService, useValue: { open: () => {} } },
         { provide: MatDialog, useValue: mockMatDialog },
-        {
-          provide: TagService,
-          useValue: jasmine.createSpyObj('TagService', ['getTagById$']),
-        },
+        { provide: TagService, useValue: mockTagService },
         { provide: WorkContextMarkdownService, useValue: {} },
         { provide: ShareService, useValue: mockShareService },
         { provide: Store, useValue: mockStore },
@@ -308,6 +317,69 @@ describe('WorkContextMenuComponent', () => {
       confirmResult$ = of(false);
       await component.completeProject();
       expect(mockProjectService.complete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rename()', () => {
+    it('updates the project title once when a different title is entered', async () => {
+      promptResult$ = of('  New project  ');
+      await component.rename();
+      expect(mockProjectService.update).toHaveBeenCalledOnceWith('project-123', {
+        title: 'New project',
+      });
+    });
+
+    it('does not update the project when the title is unchanged', async () => {
+      promptResult$ = of('Demo project');
+      await component.rename();
+      expect(mockProjectService.update).not.toHaveBeenCalled();
+    });
+
+    it('does not update the project when the prompt is empty or cancelled', async () => {
+      promptResult$ = of('   ');
+      await component.rename();
+      promptResult$ = of(undefined);
+      await component.rename();
+      expect(mockProjectService.update).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the project cannot be found', async () => {
+      mockProjectService.getByIdOnce$.and.returnValue(of(undefined as any));
+      promptResult$ = of('New project');
+      await component.rename();
+      expect(mockMatDialog.open).not.toHaveBeenCalled();
+      expect(mockProjectService.update).not.toHaveBeenCalled();
+    });
+
+    it('updates the tag title once when a different title is entered', async () => {
+      component.contextId = 'tag-1';
+      component.contextTypeSet = WorkContextType.TAG;
+      promptResult$ = of('New tag');
+      await component.rename();
+      expect(mockTagService.updateTag).toHaveBeenCalledOnceWith('tag-1', {
+        title: 'New tag',
+      });
+      expect(mockProjectService.update).not.toHaveBeenCalled();
+    });
+
+    it('does not update the tag when the title is unchanged or the prompt is cancelled', async () => {
+      component.contextId = 'tag-1';
+      component.contextTypeSet = WorkContextType.TAG;
+      promptResult$ = of('Demo tag');
+      await component.rename();
+      promptResult$ = of(undefined);
+      await component.rename();
+      expect(mockTagService.updateTag).not.toHaveBeenCalled();
+    });
+
+    it('does nothing and does not throw when the tag cannot be found', async () => {
+      component.contextId = 'missing-tag';
+      component.contextTypeSet = WorkContextType.TAG;
+      mockTagService.getTagById$.and.returnValue(of(undefined as any));
+      promptResult$ = of('New tag');
+      await expectAsync(component.rename()).toBeResolved();
+      expect(mockMatDialog.open).not.toHaveBeenCalled();
+      expect(mockTagService.updateTag).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/core-ui/work-context-menu/work-context-menu.component.ts
+++ b/src/app/core-ui/work-context-menu/work-context-menu.component.ts
@@ -160,20 +160,23 @@ export class WorkContextMenuComponent implements OnInit {
 
   async rename(): Promise<void> {
     if (this.isForProject) {
-      const project = await this._projectService.getByIdOnce$(this.contextId).toPromise();
+      const project = await firstValueFrom(
+        this._projectService.getByIdOnce$(this.contextId),
+      );
       if (!project) {
         return;
       }
-      const result = await this._matDialog
-        .open(DialogPromptComponent, {
-          restoreFocus: true,
-          data: {
-            txtValue: project.title,
-            placeholder: T.F.PROJECT.D_RENAME.PLACEHOLDER,
-          },
-        })
-        .afterClosed()
-        .toPromise();
+      const result = await firstValueFrom(
+        this._matDialog
+          .open(DialogPromptComponent, {
+            restoreFocus: true,
+            data: {
+              txtValue: project.title,
+              placeholder: T.F.PROJECT.D_RENAME.PLACEHOLDER,
+            },
+          })
+          .afterClosed(),
+      );
 
       const trimmed = (result as string | undefined)?.trim();
       if (!trimmed || trimmed === project.title) {
@@ -183,20 +186,21 @@ export class WorkContextMenuComponent implements OnInit {
       return;
     }
 
-    const tag = await this._tagService
-      .getTagById$(this.contextId)
-      .pipe(first())
-      .toPromise();
-    const result = await this._matDialog
-      .open(DialogPromptComponent, {
-        restoreFocus: true,
-        data: {
-          txtValue: tag.title,
-          placeholder: T.F.TAG.D_RENAME.PLACEHOLDER,
-        },
-      })
-      .afterClosed()
-      .toPromise();
+    const tag = await firstValueFrom(this._tagService.getTagById$(this.contextId));
+    if (!tag) {
+      return;
+    }
+    const result = await firstValueFrom(
+      this._matDialog
+        .open(DialogPromptComponent, {
+          restoreFocus: true,
+          data: {
+            txtValue: tag.title,
+            placeholder: T.F.TAG.D_RENAME.PLACEHOLDER,
+          },
+        })
+        .afterClosed(),
+    );
 
     const trimmed = (result as string | undefined)?.trim();
     if (!trimmed || trimmed === tag.title) {

--- a/src/app/features/focus-mode/store/focus-mode.effects.spec.ts
+++ b/src/app/features/focus-mode/store/focus-mode.effects.spec.ts
@@ -1,6 +1,6 @@
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
-import { BehaviorSubject, Observable, of, Subscription } from 'rxjs';
+import { BehaviorSubject, Observable, of, Subject, Subscription } from 'rxjs';
 import { FocusModeEffects } from './focus-mode.effects';
 import { provideMockStore, MockStore } from '@ngrx/store/testing';
 import { FocusModeStrategyFactory } from '../focus-mode-strategies';
@@ -30,6 +30,8 @@ import { updateGlobalConfigSection } from '../../config/store/global-config.acti
 import { take, toArray } from 'rxjs/operators';
 import { HydrationStateService } from '../../../op-log/apply/hydration-state.service';
 import { DEFAULT_TASK } from '../../tasks/task.model';
+import { IS_ELECTRON_TOKEN } from '../../../app.constants';
+import { Action } from '@ngrx/store';
 
 describe('FocusModeEffects', () => {
   let actions$: Observable<any>;
@@ -154,6 +156,7 @@ describe('FocusModeEffects', () => {
         { provide: TakeABreakService, useValue: takeABreakServiceMock },
         { provide: NotifyService, useValue: notifyServiceMock },
         { provide: IS_ANDROID_WEB_VIEW_TOKEN, useValue: false },
+        { provide: IS_ELECTRON_TOKEN, useValue: true },
         {
           provide: GlobalTrackingIntervalService,
           useValue: {
@@ -3029,5 +3032,104 @@ describe('FocusModeEffects', () => {
         });
       });
     });
+  });
+  // The OS progress bar (taskbar/dock) has exactly one writer at a time: a
+  // *timed* session owns it and task-electron.effects stands down. When the
+  // session releases it (cancel/pause), nothing else clears the bar - the task
+  // writer only wakes on setCurrentTask, and focus mode dispatches
+  // unsetCurrentTask - so this effect must clear it on the handoff itself.
+  describe('setTaskBarProgress$', () => {
+    let actionsSubject: Subject<Action>;
+    let setProgressBarSpy: jasmine.Spy;
+    const NO_PROGRESS = { progress: -1, progressBarMode: 'none' };
+    const runningCountdown = createMockTimer({
+      isRunning: true,
+      purpose: 'work',
+      duration: 25 * 60 * 1000,
+      elapsed: 5 * 60 * 1000,
+    });
+    const runningFlowtime = createMockTimer({
+      isRunning: true,
+      purpose: 'work',
+      duration: 0,
+      elapsed: 5 * 60 * 1000,
+    });
+
+    const setTimer = (timer: TimerState): void => {
+      store.overrideSelector(selectors.selectTimer, timer);
+      store.refreshState();
+    };
+
+    // The writer throttles to 500ms; step past it so every action reaches it.
+    const dispatch = (action: Action): void => {
+      actionsSubject.next(action);
+      tick(600);
+    };
+
+    beforeEach(() => {
+      actionsSubject = new Subject<Action>();
+      actions$ = actionsSubject;
+      setProgressBarSpy = jasmine.createSpy('setProgressBar');
+      (window as any).ea = { setProgressBar: setProgressBarSpy };
+    });
+
+    afterEach(() => {
+      delete (window as any).ea;
+    });
+
+    it('should publish normal progress while a countdown session runs', fakeAsync(() => {
+      setTimer(runningCountdown);
+      const sub = effects.setTaskBarProgress$.subscribe();
+
+      dispatch(actions.tick());
+      sub.unsubscribe();
+
+      expect(setProgressBarSpy).toHaveBeenCalledOnceWith({
+        progress: 0.2,
+        progressBarMode: 'normal',
+      });
+    }));
+
+    it('should clear the bar exactly once when a countdown session is cancelled', fakeAsync(() => {
+      setTimer(runningCountdown);
+      const sub = effects.setTaskBarProgress$.subscribe();
+      dispatch(actions.tick());
+      setProgressBarSpy.calls.reset();
+
+      setTimer(createMockTimer({ isRunning: false, purpose: null }));
+      dispatch(actions.cancelFocusSession());
+      // Anything after the release (e.g. a stray tick) must not re-clear.
+      dispatch(actions.tick());
+      sub.unsubscribe();
+
+      expect(setProgressBarSpy).toHaveBeenCalledOnceWith(NO_PROGRESS);
+    }));
+
+    it('should clear the bar when a countdown session is paused', fakeAsync(() => {
+      setTimer(runningCountdown);
+      const sub = effects.setTaskBarProgress$.subscribe();
+      dispatch(actions.tick());
+      setProgressBarSpy.calls.reset();
+
+      setTimer({ ...runningCountdown, isRunning: false });
+      dispatch(actions.pauseFocusSession({}));
+      sub.unsubscribe();
+
+      expect(setProgressBarSpy).toHaveBeenCalledOnceWith(NO_PROGRESS);
+    }));
+
+    // Flowtime owns nothing, so the task writer publishes instead; clearing on
+    // every tick would fight it and make the bar flicker.
+    it('should never write while a Flowtime session ticks', fakeAsync(() => {
+      setTimer(runningFlowtime);
+      const sub = effects.setTaskBarProgress$.subscribe();
+
+      dispatch(actions.tick());
+      dispatch(actions.tick());
+      dispatch(actions.tick());
+      sub.unsubscribe();
+
+      expect(setProgressBarSpy).not.toHaveBeenCalled();
+    }));
   });
 });

--- a/src/app/features/focus-mode/store/focus-mode.effects.ts
+++ b/src/app/features/focus-mode/store/focus-mode.effects.ts
@@ -9,6 +9,7 @@ import {
   filter,
   map,
   pairwise,
+  startWith,
   switchMap,
   take,
   tap,
@@ -24,7 +25,7 @@ import { playSound } from '../../../util/play-sound';
 import { startWhiteNoise, stopWhiteNoise } from '../../../util/white-noise';
 import { startBreakEndAlarm, stopBreakEndAlarm } from '../../../util/break-end-alarm';
 import { FocusModeLocalSettingsService } from '../../config/focus-mode-local-settings.service';
-import { IS_ELECTRON } from '../../../app.constants';
+import { IS_ELECTRON, IS_ELECTRON_TOKEN } from '../../../app.constants';
 import { setCurrentTask, unsetCurrentTask } from '../../tasks/store/task.actions';
 import { selectLastCurrentTask, selectTaskById } from '../../tasks/store/task.selectors';
 import { openIdleDialog } from '../../idle/store/idle.actions';
@@ -55,6 +56,7 @@ const FOCUS_SOUND_VOLUME_FACTOR = 0.4;
 export class FocusModeEffects {
   private actions$ = inject(LOCAL_ACTIONS);
   private store = inject(Store);
+  private _isElectron = inject(IS_ELECTRON_TOKEN);
   private strategyFactory = inject(FocusModeStrategyFactory);
   private globalConfigService = inject(GlobalConfigService);
   private taskService = inject(TaskService);
@@ -854,37 +856,45 @@ export class FocusModeEffects {
   // Action-based effect to update Windows taskbar progress (fixes #6061)
   // Throttled to prevent excessive IPC calls (timer ticks every 1s)
   // Follows action-based pattern (CLAUDE.md Section 8) instead of selector-based
-  setTaskBarProgress$ =
-    IS_ELECTRON &&
-    createEffect(
-      () =>
-        this.actions$.pipe(
-          ofType(
-            actions.tick,
-            actions.startFocusSession,
-            actions.pauseFocusSession,
-            actions.unPauseFocusSession,
-            actions.startBreak,
-            actions.skipBreak,
-            actions.completeBreak,
-            actions.completeFocusSession,
-            actions.cancelFocusSession,
-            actions.selectFocusTask,
+  setTaskBarProgress$ = createEffect(
+    () =>
+      !this._isElectron
+        ? EMPTY
+        : this.actions$.pipe(
+            ofType(
+              actions.tick,
+              actions.startFocusSession,
+              actions.pauseFocusSession,
+              actions.unPauseFocusSession,
+              actions.startBreak,
+              actions.skipBreak,
+              actions.completeBreak,
+              actions.completeFocusSession,
+              actions.cancelFocusSession,
+              actions.selectFocusTask,
+            ),
+            // Throttle to prevent excessive IPC calls (timer ticks every 1s)
+            // Use leading + trailing to ensure immediate feedback and final state
+            throttleTime(500, undefined, { leading: true, trailing: true }),
+            withLatestFrom(this.store.select(selectors.selectOsProgressBar)),
+            map(([_action, osProgressBar]) => osProgressBar),
+            // null = the session owns nothing (open-ended Flowtime, or a timed
+            // session that was paused/cancelled) and task-electron.effects
+            // publishes the task's own progress instead. Clear the bar exactly
+            // once on the owned -> null handoff, else it stays frozen at the last
+            // session value; nothing else clears it since focus mode dispatches
+            // unsetCurrentTask, not the setCurrentTask that setTaskBarNoProgress$
+            // listens for. Consecutive nulls (Flowtime ticks) send nothing so we
+            // don't fight the task writer every 500ms.
+            startWith(null),
+            pairwise(),
+            filter(([prev, curr]) => curr !== null || prev !== null),
+            tap(([_prev, curr]) => {
+              window.ea.setProgressBar(curr ?? { progress: -1, progressBarMode: 'none' });
+            }),
           ),
-          // Throttle to prevent excessive IPC calls (timer ticks every 1s)
-          // Use leading + trailing to ensure immediate feedback and final state
-          throttleTime(500, undefined, { leading: true, trailing: true }),
-          withLatestFrom(this.store.select(selectors.selectOsProgressBar)),
-          tap(([_action, osProgressBar]) => {
-            // null = an open-ended (Flowtime) session, which owns nothing:
-            // task-electron.effects publishes the task's own progress instead.
-            if (osProgressBar) {
-              window.ea.setProgressBar(osProgressBar);
-            }
-          }),
-        ),
-      { dispatch: false },
-    );
+    { dispatch: false },
+  );
 
   focusWindowOnBreakStart$ =
     IS_ELECTRON &&

--- a/src/app/features/focus-mode/store/focus-mode.effects.ts
+++ b/src/app/features/focus-mode/store/focus-mode.effects.ts
@@ -858,41 +858,42 @@ export class FocusModeEffects {
   // Follows action-based pattern (CLAUDE.md Section 8) instead of selector-based
   setTaskBarProgress$ = createEffect(
     () =>
-      !this._isElectron
-        ? EMPTY
-        : this.actions$.pipe(
-            ofType(
-              actions.tick,
-              actions.startFocusSession,
-              actions.pauseFocusSession,
-              actions.unPauseFocusSession,
-              actions.startBreak,
-              actions.skipBreak,
-              actions.completeBreak,
-              actions.completeFocusSession,
-              actions.cancelFocusSession,
-              actions.selectFocusTask,
-            ),
-            // Throttle to prevent excessive IPC calls (timer ticks every 1s)
-            // Use leading + trailing to ensure immediate feedback and final state
-            throttleTime(500, undefined, { leading: true, trailing: true }),
-            withLatestFrom(this.store.select(selectors.selectOsProgressBar)),
-            map(([_action, osProgressBar]) => osProgressBar),
-            // null = the session owns nothing (open-ended Flowtime, or a timed
-            // session that was paused/cancelled) and task-electron.effects
-            // publishes the task's own progress instead. Clear the bar exactly
-            // once on the owned -> null handoff, else it stays frozen at the last
-            // session value; nothing else clears it since focus mode dispatches
-            // unsetCurrentTask, not the setCurrentTask that setTaskBarNoProgress$
-            // listens for. Consecutive nulls (Flowtime ticks) send nothing so we
-            // don't fight the task writer every 500ms.
-            startWith(null),
-            pairwise(),
-            filter(([prev, curr]) => curr !== null || prev !== null),
-            tap(([_prev, curr]) => {
-              window.ea.setProgressBar(curr ?? { progress: -1, progressBarMode: 'none' });
-            }),
-          ),
+      // Gated inside the pipe, not by returning a shared EMPTY: createEffect
+      // tags the returned observable, and a singleton cannot be tagged twice.
+      this.actions$.pipe(
+        filter(() => this._isElectron),
+        ofType(
+          actions.tick,
+          actions.startFocusSession,
+          actions.pauseFocusSession,
+          actions.unPauseFocusSession,
+          actions.startBreak,
+          actions.skipBreak,
+          actions.completeBreak,
+          actions.completeFocusSession,
+          actions.cancelFocusSession,
+          actions.selectFocusTask,
+        ),
+        // Throttle to prevent excessive IPC calls (timer ticks every 1s)
+        // Use leading + trailing to ensure immediate feedback and final state
+        throttleTime(500, undefined, { leading: true, trailing: true }),
+        withLatestFrom(this.store.select(selectors.selectOsProgressBar)),
+        map(([_action, osProgressBar]) => osProgressBar),
+        // null = the session owns nothing (open-ended Flowtime, or a timed
+        // session that was paused/cancelled) and task-electron.effects
+        // publishes the task's own progress instead. Clear the bar exactly
+        // once on the owned -> null handoff, else it stays frozen at the last
+        // session value; nothing else clears it since focus mode dispatches
+        // unsetCurrentTask, not the setCurrentTask that setTaskBarNoProgress$
+        // listens for. Consecutive nulls (Flowtime ticks) send nothing so we
+        // don't fight the task writer every 500ms.
+        startWith(null),
+        pairwise(),
+        filter(([prev, curr]) => curr !== null || prev !== null),
+        tap(([_prev, curr]) => {
+          window.ea.setProgressBar(curr ?? { progress: -1, progressBarMode: 'none' });
+        }),
+      ),
     { dispatch: false },
   );
 

--- a/src/app/features/issue/issue.service.spec.ts
+++ b/src/app/features/issue/issue.service.spec.ts
@@ -29,6 +29,15 @@ import { PluginIssueProviderRegistryService } from '../../plugins/issue-provider
 import { GlobalConfigService } from '../config/global-config.service';
 import { IssueProvider } from './issue.model';
 import { TaskReminderOptionId } from '../tasks/task.model';
+import { Action } from '@ngrx/store';
+import { TaskSharedActions } from '../../root-store/meta/task-shared.actions';
+import { RootState } from '../../root-store/root-state';
+import { TASK_FEATURE_NAME } from '../tasks/store/task.reducer';
+import { createCombinedTaskSharedMetaReducer } from '../../root-store/meta/task-shared-meta-reducers/test-helpers';
+import {
+  createBaseState,
+  createMockTask as createReducerTask,
+} from '../../root-store/meta/task-shared-meta-reducers/test-utils';
 
 describe('IssueService', () => {
   let service: IssueService;
@@ -862,7 +871,7 @@ describe('IssueService', () => {
       expect(changesOfLastUpdate().remindAt).toBe(newDue - MIN_10);
     });
 
-    it('bulk poll: a remote unschedule clears the reminder', async () => {
+    it('bulk poll: a remote unschedule clears the reminder via dismissReminderOnly, not via the update', async () => {
       const task = createCaldavTask({ dueWithTime: oldDue, remindAt: oldDue });
       commonInterfaceServiceSpy.getFreshDataForIssueTasks.and.returnValue(
         Promise.resolve([
@@ -876,9 +885,32 @@ describe('IssueService', () => {
 
       await service.refreshIssueTasks([task], caldavProvider);
 
-      const changes = changesOfLastUpdate();
-      expect(Object.prototype.hasOwnProperty.call(changes, 'remindAt')).toBeTrue();
-      expect(changes.remindAt).toBeUndefined();
+      expect(
+        Object.prototype.hasOwnProperty.call(changesOfLastUpdate(), 'remindAt'),
+      ).toBeFalse();
+      expect(storeSpy.dispatch).toHaveBeenCalledWith(
+        TaskSharedActions.dismissReminderOnly({ id: task.id, isSkipSnack: true }),
+      );
+    });
+
+    it('bulk poll: a reschedule of a task without a reminder does not dispatch a clear', async () => {
+      const task = createCaldavTask({ dueWithTime: oldDue, remindAt: undefined });
+      commonInterfaceServiceSpy.getFreshDataForIssueTasks.and.returnValue(
+        Promise.resolve([
+          {
+            task,
+            taskChanges: { dueWithTime: newDue, issueWasUpdated: true },
+            issue: {},
+          },
+        ]),
+      );
+
+      await service.refreshIssueTasks([task], caldavProvider);
+
+      expect(
+        Object.prototype.hasOwnProperty.call(changesOfLastUpdate(), 'remindAt'),
+      ).toBeFalse();
+      expect(storeSpy.dispatch).not.toHaveBeenCalled();
     });
 
     it('bulk poll: an unchanged schedule leaves remindAt alone', async () => {
@@ -913,6 +945,81 @@ describe('IssueService', () => {
       await service.refreshIssueTask(task, false, false);
 
       expect(changesOfLastUpdate().remindAt).toBe(newDue);
+    });
+
+    describe('remote unschedule clears the reminder on every device (#9776 shape)', () => {
+      let dispatched: Action[];
+
+      beforeEach(() => {
+        dispatched = [];
+        storeSpy.dispatch.and.callFake(((action: Action): void => {
+          dispatched.push(action);
+        }) as Store['dispatch']);
+        // Mirror of TaskService.update: for changes without projectId it
+        // dispatches exactly this action (task.service.ts `update`).
+        taskServiceSpy.update.and.callFake((id: string, changes: Partial<Task>) => {
+          dispatched.push(TaskSharedActions.updateTask({ task: { id, changes } }));
+        });
+      });
+
+      // The op-log serializes payloads with JSON, which drops undefined-valued
+      // keys, so this is what every OTHER device replays.
+      const replayOnRemoteDevice = (task: Task): Task => {
+        const reducer = createCombinedTaskSharedMetaReducer((state) => state);
+        const base = createBaseState();
+        let state: RootState = {
+          ...base,
+          [TASK_FEATURE_NAME]: {
+            ...base[TASK_FEATURE_NAME],
+            ids: [task.id],
+            entities: {
+              [task.id]: createReducerTask({
+                id: task.id,
+                dueWithTime: task.dueWithTime,
+                remindAt: task.remindAt,
+              }),
+            },
+          },
+        };
+        for (const action of dispatched) {
+          state = reducer(state, JSON.parse(JSON.stringify(action)));
+        }
+        return state[TASK_FEATURE_NAME].entities[task.id] as Task;
+      };
+
+      it('bulk poll: the replayed ops clear remindAt', async () => {
+        const task = createCaldavTask({ dueWithTime: oldDue, remindAt: oldDue });
+        commonInterfaceServiceSpy.getFreshDataForIssueTasks.and.returnValue(
+          Promise.resolve([
+            {
+              task,
+              taskChanges: { dueWithTime: null, dueDay: null, issueWasUpdated: true },
+              issue: {},
+            },
+          ]),
+        );
+
+        await service.refreshIssueTasks([task], caldavProvider);
+
+        const remoteTask = replayOnRemoteDevice(task);
+        expect(typeof remoteTask.dueWithTime).not.toBe('number');
+        expect(remoteTask.remindAt).toBeUndefined();
+      });
+
+      it('single refresh: the replayed ops clear remindAt', async () => {
+        const task = createCaldavTask({ dueWithTime: oldDue, remindAt: oldDue });
+        commonInterfaceServiceSpy.getFreshDataForIssueTask.and.returnValue(
+          Promise.resolve({
+            taskChanges: { dueWithTime: null, dueDay: null, issueWasUpdated: true },
+            issue: {},
+            issueTitle: 'x',
+          }),
+        );
+
+        await service.refreshIssueTask(task, false, false);
+
+        expect(replayOnRemoteDevice(task).remindAt).toBeUndefined();
+      });
     });
   });
 });

--- a/src/app/features/issue/issue.service.ts
+++ b/src/app/features/issue/issue.service.ts
@@ -33,6 +33,7 @@ import { IssueTask, Task, TaskCopy } from '../tasks/task.model';
 import { GlobalConfigService } from '../config/global-config.service';
 import { DEFAULT_GLOBAL_CONFIG } from '../config/default-global-config.const';
 import { withRemindAtForDueChange } from '../tasks/util/with-remind-at-for-due-change';
+import { TaskSharedActions } from '../../root-store/meta/task-shared.actions';
 import { IssueServiceInterface } from './issue-service-interface';
 import { JiraCommonInterfacesService } from './providers/jira/jira-common-interfaces.service';
 // Trello is now a plugin — no built-in service needed
@@ -354,7 +355,7 @@ export class IssueService {
       if (this.ISSUE_REFRESH_MAP[issueProviderId]?.[issueId]) {
         this.ISSUE_REFRESH_MAP[issueProviderId][issueId].next(update.issue);
       }
-      this._taskService.update(task.id, this._withRemindAt(task, update.taskChanges));
+      this._updateTaskFromPoll(task, update.taskChanges);
 
       if (isNotifySuccess) {
         this._snackService.open({
@@ -439,10 +440,7 @@ export class IssueService {
               update.issue,
             );
           }
-          this._taskService.update(
-            update.task.id,
-            this._withRemindAt(update.task, update.taskChanges),
-          );
+          this._updateTaskFromPoll(update.task, update.taskChanges);
         }
 
         if (updates.length === 1) {
@@ -860,17 +858,28 @@ export class IssueService {
   }
 
   /**
-   * A poll result is applied as one plain `updateTask`, which never touches
-   * `remindAt`. Derive it here so a remote (re)schedule or unschedule lands with
-   * its reminder in the same op (#10047) — same default the import path uses.
+   * A poll result is applied as a plain `updateTask`, which never touches
+   * `remindAt`. Derive it here so a remote (re)schedule lands with its reminder
+   * in the same op (#10047) — same default the import path uses.
+   *
+   * A remote unschedule is two ops on purpose: `remindAt: undefined` inside
+   * `updateTask` is dropped by JSON serialization and never replays on other
+   * devices (#9776), so the clear goes through `dismissReminderOnly`, whose
+   * reducer sets it deterministically. Rare enough that the extra op is fine.
    */
-  private _withRemindAt(task: Task, taskChanges: Partial<Task>): Partial<Task> {
-    return withRemindAtForDueChange(
+  private _updateTaskFromPoll(task: Task, taskChanges: Partial<Task>): void {
+    const { changes, isClearRemindAt } = withRemindAtForDueChange(
       task,
       taskChanges,
       this._globalConfigService.cfg()?.reminder.defaultTaskRemindOption ??
         DEFAULT_GLOBAL_CONFIG.reminder.defaultTaskRemindOption!,
     );
+    this._taskService.update(task.id, changes);
+    if (isClearRemindAt) {
+      this._store.dispatch(
+        TaskSharedActions.dismissReminderOnly({ id: task.id, isSkipSnack: true }),
+      );
+    }
   }
 
   private _getService(key: IssueProviderKey): IssueServiceInterface | undefined {

--- a/src/app/features/tasks/store/task-reminder.effects.spec.ts
+++ b/src/app/features/tasks/store/task-reminder.effects.spec.ts
@@ -451,6 +451,16 @@ describe('TaskReminderEffects', () => {
         ico: 'schedule',
       });
     });
+
+    it('should not show a snack when dismissing with isSkipSnack', () => {
+      actions$ = of(
+        TaskSharedActions.dismissReminderOnly({ id: 'task-1', isSkipSnack: true }),
+      );
+
+      effects.dismissReminderSnack$.subscribe();
+
+      expect(snackService.open).not.toHaveBeenCalled();
+    });
   });
 
   // NOTE: Tests for removeTaskReminderTrigger1$ were removed because the effect no longer exists.

--- a/src/app/features/tasks/store/task-reminder.effects.ts
+++ b/src/app/features/tasks/store/task-reminder.effects.ts
@@ -201,6 +201,8 @@ export class TaskReminderEffects {
     () =>
       this._localActions$.pipe(
         ofType(TaskSharedActions.dismissReminderOnly),
+        // A background write (issue-provider poll) opts out via `isSkipSnack`.
+        filter(({ isSkipSnack }) => !isSkipSnack),
         tap(() => {
           this._snackService.open({
             type: 'SUCCESS',

--- a/src/app/features/tasks/task/_task-base.scss
+++ b/src/app/features/tasks/task/_task-base.scss
@@ -121,7 +121,7 @@
   // traces whatever radius the box already has — no border-radius of its own, so
   // nothing can leak into the sub-task boxes (which are deliberately square).
   :host.highlight-searched-task .inner-wrapper > & {
-    outline: 2px solid var(--c-accent);
+    outline: var(--focus-ring-width) solid var(--c-accent);
   }
 
   :host.isCurrent.isCurrent.isCurrent.isCurrent.isCurrent & {

--- a/src/app/features/tasks/util/with-remind-at-for-due-change.spec.ts
+++ b/src/app/features/tasks/util/with-remind-at-for-due-change.spec.ts
@@ -17,7 +17,8 @@ describe('withRemindAtForDueChange', () => {
       changes,
       TaskReminderOptionId.AtStart,
     );
-    expect(res).toBe(changes);
+    expect(res.changes).toBe(changes);
+    expect(res.isClearRemindAt).toBeFalse();
   });
 
   it('leaves remindAt alone when dueWithTime is unchanged', () => {
@@ -26,16 +27,18 @@ describe('withRemindAtForDueChange', () => {
       { dueWithTime: oldDue, title: 'renamed' },
       TaskReminderOptionId.AtStart,
     );
-    expect(hasRemindAt(res)).toBeFalse();
+    expect(hasRemindAt(res.changes)).toBeFalse();
+    expect(res.isClearRemindAt).toBeFalse();
   });
 
-  it('uses the default remind option when the task had no reminder', () => {
+  it('uses the default remind option on a first-time schedule', () => {
     const res = withRemindAtForDueChange(
       { dueWithTime: undefined, remindAt: undefined },
       { dueWithTime: newDue },
       TaskReminderOptionId.m10,
     );
-    expect(res.remindAt).toBe(newDue - MIN_10);
+    expect(res.changes.remindAt).toBe(newDue - MIN_10);
+    expect(res.isClearRemindAt).toBeFalse();
   });
 
   it('keeps the existing reminder offset on a reschedule', () => {
@@ -44,7 +47,19 @@ describe('withRemindAtForDueChange', () => {
       { dueWithTime: newDue },
       TaskReminderOptionId.AtStart,
     );
-    expect(res.remindAt).toBe(newDue - MIN_30);
+    expect(res.changes.remindAt).toBe(newDue - MIN_30);
+    expect(res.isClearRemindAt).toBeFalse();
+  });
+
+  it('keeps an already scheduled task reminder-less on a reschedule (no default)', () => {
+    const changes = { dueWithTime: newDue };
+    const res = withRemindAtForDueChange(
+      { dueWithTime: oldDue, remindAt: undefined },
+      changes,
+      TaskReminderOptionId.m10,
+    );
+    expect(res.changes).toBe(changes);
+    expect(res.isClearRemindAt).toBeFalse();
   });
 
   it('falls back to the default when the task had a reminder but no dueWithTime', () => {
@@ -53,47 +68,81 @@ describe('withRemindAtForDueChange', () => {
       { dueWithTime: newDue },
       TaskReminderOptionId.h1,
     );
-    expect(res.remindAt).toBe(newDue - MIN_60);
+    expect(res.changes.remindAt).toBe(newDue - MIN_60);
+    expect(res.isClearRemindAt).toBeFalse();
   });
 
-  it('sets no reminder when the default is DoNotRemind', () => {
+  it('sets no reminder on a first-time schedule when the default is DoNotRemind', () => {
+    const changes = { dueWithTime: newDue };
     const res = withRemindAtForDueChange(
       { dueWithTime: undefined, remindAt: undefined },
-      { dueWithTime: newDue },
+      changes,
       TaskReminderOptionId.DoNotRemind,
     );
-    expect(hasRemindAt(res)).toBeTrue();
-    expect(res.remindAt).toBeUndefined();
+    expect(res.changes).toBe(changes);
+    expect(res.isClearRemindAt).toBeFalse();
   });
 
-  it('clears remindAt when dueWithTime is cleared with undefined', () => {
+  it('signals a clear when DoNotRemind replaces a reminder of a day-only task', () => {
+    const changes = { dueWithTime: newDue, dueDay: null };
+    const res = withRemindAtForDueChange(
+      { dueWithTime: undefined, remindAt: oldDue },
+      changes,
+      TaskReminderOptionId.DoNotRemind,
+    );
+    expect(res.changes).toBe(changes);
+    expect(res.isClearRemindAt).toBeTrue();
+  });
+
+  it('signals a clear when dueWithTime is cleared with undefined', () => {
+    const changes = { dueWithTime: undefined };
     const res = withRemindAtForDueChange(
       { dueWithTime: oldDue, remindAt: oldDue },
-      { dueWithTime: undefined },
+      changes,
       TaskReminderOptionId.AtStart,
     );
-    expect(hasRemindAt(res)).toBeTrue();
-    expect(res.remindAt).toBeUndefined();
+    expect(res.changes).toBe(changes);
+    expect(res.isClearRemindAt).toBeTrue();
   });
 
-  it('clears remindAt when dueWithTime is cleared with null (CalDAV shape)', () => {
+  it('signals a clear when dueWithTime is cleared with null (CalDAV shape)', () => {
+    const changes = { dueWithTime: null, dueDay: null };
     const res = withRemindAtForDueChange(
       { dueWithTime: oldDue, remindAt: oldDue },
-      { dueWithTime: null, dueDay: null },
+      changes,
       TaskReminderOptionId.AtStart,
     );
-    expect(hasRemindAt(res)).toBeTrue();
-    expect(res.remindAt).toBeUndefined();
+    expect(res.changes).toBe(changes);
+    expect(res.isClearRemindAt).toBeTrue();
   });
 
-  it('does not add a remindAt key when clearing a task that had no reminder', () => {
+  it('does not signal a clear when clearing a task that had no reminder', () => {
     const changes = { dueWithTime: null };
     const res = withRemindAtForDueChange(
       { dueWithTime: oldDue, remindAt: undefined },
       changes,
       TaskReminderOptionId.AtStart,
     );
-    expect(res).toBe(changes);
+    expect(res.changes).toBe(changes);
+    expect(res.isClearRemindAt).toBeFalse();
+  });
+
+  it('never puts an undefined remindAt into changes (dropped by JSON on the wire)', () => {
+    const { AtStart, DoNotRemind, m10 } = TaskReminderOptionId;
+    const cases: Parameters<typeof withRemindAtForDueChange>[] = [
+      [{ dueWithTime: oldDue, remindAt: oldDue }, { dueWithTime: null }, AtStart],
+      [{ dueWithTime: oldDue, remindAt: oldDue }, { dueWithTime: undefined }, AtStart],
+      [
+        { dueWithTime: undefined, remindAt: oldDue },
+        { dueWithTime: newDue },
+        DoNotRemind,
+      ],
+      [{ dueWithTime: oldDue, remindAt: undefined }, { dueWithTime: newDue }, m10],
+    ];
+    for (const args of cases) {
+      const res = withRemindAtForDueChange(...args);
+      expect(hasRemindAt(res.changes)).withContext(JSON.stringify(args)).toBeFalse();
+    }
   });
 
   it('does not mutate the input changes', () => {

--- a/src/app/features/tasks/util/with-remind-at-for-due-change.ts
+++ b/src/app/features/tasks/util/with-remind-at-for-due-change.ts
@@ -4,16 +4,33 @@ import {
   remindOptionToMilliseconds,
 } from './remind-option-to-milliseconds';
 
+export interface RemindAtForDueChange {
+  changes: Partial<Task>;
+  /**
+   * The existing reminder must go. Callers clear it with a dedicated action
+   * (`TaskSharedActions.dismissReminderOnly`) — never via
+   * `changes.remindAt = undefined`: JSON serialization drops undefined-valued
+   * keys from the op payload, so that clear would replay as a no-op on every
+   * other device (#9776).
+   */
+  isClearRemindAt: boolean;
+}
+
 /**
  * Keeps `remindAt` in step with a `dueWithTime` change that bypasses the
  * schedule actions (e.g. an issue-provider poll writing a remote reschedule via
  * a plain `updateTask`). Reminders fire strictly off `remindAt`, so a moved or
- * cleared `dueWithTime` must carry the reminder along in the same change.
+ * cleared `dueWithTime` must carry the reminder along.
  *
  * - unchanged or absent `dueWithTime` → changes returned as-is
- * - `dueWithTime` cleared → `remindAt` cleared (when one was set)
+ * - `dueWithTime` cleared → `isClearRemindAt` (when a reminder was set)
  * - moved, with an existing reminder → the reminder keeps its offset
+ * - moved, already scheduled without a reminder → stays without one (like
+ *   the schedule dialog)
  * - set for the first time → `defaultRemindCfg` decides, like the import path
+ *
+ * `changes` never carries an undefined `remindAt`; a clear is only ever
+ * signalled through `isClearRemindAt` (see there for why).
  *
  * Computed at dispatch time on purpose: deriving it inside a reducer from the
  * replaying device's config would break replay determinism (sync rule 4).
@@ -22,22 +39,27 @@ export const withRemindAtForDueChange = (
   task: Pick<Task, 'dueWithTime' | 'remindAt'>,
   changes: Partial<Task>,
   defaultRemindCfg: TaskReminderOptionId,
-): Partial<Task> => {
+): RemindAtForDueChange => {
+  const hadReminder = typeof task.remindAt === 'number';
   if (!Object.prototype.hasOwnProperty.call(changes, 'dueWithTime')) {
-    return changes;
+    return { changes, isClearRemindAt: false };
   }
   const newDue = changes.dueWithTime;
   if (typeof newDue !== 'number') {
-    return typeof task.remindAt === 'number'
-      ? { ...changes, remindAt: undefined }
-      : changes;
+    return { changes, isClearRemindAt: hadReminder };
   }
   if (newDue === task.dueWithTime) {
-    return changes;
+    return { changes, isClearRemindAt: false };
   }
-  const remindCfg =
-    typeof task.dueWithTime === 'number' && typeof task.remindAt === 'number'
-      ? millisecondsDiffToRemindOption(task.dueWithTime, task.remindAt)
-      : defaultRemindCfg;
-  return { ...changes, remindAt: remindOptionToMilliseconds(newDue, remindCfg) };
+  const wasScheduledWithTime = typeof task.dueWithTime === 'number';
+  if (wasScheduledWithTime && !hadReminder) {
+    return { changes, isClearRemindAt: false };
+  }
+  const remindCfg = wasScheduledWithTime
+    ? millisecondsDiffToRemindOption(task.dueWithTime as number, task.remindAt)
+    : defaultRemindCfg;
+  const remindAt = remindOptionToMilliseconds(newDue, remindCfg);
+  return typeof remindAt === 'number'
+    ? { changes: { ...changes, remindAt }, isClearRemindAt: false }
+    : { changes, isClearRemindAt: hadReminder };
 };

--- a/src/app/features/worklog/worklog-task-row/worklog-task-row.component.scss
+++ b/src/app/features/worklog/worklog-task-row/worklog-task-row.component.scss
@@ -13,8 +13,7 @@
 // for as long as the class is on. That ring sets no `position` either and still
 // paints unclipped over the neighbouring cells' collapsed borders.
 :host.highlight-searched-task {
-  box-shadow: 0 0 0 2px var(--c-accent);
-  border-radius: var(--card-border-radius);
+  box-shadow: 0 0 0 var(--focus-ring-width) var(--c-accent);
 }
 
 td {

--- a/src/app/op-log/apply/bulk-hydration.action.ts
+++ b/src/app/op-log/apply/bulk-hydration.action.ts
@@ -34,6 +34,14 @@ export const bulkApplyOperations = createAction(
      * schema migration cannot leave a state that the durable log cannot rebuild.
      */
     atomicReplayGroups?: string[][];
+    /**
+     * The batch is applied onto default (empty) state and is the whole history
+     * from seq 0. Only then may the client's own leading genesis op replay as
+     * full state (#9863): on a non-empty baseline — the normal tail replay, a
+     * remote-apply batch, the file-provider snapshot + suffix path — the same
+     * op must stay inert, or it would replace state the batch did not build.
+     */
+    isReplayFromEmptyBaseline?: boolean;
   }>(),
 );
 

--- a/src/app/op-log/apply/bulk-hydration.meta-reducer.ts
+++ b/src/app/op-log/apply/bulk-hydration.meta-reducer.ts
@@ -131,10 +131,31 @@ export const bulkOperationsMetaReducer = <T>(
             // strictly on a KNOWN matching clientId: an unknown localClientId
             // keeps the op inert (the pre-fix behaviour) rather than risking a
             // foreign genesis op replacing this device's state mid-log.
+            //
+            // It must also be the FIRST op of the batch. The genesis op is the
+            // state at the moment this client's log began, so it can only stand
+            // in for the history when nothing precedes it. Pre-#9921 clients
+            // uploaded their genesis op like any other op, so a server history
+            // can read [other device's ops…, own genesis, own ops…]; a
+            // USE_REMOTE raw rebuild replays that order from seq 0 and a
+            // full-state replay mid-batch would discard everything the other
+            // device did before this one joined. Every replay-from-scratch
+            // path hands the whole history to one dispatch (no chunking), so
+            // batch position is log position there. Mid-batch it stays inert —
+            // the pre-#10052 behaviour — and is logged so the loss is
+            // diagnosable.
             const isOwnGenesisOp =
               !!localClientId &&
               op.clientId === localClientId &&
               isGenesisEntityType(op.entityType);
+            const isLeadingOwnGenesisOp = isOwnGenesisOp && operations[0]?.id === op.id;
+            if (isOwnGenesisOp && !isLeadingOwnGenesisOp) {
+              OpLog.warn(
+                'bulkOperationsMetaReducer: own genesis op is not first in the batch — ' +
+                  'replaying it as inert; its pre-migration state is not restored',
+                { opId: op.id, entityType: op.entityType },
+              );
+            }
             try {
               const isLww = hasArchives && isLwwUpdateActionType(op.actionType);
               const recreatesEntityAfterDelete =
@@ -164,7 +185,7 @@ export const bulkOperationsMetaReducer = <T>(
                   )
                 : op;
               const opAction = convertOpToAction(opForApply, {
-                replayAsFullState: isOwnGenesisOp,
+                replayAsFullState: isLeadingOwnGenesisOp,
               });
               // Mark ops authored by a DIFFERENT client so reducers can preserve
               // per-device "local-only" settings against remote overwrites — while
@@ -194,7 +215,7 @@ export const bulkOperationsMetaReducer = <T>(
               currentState = reducer(currentState, finalAction);
             } catch (error) {
               const isNewFailure = reportFailure(op, error);
-              if (isFullStateOpType(op.opType) || isOwnGenesisOp) {
+              if (isFullStateOpType(op.opType) || isLeadingOwnGenesisOp) {
                 // A full-state operation replaces the entire model. Continuing
                 // from the pre-import state would expose a projection that never
                 // existed in the log, so discard the speculative batch.

--- a/src/app/op-log/apply/bulk-hydration.meta-reducer.ts
+++ b/src/app/op-log/apply/bulk-hydration.meta-reducer.ts
@@ -54,6 +54,7 @@ export const bulkOperationsMetaReducer = <T>(
         operations,
         localClientId,
         atomicReplayGroups = [],
+        isReplayFromEmptyBaseline = false,
       } = action as ReturnType<typeof bulkApplyOperations>;
 
       // Apply every op in one synchronous reducer pass. Suppress the action
@@ -132,28 +133,39 @@ export const bulkOperationsMetaReducer = <T>(
             // keeps the op inert (the pre-fix behaviour) rather than risking a
             // foreign genesis op replacing this device's state mid-log.
             //
-            // It must also be the FIRST op of the batch. The genesis op is the
-            // state at the moment this client's log began, so it can only stand
-            // in for the history when nothing precedes it. Pre-#9921 clients
+            // It must also be the FIRST op of a batch that the caller declared
+            // as replayed from an empty baseline. The genesis op is the state at
+            // the moment this client's log began, so it can only stand in for
+            // the history when nothing precedes it — neither an earlier op in
+            // the batch nor state hydrated before the batch. Pre-#9921 clients
             // uploaded their genesis op like any other op, so a server history
             // can read [other device's ops…, own genesis, own ops…]; a
             // USE_REMOTE raw rebuild replays that order from seq 0 and a
             // full-state replay mid-batch would discard everything the other
-            // device did before this one joined. Every replay-from-scratch
-            // path hands the whole history to one dispatch (no chunking), so
-            // batch position is log position there. Mid-batch it stays inert —
-            // the pre-#10052 behaviour — and is logged so the loss is
-            // diagnosable.
+            // device did before this one joined. File providers still upload
+            // it, and their USE_REMOTE hydrates a snapshot first and replays
+            // the suffix on top — a leading own genesis there must stay inert.
+            // Every replay-from-scratch path hands the whole history to one
+            // dispatch (no chunking), so batch position is log position there.
+            // Otherwise it stays inert — the pre-#10052 behaviour — and is
+            // logged so the loss is diagnosable.
             const isOwnGenesisOp =
               !!localClientId &&
               op.clientId === localClientId &&
               isGenesisEntityType(op.entityType);
-            const isLeadingOwnGenesisOp = isOwnGenesisOp && operations[0]?.id === op.id;
+            const isLeadingOwnGenesisOp =
+              isOwnGenesisOp && isReplayFromEmptyBaseline && operations[0]?.id === op.id;
             if (isOwnGenesisOp && !isLeadingOwnGenesisOp) {
               OpLog.warn(
-                'bulkOperationsMetaReducer: own genesis op is not first in the batch — ' +
-                  'replaying it as inert; its pre-migration state is not restored',
-                { opId: op.id, entityType: op.entityType },
+                'bulkOperationsMetaReducer: own genesis op is not the first op of a ' +
+                  'replay from an empty baseline — replaying it as inert; its ' +
+                  'pre-migration state is not restored',
+                {
+                  opId: op.id,
+                  entityType: op.entityType,
+                  isFirstInBatch: operations[0]?.id === op.id,
+                  isReplayFromEmptyBaseline,
+                },
               );
             }
             try {

--- a/src/app/op-log/apply/operation-applier.service.spec.ts
+++ b/src/app/op-log/apply/operation-applier.service.spec.ts
@@ -130,6 +130,19 @@ describe('OperationApplierService', () => {
       expect(result.failedOp).toBeUndefined();
     });
 
+    it('forwards isReplayFromEmptyBaseline to the bulk action only when set', async () => {
+      const op = createMockOperation('op-1', 'TASK', OpType.Update, { title: 'Test' });
+
+      await service.applyOperations([op]);
+      await service.applyOperations([op], { isReplayFromEmptyBaseline: true });
+
+      const [plain, fromScratch] = mockStore.dispatch.calls
+        .allArgs()
+        .map(([action]) => action as unknown as { isReplayFromEmptyBaseline?: boolean });
+      expect(plain.isReplayFromEmptyBaseline).toBeUndefined();
+      expect(fromScratch.isReplayFromEmptyBaseline).toBeTrue();
+    });
+
     it('should dispatch bulkApplyOperations with multiple operations', async () => {
       const ops = [
         createMockOperation('op-1', 'TASK', OpType.Update, { title: 'First' }),

--- a/src/app/op-log/apply/operation-applier.service.ts
+++ b/src/app/op-log/apply/operation-applier.service.ts
@@ -130,7 +130,13 @@ export class OperationApplierService implements OperationApplyPort<Operation> {
           ),
       },
       createBulkApplyAction: (operations) =>
-        bulkApplyOperations({ operations, localClientId }),
+        bulkApplyOperations({
+          operations,
+          localClientId,
+          ...(options.isReplayFromEmptyBaseline
+            ? { isReplayFromEmptyBaseline: true }
+            : {}),
+        }),
       getReducerFailures: () => reducerFailures,
       remoteApplyWindow: options.remoteApplyWindowAlreadyOpen
         ? CALLER_MANAGED_REMOTE_APPLY_WINDOW

--- a/src/app/op-log/backup/backup.service.spec.ts
+++ b/src/app/op-log/backup/backup.service.spec.ts
@@ -111,6 +111,7 @@ describe('BackupService', () => {
       'saveImportBackup',
       'pruneImportBackups',
       'loadImportBackup',
+      'loadImportBackupById',
       'clearImportBackup',
       'runDestructiveStateReplacement',
     ]);
@@ -271,9 +272,31 @@ describe('BackupService', () => {
 
       const meta = await service.captureRecoveryPointIfMeaningful('REMOTE_IMPORT');
 
-      expect(mockOpLogStore.pruneImportBackups).toHaveBeenCalledOnceWith(1);
+      expect(mockOpLogStore.pruneImportBackups).toHaveBeenCalledOnceWith(1, undefined);
       expect(mockOpLogStore.saveImportBackup).toHaveBeenCalledTimes(2);
       expect(meta?.backupId).toBe('b2');
+    });
+
+    it('should protect the snapshot being restored when the quota prune runs mid-restore', async () => {
+      mockOpLogStore.loadImportBackupById.and.resolveTo({
+        backupId: 'r1',
+        savedAt: 1,
+        state: createMinimalValidBackup(),
+      });
+      mockStateSnapshotService.getStateSnapshotAsync.and.resolveTo(
+        snapshotWithTask() as any,
+      );
+      mockOpLogStore.saveImportBackup.and.returnValues(
+        Promise.reject(new DOMException('full', 'QuotaExceededError')),
+        Promise.resolve({ backupId: 'b2', savedAt: 2 }),
+      );
+      mockOpLogStore.pruneImportBackups.and.resolveTo(2);
+
+      await service.restoreImportBackupById('r1');
+
+      // Pruning to the newest capture alone would delete r1 while it is still
+      // needed for a retry if the rest of the restore fails.
+      expect(mockOpLogStore.pruneImportBackups).toHaveBeenCalledOnceWith(1, 'r1');
     });
 
     it('should still fail when the retry after pruning fails too', async () => {

--- a/src/app/op-log/backup/backup.service.ts
+++ b/src/app/op-log/backup/backup.service.ts
@@ -312,7 +312,7 @@ export class BackupService {
       OpLog.warn(
         'BackupService: Recovery point hit storage quota; pruning ring and retrying',
       );
-      await this._opLogStore.pruneImportBackups(1);
+      await this._opLogStore.pruneImportBackups(1, meta.protectBackupId);
       return this._opLogStore.saveImportBackup(state, meta);
     }
   }

--- a/src/app/op-log/core/types/apply.types.ts
+++ b/src/app/op-log/core/types/apply.types.ts
@@ -54,6 +54,12 @@ export interface ApplyOperationsOptions {
   skipReducerDispatch?: boolean;
 
   /**
+   * The ops are the whole history from seq 0, applied onto default state.
+   * Forwarded to `bulkApplyOperations`; see there for what it unlocks.
+   */
+  isReplayFromEmptyBaseline?: boolean;
+
+  /**
    * Called after the bulk reducer dispatch commits and before archive side effects.
    * Remote apply uses this to persist its reducer/archive checkpoint and merge the
    * causal frontier before deferred local actions can be written.

--- a/src/app/op-log/persistence/import-backup-ring.util.spec.ts
+++ b/src/app/op-log/persistence/import-backup-ring.util.spec.ts
@@ -3,6 +3,7 @@ import {
   ImportBackupReason,
   listImportBackupsTx,
   loadImportBackupByIdTx,
+  pruneImportBackupRingTx,
   saveImportBackupTx,
 } from './import-backup-ring.util';
 import { OpLogTx } from './op-log-db-adapter';
@@ -64,6 +65,25 @@ describe('import backup ring', () => {
     expect(kept.map((e) => e.backupId)).toContain(oldest.backupId);
     expect(await loadImportBackupByIdTx(tx, oldest.backupId)).not.toBeNull();
     expect(kept.length).toBe(IMPORT_BACKUP_RING_SIZE);
+  });
+
+  it('does not evict the entry being restored when the quota prune runs mid-restore', async () => {
+    const tx = createTx();
+    const oldest = await save(tx, { pre: 'loss' }, 'REMOTE_IMPORT');
+    for (let i = 0; i < IMPORT_BACKUP_RING_SIZE - 1; i++) {
+      await save(tx, { i }, 'REMOTE_IMPORT');
+    }
+
+    // The pre-restore capture hit the storage quota, so the ring is pruned to
+    // make room before the capture is retried. Without the protection this
+    // keeps only the newest capture and deletes the snapshot being restored.
+    await pruneImportBackupRingTx(tx, 1, oldest.backupId);
+
+    const kept = await listImportBackupsTx(tx);
+    expect(kept.map((e) => e.backupId)).toContain(oldest.backupId);
+    expect(await loadImportBackupByIdTx(tx, oldest.backupId)).not.toBeNull();
+    // The prune still frees space; the protected entry is a floor, not a no-op.
+    expect(kept.length).toBeLessThan(IMPORT_BACKUP_RING_SIZE);
   });
 
   it('still guards the newest pre-replacement capture from a plain restore', async () => {

--- a/src/app/op-log/persistence/import-backup-ring.util.ts
+++ b/src/app/op-log/persistence/import-backup-ring.util.ts
@@ -184,13 +184,18 @@ export const listImportBackupsTx = (tx: OpLogTx): Promise<ImportBackupMeta[]> =>
  * make room when a capture fails (typically storage quota). Zero clears all
  * snapshots, including the protected capture. The undo pointer is
  * retired if its snapshot goes. Returns how many snapshots were evicted.
+ *
+ * `protectBackupId` keeps the entry currently being restored, same as in
+ * {@link saveImportBackupTx}: the quota retry runs mid-restore, and pruning
+ * to the newest capture alone would delete the snapshot the retry is for.
  */
 export const pruneImportBackupRingTx = async (
   tx: OpLogTx,
   keep: number,
+  protectBackupId?: string,
 ): Promise<number> => {
   const entries = await readRingMeta(tx);
-  const kept = keepNewest(entries, keep);
+  const kept = keepNewest(entries, keep, protectBackupId);
   const evicted = entries.filter((e) => !kept.includes(e));
   if (evicted.length === 0) {
     return 0;

--- a/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.spec.ts
@@ -1801,6 +1801,7 @@ describe('OperationLogHydratorService', () => {
           bulkApplyHydrationOperations({
             operations: allOps.map((e) => e.op),
             localClientId: 'test-client',
+            isReplayFromEmptyBaseline: true,
           }),
         );
       });
@@ -1840,6 +1841,7 @@ describe('OperationLogHydratorService', () => {
           bulkApplyHydrationOperations({
             operations: [genesisOp, postMigrationOp],
             localClientId,
+            isReplayFromEmptyBaseline: true,
           }),
         );
         expect(mockSnapshotService.saveCurrentStateAsSnapshot).toHaveBeenCalled();
@@ -1888,6 +1890,7 @@ describe('OperationLogHydratorService', () => {
           bulkApplyHydrationOperations({
             operations: allOps.map((e) => e.op),
             localClientId: 'test-client',
+            isReplayFromEmptyBaseline: true,
           }),
         );
         // The degraded recovery must be visible to the user...
@@ -2034,6 +2037,7 @@ describe('OperationLogHydratorService', () => {
           bulkApplyHydrationOperations({
             operations: allOps.map((e) => e.op),
             localClientId: 'test-client',
+            isReplayFromEmptyBaseline: true,
           }),
         );
         // Degraded recovery is visible; the partial replay is never persisted
@@ -2075,6 +2079,7 @@ describe('OperationLogHydratorService', () => {
           bulkApplyHydrationOperations({
             operations: allOps.map((e) => e.op),
             localClientId: 'test-client',
+            isReplayFromEmptyBaseline: true,
           }),
         );
         // Hydration state is managed around the dispatch

--- a/src/app/op-log/persistence/operation-log-hydrator.service.ts
+++ b/src/app/op-log/persistence/operation-log-hydrator.service.ts
@@ -731,6 +731,7 @@ export class OperationLogHydratorService {
       replayBatch,
       localClientId,
       pendingRemoteOps.filter((entry) => allOpIds.has(entry.op.id)),
+      { isReplayFromEmptyBaseline: true },
     );
 
     if (fallbackCause !== undefined) {
@@ -772,6 +773,7 @@ export class OperationLogHydratorService {
     replayBatch: HydrationReplayBatch,
     localClientId: string | undefined,
     pendingRemoteOps: OperationLogEntry[],
+    options: { isReplayFromEmptyBaseline?: boolean } = {},
   ): Promise<void> {
     const {
       operations,
@@ -791,6 +793,9 @@ export class OperationLogHydratorService {
               operations,
               localClientId,
               ...(atomicReplayGroups.length > 0 ? { atomicReplayGroups } : {}),
+              ...(options.isReplayFromEmptyBaseline
+                ? { isReplayFromEmptyBaseline: true }
+                : {}),
             }),
           ),
       );

--- a/src/app/op-log/persistence/operation-log-store.service.ts
+++ b/src/app/op-log/persistence/operation-log-store.service.ts
@@ -2421,8 +2421,10 @@ export class OperationLogStoreService implements RemoteOperationApplyStorePort<O
   }
 
   /** Keeps `keep` snapshots, prioritizing the newest pre-replacement capture. */
-  async pruneImportBackups(keep: number): Promise<number> {
-    return this._importBackupTx('readwrite', (tx) => pruneImportBackupRingTx(tx, keep));
+  async pruneImportBackups(keep: number, protectBackupId?: string): Promise<number> {
+    return this._importBackupTx('readwrite', (tx) =>
+      pruneImportBackupRingTx(tx, keep, protectBackupId),
+    );
   }
 
   /** Retires the Undo slot (only if it still matches `expectedBackupId`). */

--- a/src/app/op-log/sync/operation-log-sync.service.spec.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.spec.ts
@@ -5634,6 +5634,7 @@ describe('OperationLogSyncService', () => {
           skipConflictDetection: true,
           callerHoldsOperationLogLock: true,
           skipRecoveryPoint: true,
+          isReplayFromEmptyBaseline: true,
         },
       );
     });
@@ -5811,6 +5812,7 @@ describe('OperationLogSyncService', () => {
           skipConflictDetection: true,
           callerHoldsOperationLogLock: true,
           skipRecoveryPoint: true,
+          isReplayFromEmptyBaseline: true,
         },
       );
     });
@@ -5992,6 +5994,7 @@ describe('OperationLogSyncService', () => {
           skipConflictDetection: true,
           callerHoldsOperationLogLock: true,
           skipRecoveryPoint: true,
+          isReplayFromEmptyBaseline: true,
         },
       );
     });

--- a/src/app/op-log/sync/operation-log-sync.service.ts
+++ b/src/app/op-log/sync/operation-log-sync.service.ts
@@ -2246,6 +2246,10 @@ export class OperationLogSyncService {
                 skipConflictDetection: true,
                 callerHoldsOperationLogLock: true,
                 skipRecoveryPoint: true,
+                // Whole history onto the default baseline dispatched above; the
+                // file-provider branch hydrates a snapshot first and must NOT
+                // set this (#9863 genesis gate).
+                isReplayFromEmptyBaseline: true,
               }),
           );
 

--- a/src/app/op-log/sync/remote-ops-processing.service.ts
+++ b/src/app/op-log/sync/remote-ops-processing.service.ts
@@ -115,6 +115,13 @@ export class RemoteOpsProcessingService {
        * pointer and break that flow's Undo offer.
        */
       skipRecoveryPoint?: boolean;
+      /**
+       * Raw rebuild onto default state (USE_REMOTE on an API provider): the
+       * ops are the whole history from seq 0. Lets the client's own leading
+       * genesis op replay as full state (#9863). Never set on the file-provider
+       * snapshot + suffix path, where a snapshot was hydrated first.
+       */
+      isReplayFromEmptyBaseline?: boolean;
       ignoredLocalFullStateOpIds?: readonly string[];
       /**
        * Final full-state conflict check. Runs with the operation-log lock held,
@@ -420,6 +427,9 @@ export class RemoteOpsProcessingService {
       await this.applyNonConflictingOps(
         validOps,
         options.callerHoldsOperationLogLock ?? false,
+        {
+          isReplayFromEmptyBaseline: options.isReplayFromEmptyBaseline,
+        },
       );
       await this.validateAfterSync(options.callerHoldsOperationLogLock ?? false);
       return {
@@ -605,7 +615,10 @@ export class RemoteOpsProcessingService {
   async applyNonConflictingOps(
     ops: Operation[],
     callerHoldsLock: boolean = false,
-    options: { skipDeferredActionDrain?: boolean } = {},
+    options: {
+      skipDeferredActionDrain?: boolean;
+      isReplayFromEmptyBaseline?: boolean;
+    } = {},
   ): Promise<string[]> {
     const locallyReplayableOps =
       await this._withLocalOnlySyncSettingsForFullStateOps(ops);
@@ -630,6 +643,9 @@ export class RemoteOpsProcessingService {
             this.operationApplier.applyOperations(opsToApply, {
               skipDeferredLocalActions: true,
               onReducersCommitted: applyOptions?.onReducersCommitted,
+              ...(options.isReplayFromEmptyBaseline
+                ? { isReplayFromEmptyBaseline: true }
+                : {}),
             }),
         },
         isFullStateOperation: this._isFullStateOperation,

--- a/src/app/op-log/testing/integration/import-backup-ring.integration.spec.ts
+++ b/src/app/op-log/testing/integration/import-backup-ring.integration.spec.ts
@@ -69,6 +69,30 @@ describe('import backup ring — integration (real IndexedDB)', () => {
     expect((reloaded?.state as { marker: string }).marker).toBe('pre-loss');
   });
 
+  it('keeps the snapshot being restored readable after the quota prune runs mid-restore', async () => {
+    const oldest = await store.saveImportBackup(
+      { marker: 'pre-loss' },
+      { reason: 'REMOTE_IMPORT', taskCount: 1 },
+    );
+    for (let i = 0; i < IMPORT_BACKUP_RING_SIZE - 1; i++) {
+      await store.saveImportBackup(
+        { marker: `filler-${i}` },
+        { reason: 'REMOTE_IMPORT', taskCount: 1 },
+      );
+    }
+
+    // The pre-restore capture of `oldest` hit the storage quota, so
+    // BackupService prunes the ring to one entry before retrying it.
+    await store.pruneImportBackups(1, oldest.backupId);
+
+    expect((await store.listImportBackups()).map((e) => e.backupId)).toContain(
+      oldest.backupId,
+    );
+    const reloaded = await store.loadImportBackupById(oldest.backupId);
+    expect(reloaded).not.toBeNull();
+    expect((reloaded?.state as { marker: string }).marker).toBe('pre-loss');
+  });
+
   it('still rotates the oldest entry out when nothing is protected', async () => {
     const oldest = await store.saveImportBackup(
       { marker: 'oldest' },

--- a/src/app/op-log/testing/integration/migration-genesis-replay.integration.spec.ts
+++ b/src/app/op-log/testing/integration/migration-genesis-replay.integration.spec.ts
@@ -39,6 +39,7 @@ describe('MIGRATION genesis op replay-from-scratch (#9863)', () => {
   const CLIENT_ID = 'legacy-client';
   const PRE_MIGRATION_TASK_ID = 'task-from-before-the-update';
   const POST_MIGRATION_TASK_ID = 'task-created-after-the-update';
+  const FOREIGN_TASK_ID = 'task-from-another-device';
 
   // Real feature reducer for the task slice; everything else passes through.
   const featureReducer: ActionReducer<RootState, Action> = (state, action) => {
@@ -86,18 +87,21 @@ describe('MIGRATION genesis op replay-from-scratch (#9863)', () => {
     entityType: 'ALL',
   });
 
-  const createPostMigrationAddOp = (): Operation => ({
-    id: 'post-migration-add',
+  const createAddOp = (opts: {
+    id: string;
+    taskId: string;
+    title: string;
+    clientId: string;
+    timestamp: number;
+  }): Operation => ({
+    id: opts.id,
     actionType: ActionType.TASK_SHARED_ADD,
     opType: OpType.Create,
     entityType: 'TASK',
-    entityId: POST_MIGRATION_TASK_ID,
+    entityId: opts.taskId,
     payload: {
       actionPayload: {
-        task: createMockTask({
-          id: POST_MIGRATION_TASK_ID,
-          title: 'Created after the migration',
-        }),
+        task: createMockTask({ id: opts.taskId, title: opts.title }),
         workContextId: 'project1',
         workContextType: WorkContextType.PROJECT,
         isAddToBacklog: false,
@@ -105,11 +109,30 @@ describe('MIGRATION genesis op replay-from-scratch (#9863)', () => {
       },
       entityChanges: [],
     },
-    clientId: CLIENT_ID,
-    vectorClock: { [CLIENT_ID]: 2 },
-    timestamp: 2_000,
+    clientId: opts.clientId,
+    vectorClock: { [opts.clientId]: opts.clientId === CLIENT_ID ? 2 : 1 },
+    timestamp: opts.timestamp,
     schemaVersion: CURRENT_SCHEMA_VERSION,
   });
+
+  const createPostMigrationAddOp = (): Operation =>
+    createAddOp({
+      id: 'post-migration-add',
+      taskId: POST_MIGRATION_TASK_ID,
+      title: 'Created after the migration',
+      clientId: CLIENT_ID,
+      timestamp: 2_000,
+    });
+
+  // Another device's op that reached the server BEFORE this client joined.
+  const createForeignAddOp = (): Operation =>
+    createAddOp({
+      id: 'foreign-add',
+      taskId: FOREIGN_TASK_ID,
+      title: 'Created on another device before this one joined',
+      clientId: 'someOtherDevice',
+      timestamp: 500,
+    });
 
   // Options object rather than a defaulted param: an explicit `undefined`
   // argument would trigger the default and silently reinstate the client id.
@@ -152,6 +175,32 @@ describe('MIGRATION genesis op replay-from-scratch (#9863)', () => {
     expect(state[TASK_FEATURE_NAME].ids).toEqual(
       jasmine.arrayWithExactContents([PRE_MIGRATION_TASK_ID, POST_MIGRATION_TASK_ID]),
     );
+  });
+
+  // A genesis op is the complete state at the moment THIS client's log began,
+  // so it may only stand in for the history when nothing precedes it. Legacy
+  // clients (pre-#9921) uploaded their genesis op to SuperSync like any other
+  // op, so an account that already held another device's ops keeps the history
+  // [B ops…, genesis A, A ops…]. A USE_REMOTE raw rebuild replays exactly that
+  // order onto an empty baseline: replacing state at the genesis would discard
+  // everything B did before A joined.
+  it("leaves an own genesis op inert when another client's op precedes it (raw rebuild of a pre-#9921 history)", () => {
+    const state = replayFromScratch([
+      createForeignAddOp(),
+      createGenesisOp(),
+      createPostMigrationAddOp(),
+    ]);
+
+    expect(state[TASK_FEATURE_NAME].ids).toEqual(
+      jasmine.arrayWithExactContents([FOREIGN_TASK_ID, POST_MIGRATION_TASK_ID]),
+    );
+    expect(state[TASK_FEATURE_NAME].entities[PRE_MIGRATION_TASK_ID]).toBeUndefined();
+  });
+
+  it('leaves an own genesis op inert when one of its own ops precedes it', () => {
+    const state = replayFromScratch([createPostMigrationAddOp(), createGenesisOp()]);
+
+    expect(state[TASK_FEATURE_NAME].ids).toEqual([POST_MIGRATION_TASK_ID]);
   });
 
   // A genesis op is local bookkeeping, not sync history: another device's

--- a/src/app/op-log/testing/integration/migration-genesis-replay.integration.spec.ts
+++ b/src/app/op-log/testing/integration/migration-genesis-replay.integration.spec.ts
@@ -142,7 +142,10 @@ describe('MIGRATION genesis op replay-from-scratch (#9863)', () => {
       localClientId: CLIENT_ID,
     },
   ): RootState =>
-    rootReducer(createBaseState(), bulkApplyOperations({ operations, localClientId }));
+    rootReducer(
+      createBaseState(),
+      bulkApplyOperations({ operations, localClientId, isReplayFromEmptyBaseline: true }),
+    );
 
   it('control: a full-state SyncImport op followed by an add keeps both tasks', () => {
     const state = replayFromScratch([createSyncImportOp(), createPostMigrationAddOp()]);
@@ -195,6 +198,22 @@ describe('MIGRATION genesis op replay-from-scratch (#9863)', () => {
       jasmine.arrayWithExactContents([FOREIGN_TASK_ID, POST_MIGRATION_TASK_ID]),
     );
     expect(state[TASK_FEATURE_NAME].entities[PRE_MIGRATION_TASK_ID]).toBeUndefined();
+  });
+
+  // File providers still upload genesis ops, and their USE_REMOTE hydrates the
+  // remote snapshot first and replays the post-snapshot suffix on top. A
+  // leading own genesis in that suffix must not replace the hydrated state, so
+  // the caller has to declare the empty baseline explicitly.
+  it('leaves a leading own genesis op inert when the batch is not declared as replayed from an empty baseline', () => {
+    const state = rootReducer(
+      createBaseState(),
+      bulkApplyOperations({
+        operations: [createGenesisOp(), createPostMigrationAddOp()],
+        localClientId: CLIENT_ID,
+      }),
+    );
+
+    expect(state[TASK_FEATURE_NAME].ids).toEqual([POST_MIGRATION_TASK_ID]);
   });
 
   it('leaves an own genesis op inert when one of its own ops precedes it', () => {

--- a/src/app/root-store/meta/task-shared.actions.ts
+++ b/src/app/root-store/meta/task-shared.actions.ts
@@ -260,7 +260,7 @@ export const TaskSharedActions = createActionGroup({
       } satisfies PersistentActionMeta,
     }),
 
-    dismissReminderOnly: (taskProps: { id: string }) => ({
+    dismissReminderOnly: (taskProps: { id: string; isSkipSnack?: boolean }) => ({
       ...taskProps,
       meta: {
         isPersistent: true,

--- a/src/app/t.const.ts
+++ b/src/app/t.const.ts
@@ -1011,7 +1011,6 @@ const T = {
         MSG: 'F.PROJECT.D_DELETE.MSG',
       },
       D_RENAME: {
-        LABEL: 'F.PROJECT.D_RENAME.LABEL',
         PLACEHOLDER: 'F.PROJECT.D_RENAME.PLACEHOLDER',
       },
       COMPLETE: {
@@ -1820,7 +1819,6 @@ const T = {
         CONFIRM_MSG: 'F.TAG.D_DELETE.CONFIRM_MSG',
       },
       D_RENAME: {
-        LABEL: 'F.TAG.D_RENAME.LABEL',
         PLACEHOLDER: 'F.TAG.D_RENAME.PLACEHOLDER',
       },
       D_EDIT: {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -993,7 +993,6 @@
         "MSG": "Are you sure you want to delete the project \"{{title}}\"?"
       },
       "D_RENAME": {
-        "LABEL": "Project name",
         "PLACEHOLDER": "Enter project name"
       },
       "COMPLETE": {
@@ -1769,7 +1768,6 @@
         "CONFIRM_MSG": "Do you really want to delete the tag \"{{tagName}}\"? It will be removed from all tasks. This cannot be undone!"
       },
       "D_RENAME": {
-        "LABEL": "Tag name",
         "PLACEHOLDER": "Enter tag name"
       },
       "D_EDIT": {


### PR DESCRIPTION
## Summary

Follow-up to a review of the 29 commits merged to master on 2026-09-11. Every fix starts from a test that fails on master; each was mutation-checked by toggling the fix and re-running its spec.

### Sync (high)
- **Own genesis op replayed mid-history wiped earlier state on USE_REMOTE** (`bulk-hydration.meta-reducer.ts`). #10052 replayed the client's own MIGRATION/RECOVERY genesis op as `loadAllData` gated on clientId alone. Pre-#9921 clients uploaded genesis ops like any other op, so a raw rebuild of `[B ops…, genesis A, A ops…]` discarded everything B did before A joined. The full-state replay now requires the op to be first in the batch **and** the caller to declare `isReplayFromEmptyBaseline` (set only by the hydrator's replay-from-scratch and the USE_REMOTE raw rebuild on API providers; the file-provider snapshot + suffix path never sets it). Mid-batch it stays inert and logs.

### Reminders / issue polling (medium)
- **Poll-driven reminder clear never reached other devices** (`issue.service.ts`, `with-remind-at-for-due-change.ts`). #10055 put `remindAt: undefined` into `updateTask`; JSON drops it (#9776), and the same op carried the new `issueLastUpdated` so other devices' polls never re-derived. The clear now goes through the existing `dismissReminderOnly` (id-only payload, reducer-side clear). `dismissReminderOnly` gains optional `isSkipSnack` so a background poll does not show "Reminder deleted"; old clients ignore it. Also: an already-scheduled task without a reminder keeps none when a poll moves it, matching the schedule dialog.

### Electron (medium)
- **OS progress bar frozen after cancelling/pausing a timed focus session** (`focus-mode.effects.ts`). #10048 relied on `setTaskBarNoProgress$`, which listens for `setCurrentTask`, while focus mode dispatches `unsetCurrentTask`. The session writer now publishes one `{-1, none}` on the owned → not-owned handoff and nothing during Flowtime. The effect reads `IS_ELECTRON_TOKEN` so it is testable.

### Backup ring
- **Quota-retry prune could delete the snapshot being restored** (`backup.service.ts`, `import-backup-ring.util.ts`). #10046's `protectBackupId` was not passed on the `QuotaExceededError` retry. Pinned at util, real-IndexedDB, and service level.

### Small
- Rename menu (#9978): tag branch null guard, `firstValueFrom`, two dead i18n keys removed, specs for `rename()`.
- Search highlight (#9820): `--focus-ring-width` token instead of hardcoded 2px; inert `border-radius` on a table row removed.
- Release snap workflow: separate image-pull step, mirroring build.yml.

## Verification
- `npm test`: 15,228 + 15,214 SUCCESS; `npm run lint`: 0 errors.
- Independent sub-agent review of the branch confirmed every commit and found the file-provider suffix gap, fixed in the last commit.

## Known, not addressed here
- iCal all-day events produce no `dueWithTime` key at all, so a timed → all-day change on iCal never clears the time or reminder on any device (pre-existing, separate provider).
- Plainspace clears the schedule with `dueWithTime: undefined` inside `updateTask` (`plainspace-common-interfaces.service.ts:143`), same #9776 class; needs its own reproduction.
- `operation-log-store.service.ts` (grandfathered `max-lines`) grew by 3 lines for the `protectBackupId` pass-through.

## Before merging
Dispatch `E2E Tests (Scheduled)` for this branch: the genesis gate is verified at reducer level and by spec, not with a two-device run.

Refs #9863, #9921, #10047, #9776

https://claude.ai/code/session_01HvnHf8ppu1F2u2gw3LadFg
