### PR TITLE
fix(issue): don't overwrite isDone when polling issue updates (#9909)

### DIFF
--- a/docs/wiki/3.07-Issue-Integration-Comparison.md
+++ b/docs/wiki/3.07-Issue-Integration-Comparison.md
@@ -14,7 +14,7 @@ Every issue provider supports the same basic operations: checking that the integ
 | --------------- | ------ | ------------- | ---------- | -------- | -------- | ----------- | -------------------- | ----------- | --------- | --------- |
 | Jira            | Yes    | Yes           | Yes        | Yes      | Yes      | Yes         | JQL                  | Yes         | Yes       | —         |
 | GitHub          | Yes    | No            | No         | Yes      | No       | No          | Repo, assignee       | Yes         | —         | —         |
-| GitLab          | Yes    | Auto (closed) | Deprecated | Yes      | No       | No          | Project, scope       | —           | Weight    | Yes       |
+| GitLab          | Yes    | No            | Deprecated | Yes      | No       | No          | Project, scope       | —           | Weight    | Yes       |
 | Gitea           | Yes    | No            | No         | No       | No       | No          | Repo, scope, labels  | Last 100    | —         | —         |
 | OpenProject     | Yes    | Yes           | Yes        | No       | No       | Yes         | Scope, status        | —           | Yes       | Yes       |
 | CalDAV          | Yes    | Config        | No         | No       | No       | No          | Category             | —           | —         | Yes       |
@@ -54,7 +54,7 @@ Every issue provider supports the same basic operations: checking that the integ
 ### 3. GitLab
 
 - **Issue import:** Full import from projects (cloud or self-hosted).
-- **Status transitions:** Issues auto-marked as done when closed in GitLab.
+- **Status transitions:** Not supported. Closing an issue in GitLab does not complete the linked task, and completing the task does not close the issue.
 - **Worklog:** Previously supported; now deprecated.
 - **Comments:** Comment tracking with optional filter by username.
 - **Filtering:** Project-based; scope (All, Assigned, Created); custom filter parameters.

--- a/src/app/features/issue/base/base-issue-provider.service.ts
+++ b/src/app/features/issue/base/base-issue-provider.service.ts
@@ -113,15 +113,18 @@ export abstract class BaseIssueProviderService<
     }
 
     if (this._wasUpdated(task, issue)) {
-      // Exclude dueDay/dueWithTime from polling updates to prevent overwriting
-      // user-set schedules. Due dates are only set on initial task creation.
-      // Providers that need to sync due dates during polling (e.g. Calendar)
-      // override this method with their own change detection logic.
+      // Exclude dueDay/dueWithTime/isDone from polling updates to prevent
+      // overwriting user-set state. These are set on initial task creation only.
+      // Completion is the user's call, not the tracker's (#9909).
+      // Providers that need to sync due dates or completion during polling
+      // (e.g. Calendar, CalDAV, Plainspace, Nextcloud Deck) override this method
+      // with their own change detection logic.
       const taskData: Partial<TaskCopy> & { title: string } = {
         ...this.getAddTaskData(issue as IssueDataReduced),
       };
       delete taskData.dueDay;
       delete taskData.dueWithTime;
+      delete taskData.isDone;
       return {
         taskChanges: {
           ...taskData,

--- a/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.spec.ts
+++ b/src/app/features/issue/providers/gitlab/gitlab-common-interfaces.service.spec.ts
@@ -169,5 +169,27 @@ describe('GitlabCommonInterfacesService', () => {
       expect(issue.commentsNr).toBe(1);
       expect(result?.issueTitle).toBe('#42 GitLab issue');
     });
+
+    it('does not overwrite isDone when an open issue is updated (#9909)', async () => {
+      const issueLastUpdated = new Date(BASE_UPDATED_AT).getTime();
+      gitlabApiService.getById$.and.returnValue(of(makeIssue(NEWER_UPDATED_AT)));
+
+      const result = await service.getFreshDataForIssueTask(makeTask(issueLastUpdated));
+
+      expect(result?.taskChanges.issueWasUpdated).toBe(true);
+      expect('isDone' in result!.taskChanges).toBe(false);
+    });
+
+    it('does not overwrite isDone when a closed issue is updated (#9909)', async () => {
+      const issueLastUpdated = new Date(BASE_UPDATED_AT).getTime();
+      gitlabApiService.getById$.and.returnValue(
+        of({ ...makeIssue(NEWER_UPDATED_AT), state: 'closed' }),
+      );
+
+      const result = await service.getFreshDataForIssueTask(makeTask(issueLastUpdated));
+
+      expect(result?.taskChanges.issueWasUpdated).toBe(true);
+      expect('isDone' in result!.taskChanges).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Problem

Fixes #9909. When a polled GitLab issue's `updated_at` changes (comment, label, reassignment), `BaseIssueProviderService.getFreshDataForIssueTask` writes the whole `getAddTaskData()` payload back onto the task. GitLab emits `isDone: issue.state === 'closed'` there, so any change to a still-open issue un-completes a task the user marked done. Conversely, a task the user reopened gets re-completed while its issue stays closed.

## Solution

As suggested in https://github.com/super-productivity/super-productivity/issues/9909#issuecomment-5632909778: `isDone` is now excluded from polling updates, together with `dueDay`/`dueWithTime`. Completion is the user's call, not the tracker's. Providers that sync completion on purpose (CalDAV, Plainspace, Nextcloud Deck) override the refresh path and are not affected. Jira, Redmine and OpenProject also use the base path but don't emit `isDone` from `getAddTaskData`, so this only changes behaviour for GitLab.

**Trade-off:** closing a GitLab issue no longer auto-completes the linked task. `docs/wiki/3.07-Issue-Integration-Comparison.md` described that behaviour ("Issues auto-marked as done when closed in GitLab", matrix `Auto (closed)`). I updated both places to match.

Out of scope: #9774 (plugin adapter has its own refresh path).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

Tests: two new cases in `gitlab-common-interfaces.service.spec.ts` (open and closed issue with a bumped `updated_at` → no `isDone` in `taskChanges`). Both fail without the fix. All 488 specs under `src/app/features/issue` pass.

🤖 Created in collaboration with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rz6i2vGpyVysirEz4XrRqo
