### PR TITLE
ci(build): add a Windows-only dispatch path for a stranded release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,17 @@ on:
     branches: [master, release/*, test/git-actions]
     tags:
       - v*
+  # Finish the Windows half of a release whose tag run already burned its
+  # windows-bin job. Runs windows-bin alone, from the branch dispatched (so it
+  # picks up build fixes the tag predates) and attaches to the existing draft
+  # release for `release_tag`. Never moves or re-pushes the tag: that would
+  # re-fire the iOS and Android release workflows, which have already run.
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Tag of the existing DRAFT release to sign and attach Windows binaries to (e.g. v19.0.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -71,6 +82,9 @@ jobs:
 
   linux-bin-and-snap-release:
     runs-on: ubuntu-latest
+    # The only job here without a tag gate, so it would otherwise run on a
+    # Windows-only dispatch and spend ~40 minutes rebuilding what already shipped.
+    if: github.event_name != 'workflow_dispatch'
     env:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
       UNSPLASH_KEY: ${{ secrets.UNSPLASH_KEY }}
@@ -542,7 +556,12 @@ jobs:
   windows-bin:
     needs: [create-release]
     runs-on: windows-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    # create-release is skipped on a dispatch run, and a plain `if` would skip
+    # this job with it -- a status function is required to opt out of that.
+    if: >-
+      !cancelled()
+      && (needs.create-release.result == 'success' || needs.create-release.result == 'skipped')
+      && (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch')
     permissions:
       contents: write
       actions: read # Required by SignPath action
@@ -550,8 +569,37 @@ jobs:
     env:
       UNSPLASH_KEY: ${{ secrets.UNSPLASH_KEY }}
       UNSPLASH_CLIENT_ID: ${{ secrets.UNSPLASH_CLIENT_ID }}
+      # The release these binaries belong to: the pushed tag, or the one the
+      # dispatch names. github.ref_name is the branch on a dispatch run, so the
+      # publish step cannot fall back to it.
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
 
     steps:
+      # A dispatch run has no create-release job to make the draft, so the draft
+      # must already exist. Check before the build rather than after signing:
+      # a wrong tag would otherwise create a stray release, or push assets onto
+      # a published one, having already spent SignPath quota.
+      - name: Verify the target draft release exists
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$RELEASE_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::release_tag must look like v1.2.3 (got '$RELEASE_TAG')"
+            exit 1
+          fi
+          if ! IS_DRAFT=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft); then
+            echo "::error::no release found for $RELEASE_TAG"
+            exit 1
+          fi
+          if [ "$IS_DRAFT" != "true" ]; then
+            echo "::error::$RELEASE_TAG is already published -- refusing to push assets onto a live release"
+            exit 1
+          fi
+          echo "$RELEASE_TAG is a draft; proceeding"
+
       # required because setting via env.TZ does not work on windows
       - name: Set timezone to Europe Standard Time
         uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
@@ -562,6 +610,29 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
           persist-credentials: false
+
+      # Every other platform's binaries for this tag were built from the tag. This
+      # job builds from the dispatched ref instead, which is only sound while that
+      # ref differs from the tag by release tooling alone -- otherwise Windows
+      # users get app code no other platform shipped for this version.
+      - name: Verify the dispatched ref matches the tag's app code
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          echo "Commits on top of $RELEASE_TAG:"
+          git log --oneline "$RELEASE_TAG..HEAD" || true
+          DRIFT=$(git diff --name-only "$RELEASE_TAG" HEAD -- . \
+            ':(exclude).github/**' ':(exclude)tools/**' ':(exclude)docs/**' \
+            ':(exclude)e2e/**' ':(exclude)*.md')
+          if [ -n "$DRIFT" ]; then
+            echo "::error::the dispatched ref changes app code relative to $RELEASE_TAG:"
+            printf '%s\n' "$DRIFT"
+            echo "::error::dispatch from a branch off $RELEASE_TAG carrying only the release-tooling fix"
+            exit 1
+          fi
+          echo "no app-code drift from $RELEASE_TAG"
 
       - name: Setup Electron build environment
         uses: ./.github/actions/setup-electron-build
@@ -751,5 +822,6 @@ jobs:
           # or latest.yml means a published Windows release whose updater feed
           # is broken -- fail the job instead of shipping it.
           fail_on_unmatched_files: true
+          tag_name: ${{ env.RELEASE_TAG }}
           draft: true
-          prerelease: ${{ contains(github.ref, 'RC') || contains(github.ref, 'beta') || contains(github.ref, 'alpha') }}
+          prerelease: ${{ contains(env.RELEASE_TAG, 'RC') || contains(env.RELEASE_TAG, 'beta') || contains(env.RELEASE_TAG, 'alpha') }}

--- a/tools/verify-windows-artifact-contract.test.js
+++ b/tools/verify-windows-artifact-contract.test.js
@@ -219,3 +219,48 @@ test('the tool fails instead of writing metadata without executables', async (t)
     /No setup executables found/,
   );
 });
+
+// The Windows-only dispatch path finishes a release whose tag run already spent
+// its windows-bin job. Each of these is a way it silently does the wrong thing
+// rather than failing: a dispatch that rebuilds everything, one that publishes to
+// a release named after the branch, or one that skips the only job it exists for.
+test('the Windows-only dispatch path stays windows-only', () => {
+  const linuxJob = RELEASE_WORKFLOW.indexOf('  linux-bin-and-snap-release:');
+  const macJob = RELEASE_WORKFLOW.indexOf('  mac-bin:');
+  assert.notEqual(linuxJob, -1, 'linux job not found');
+  assert.match(
+    RELEASE_WORKFLOW.slice(linuxJob, macJob),
+    /if: github\.event_name != 'workflow_dispatch'/,
+    'the linux job has no tag gate, so it must opt out of dispatch runs explicitly',
+  );
+});
+
+test('a dispatch run publishes to the named release, not to the dispatched branch', () => {
+  assert.match(
+    RELEASE_WORKFLOW,
+    /RELEASE_TAG: \$\{\{ inputs\.release_tag \|\| github\.ref_name \}\}/,
+  );
+  assert.match(RELEASE_WORKFLOW, /tag_name: \$\{\{ env\.RELEASE_TAG \}\}/);
+  // github.ref_name is the branch on a dispatch run, so the publish step must not
+  // fall back to it for either the target release or the prerelease flag.
+  // Scoped to windows-bin: create-release only ever runs on a tag push, where
+  // github.ref is the tag, so its own use of it is correct.
+  const windowsJob = RELEASE_WORKFLOW.slice(RELEASE_WORKFLOW.indexOf('  windows-bin:'));
+  assert.doesNotMatch(
+    windowsJob,
+    /prerelease: \$\{\{ contains\(github\.ref/,
+    'prerelease must be derived from RELEASE_TAG, not the dispatched ref',
+  );
+  assert.match(windowsJob, /prerelease: \$\{\{ contains\(env\.RELEASE_TAG/);
+});
+
+test('windows-bin opts out of being skipped alongside create-release', () => {
+  const winJob = RELEASE_WORKFLOW.indexOf('  windows-bin:');
+  assert.notEqual(winJob, -1, 'windows job not found');
+  const gate = RELEASE_WORKFLOW.slice(winJob, winJob + 600);
+  // Without a status function the implied success() skips this job whenever
+  // create-release is skipped -- which is every dispatch run.
+  assert.match(gate, /!cancelled\(\)/);
+  assert.match(gate, /needs\.create-release\.result == 'skipped'/);
+  assert.match(gate, /github\.event_name == 'workflow_dispatch'/);
+});


### PR DESCRIPTION
## Problem

v18.22.0 and v19.0.0 both have draft releases with **no Windows binaries**. Their `windows-bin` jobs died before the publish step, and as things stand nothing can finish them:

- An Actions **re-run** replays the original commit's workflow file and tree, so it hits the same failure.
- `build.yml` has **no `workflow_dispatch`**, and `windows-bin` is gated on the ref being a tag, so a dispatch from `master` would skip it.
- `manual-build.yml` builds Windows but neither signs via SignPath nor uploads to a release.

Moving the tag is the obvious escape and the wrong one. A tag push also fires `build-ios.yml` — which already uploaded v19.0.0 and **submitted it for App Store review** — and `build-android.yml`, whose hardcoded `versionCode 19_00_00_9000` Play rejects on a second upload. Both would run again to fix a Windows build script.

## Solution

`workflow_dispatch` with a required `release_tag`, running `windows-bin` alone against the branch dispatched rather than the tag, attaching to the draft release that tag already has.

Wiring, each piece load-bearing:

- `create-release` is skipped on a dispatch run, so `windows-bin`'s gate needs an explicit status function — a plain `if` implies `success()` and would skip the job along with its dependency.
- `linux-bin-and-snap-release` is the only job with no tag gate of its own, so it opts out of dispatch runs explicitly. Otherwise a Windows-only dispatch spends ~40 minutes rebuilding what already shipped.
- The publish step takes the release tag from `RELEASE_TAG`, not `github.ref_name`, which on a dispatch run is the *branch*. Same for the prerelease flag.

Two preflights, both before the build and long before SignPath:

1. **The target release must exist and still be a draft.** A dispatch has no `create-release` to make one, so a typo would otherwise create a stray release or push assets onto a published one.
2. **The dispatched ref must not differ from the tag in app code.** This is what makes building from a branch sound at all: every other platform's binaries for the tag were built *from the tag*, so drift would ship Windows users code no one else got for that version. Release tooling (`.github/`, `tools/`, `docs/`, `e2e/`, `*.md`) is allowed to differ — that's the point.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, release tooling only
- [ ] I have run `npm run checkFile` on changed `.ts`/`.scss` files — n/a, none changed; Prettier run on both files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

## Verification

The drift preflight was run against the real repository, not reasoned about: `master` differs from `v19.0.0` in exactly `.github/workflows/build.yml`, `tools/finalize-windows-release-metadata.js`, `tools/lighthouse/{budget.json,.lighthouserc.json}` and `tools/verify-windows-artifact-contract.test.js` — so the check passes today — and it fails as intended against a ref touching `src/`, `android/` and `package.json`.

`tools/verify-windows-artifact-contract.test.js` is 11/11 green. Three new tests pin the ways this path silently does the wrong thing rather than failing — a dispatch that rebuilds everything, one that publishes to a release named after the branch, one that skips the only job it exists for — and each was confirmed to fail against the mutation it catches. Both new shell steps pass `bash -n`; the workflow parses.

Not verified here: an actual dispatch run, which needs this merged first.

## Usage

Actions → *Build All & Release* → Run workflow, from `master`, with `release_tag: v19.0.0`. Then finalize metadata over the signed output, create the legacy aliases, and check `latest.yml`'s `sha512`/`size` against the attached setup `.exe` before publishing the draft — that file silently breaks auto-update for every Windows user if it is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvVQtnEjh2MZgrvuhjiLXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvVQtnEjh2MZgrvuhjiLXU)_