### PR TITLE
test(e2e): derive the #10047 reschedule time from now instead of a fixed UTC hour

### DIFF
--- a/e2e/tests/calendar/issue-10047-poll-reschedule-remind-at.spec.ts
+++ b/e2e/tests/calendar/issue-10047-poll-reschedule-remind-at.spec.ts
@@ -36,25 +36,49 @@ const UID = 'e2e-10047-event';
 const PANEL_BTN = '.e2e-toggle-issue-provider-panel';
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const ONE_HOUR_MS = 60 * 60 * 1000;
 
 const pad = (n: number): string => String(n).padStart(2, '0');
 
 const icalDate = (d: Date): string =>
   `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}`;
 
+const icalDateTimeUtc = (d: Date): string =>
+  `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}T` +
+  `${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}Z`;
+
 // Toggled by the test once the task has auto-imported, to simulate the event
 // gaining a start time on the remote calendar.
 let icsPhase: 'allDay' | 'timed' = 'allDay';
+
+/**
+ * The timed DTSTART, frozen on first use so every poll in one run sees the same
+ * remote event and the reschedule is applied exactly once.
+ *
+ * It must be derived from `now` rather than written as a fixed UTC hour: the
+ * suite rotates the wall-clock timezone (`e2e/utils/test-timezone.ts`) so local
+ * time lands near midday, so a literal like `T180000Z` falls on the *next* local
+ * day in the eastern candidates (the run that caught this was Pacific/Guadalcanal,
+ * UTC+11). The task then leaves the Today list and the assertion below cannot
+ * see it — a failure that has nothing to do with the reminder under test.
+ * `now + 1h` stays on today's local date with ~10h of margin to midnight.
+ */
+let timedStart: Date | null = null;
 
 const buildIcal = (): string => {
   const now = new Date();
   const today = icalDate(now);
   const tomorrow = icalDate(new Date(now.getTime() + ONE_DAY_MS));
 
+  timedStart = timedStart ?? new Date(now.getTime() + ONE_HOUR_MS);
+
   const [dtstart, dtend] =
     icsPhase === 'allDay'
       ? [`DTSTART;VALUE=DATE:${today}`, `DTEND;VALUE=DATE:${tomorrow}`]
-      : [`DTSTART:${today}T180000Z`, `DTEND:${today}T190000Z`];
+      : [
+          `DTSTART:${icalDateTimeUtc(timedStart)}`,
+          `DTEND:${icalDateTimeUtc(new Date(timedStart.getTime() + ONE_HOUR_MS))}`,
+        ];
 
   return [
     'BEGIN:VCALENDAR',
@@ -76,6 +100,10 @@ test.describe('Calendar #10047', () => {
     workViewPage,
     taskPage,
   }) => {
+    // Module-level feed state, so reset it for a retry of this same test.
+    icsPhase = 'allDay';
+    timedStart = null;
+
     await page.route(ICAL_URL, (route) =>
       route.fulfill({
         status: 200,


### PR DESCRIPTION
The spec wrote the rescheduled event as `DTSTART:${today}T180000Z`, with
`today` taken from the *local* date. The suite rotates the wall-clock
timezone so local time lands near midday
(`e2e/utils/test-timezone.ts`), so in the eastern candidates 18:00Z is
already the next local day: run 34667476491 picked Pacific/Guadalcanal
(UTC+11, 13:22 local), where the poll scheduled the task for tomorrow
05:00. The task left the Today list, the alarm icon it asserts never
rendered there, and the job went red — nothing to do with the reminder
under test, which the store confirms was set correctly.

Derive the timed DTSTART from `now + 1h` and emit it in UTC. The picked
zone keeps local time within ~2h of midday, so the event stays on today's
local date in every candidate while remaining in the future. Frozen on
first use so the two polls in a run see one stable event rather than a
start time that drifts with the clock.

Also reset the module-level feed state at the top of the test: it was
left at `timed` after a first attempt, so a retry would have started from
the wrong phase and failed for a second unrelated reason.

Verified failing-then-passing locally in Pacific/Guadalcanal (the zone
the CI run used) and passing in Asia/Dhaka and Pacific/Honolulu, the
opposite end of the rotation.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019GeLHPkKHfjCLkfBeVH8ro