### PR TITLE
feat(local-rest-api): log one debug line per request #9947

### DIFF
--- a/electron/local-rest-api.ts
+++ b/electron/local-rest-api.ts
@@ -1,5 +1,5 @@
 import { app, ipcMain } from 'electron';
-import { log, warn } from 'electron-log/main';
+import { debug, log, warn } from 'electron-log/main';
 import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
 import { randomBytes, randomUUID, timingSafeEqual } from 'crypto';
 import {
@@ -315,6 +315,9 @@ const writeJson = (
   body: LocalRestApiResponsePayload['body'],
   extraHeaders: Record<string, string> = {},
 ): void => {
+  if ('error' in body) {
+    responseErrorCodes.set(res, body.error.code);
+  }
   const responseJson = JSON.stringify(body);
   res.writeHead(status, {
     ...JSON_HEADERS,
@@ -323,6 +326,43 @@ const writeJson = (
     ...extraHeaders,
   });
   res.end(responseJson);
+};
+
+// The envelope's error code for each response, so the request log says why a
+// request failed and not just its status.
+const responseErrorCodes = new WeakMap<ServerResponse, string>();
+
+// The route a request hit, with the task id replaced, so the log records what a
+// client called without recording which tasks it touched. Mirrors the renderer's
+// dispatch, which reads the second segment under /tasks as the task id.
+const toRoutePattern = (pathname: string): string => {
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments[0] === 'tasks' && segments.length >= 2) {
+    return ['', 'tasks', ':id', ...segments.slice(2)].join('/');
+  }
+  return pathname;
+};
+
+// One line per request, including those rejected before reaching the renderer:
+//   [local-rest-api] POST /tasks/:id/archive 200 3ms
+//   [local-rest-api] GET /tasks/:id 404 TASK_NOT_FOUND 2ms
+// Never the Authorization header, the query string or the body.
+const logRequest = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  startedAt: number,
+): void => {
+  try {
+    const { pathname } = new URL(req.url ?? '/', `http://${LOCAL_REST_API_HOST}`);
+    const outcome = res.writableFinished ? String(res.statusCode) : 'aborted';
+    const code = responseErrorCodes.get(res);
+    debug(
+      `[local-rest-api] ${req.method ?? 'GET'} ${toRoutePattern(pathname)} ${outcome}` +
+        `${code ? ` ${code}` : ''} ${Date.now() - startedAt}ms`,
+    );
+  } catch (error) {
+    warn('[local-rest-api] Could not log request', error);
+  }
 };
 
 // RFC 7235 requires a challenge on every 401. It also tells the scripts written
@@ -485,6 +525,10 @@ const handleHttpRequest = async (
   req: IncomingMessage,
   res: ServerResponse,
 ): Promise<void> => {
+  const startedAt = Date.now();
+  // 'close' rather than 'finish', so a client that hangs up is logged too.
+  res.once('close', () => logRequest(req, res, startedAt));
+
   // Reject everything while disabled. server.close() stops accepting new
   // sockets, but an in-flight keep-alive connection could still be served
   // during the close window; this makes the off switch immediate.


### PR DESCRIPTION
## Problem

Closes #9947.

The Local REST API writes its "Listening on" line at startup and nothing per request, so when a bug is triggered through the API the log holds no record of which requests were in flight.

## Solution

One `debug` line per request, from `electron/local-rest-api.ts`:

```
[local-rest-api] POST /tasks/:id/archive 200 3ms
[local-rest-api] GET /tasks/:id 404 TASK_NOT_FOUND 2ms
[local-rest-api] GET /status 401 UNAUTHORIZED 0ms
[local-rest-api] GET /tasks aborted 51ms
```

- **Every request**, including the ones rejected before they reach the renderer (401, 403, 429, 503, 400). The listener is registered at the top of `handleHttpRequest`.
- **Route, not path.** The task id is replaced with `:id`. This mirrors the renderer's own dispatch in `LocalRestApiHandlerService._routeRequest`, which treats the second segment under `/tasks` as the task id, so the exportable log records what a client called, not which tasks it touched.
- **The envelope's error code** is included next to the status. `writeJson` records it in a `WeakMap` keyed by the response, so every response path gets it without threading it through.
- **Logged on `'close'`** rather than `'finish'`, so a client that hangs up shows as `aborted` instead of vanishing.
- **Never logged:** the `Authorization` header, the query string, the body.

One thing that differs from the issue's assumption: electron-log's file transport defaults to level `silly` and the app doesn't lower it, so these `debug` lines do end up in `main.log`, not just when logging is turned up. Each line carries only method, route pattern, status, error code and duration, nothing identifying, so I kept it at `debug` rather than add another switch. If you'd rather keep it out of the default log, I'm happy to gate it differently.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [ ] I have added tests for my changes (if applicable)
- [ ] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

`npm run checkFile` wouldn't start here (the Angular CLI wants Node 20.19+, this machine has 20.18), so I ran what it wraps directly: `prettier --check` and `eslint` are clean on the changed file.

There is no test harness for `electron/` yet (#8735), so there is no spec here. To check the behaviour, I ran the same `writeJson` / `toRoutePattern` / `logRequest` code against a real Node `http` server: a 200 with a task id and a query string, a 404 carrying an error code, an unauthenticated request, and a client that disconnects before the response. It produced the lines above, with no task id or query value in any of them. `tsc -p electron/tsconfig.electron.json` reports no errors in this file (it has the same pre-existing unresolved `@sp/*` imports as `master`). I didn't run the Angular unit suite, since it doesn't cover `electron/`.

