### PR TITLE
fix(task-detail): don't steal focus back from a field the user re-entered

### DIFF
--- a/e2e/tests/task-detail/live-markdown-editor-9910.spec.ts
+++ b/e2e/tests/task-detail/live-markdown-editor-9910.spec.ts
@@ -39,9 +39,16 @@ test.describe('Live markdown editor (#9910)', () => {
     await page.keyboard.press('Enter');
     await page.keyboard.type('- [ ] a checklist item');
 
-    // Blur, so no line is revealed as raw source any more.
+    // Blur, so no line is revealed as raw source any more. Escape hands focus
+    // back to the detail panel's notes item 150ms later; wait for that settled
+    // state, or the panel grabs focus in the middle of the click below.
     await page.keyboard.press('Escape');
     await editor.blur();
+    await expect
+      .poll(() =>
+        page.evaluate(() => document.activeElement?.tagName.toLowerCase() ?? ''),
+      )
+      .toBe('task-detail-item');
 
     // The heading renders as a heading and its `#` marker is hidden from view,
     // even though the note's text still holds it.

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.spec.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.spec.ts
@@ -514,6 +514,45 @@ describe('TaskDetailPanelComponent stale-focus guard', () => {
 
     expect(focusItemSpy).not.toHaveBeenCalled();
   }));
+
+  // Escape in the notes editor blurs it and hands focus back to the notes item
+  // 150ms later. Clicking straight back into the editor inside that window must
+  // not have the caret yanked out again by the pending timer.
+  it('does not steal focus from a text field focused while the timer is pending', fakeAsync(() => {
+    (component as unknown as { itemEls: () => TaskDetailItemComponent[] }).itemEls =
+      () => [makeItem()];
+    const focusItemSpy = spyOn(component, 'focusItem');
+    const editable = document.createElement('div');
+    editable.contentEditable = 'true';
+    editable.tabIndex = 0;
+    document.body.appendChild(editable);
+
+    (component as unknown as { _focusFirst: () => void })._focusFirst();
+    // ...the user clicks back into the editor before the timer fires.
+    editable.focus();
+
+    tick(200);
+
+    expect(focusItemSpy).not.toHaveBeenCalled();
+    editable.remove();
+  }));
+
+  it('still focuses the panel item when focus is not in a text field', fakeAsync(() => {
+    (component as unknown as { itemEls: () => TaskDetailItemComponent[] }).itemEls =
+      () => [makeItem()];
+    const focusItemSpy = spyOn(component, 'focusItem');
+    const item = document.createElement('div');
+    item.tabIndex = 0;
+    document.body.appendChild(item);
+
+    (component as unknown as { _focusFirst: () => void })._focusFirst();
+    item.focus();
+
+    tick(200);
+
+    expect(focusItemSpy).toHaveBeenCalled();
+    item.remove();
+  }));
 });
 
 // Opening the notes panel via a checklist's progress badge routes through

--- a/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
+++ b/src/app/features/tasks/task-detail-panel/task-detail-panel.component.ts
@@ -822,6 +822,14 @@ export class TaskDetailPanelComponent implements OnInit, AfterViewInit, OnDestro
       if (this.isAddSubtaskInputVisible()) {
         return;
       }
+      // Nor from any other text field the user moved into while this timer was
+      // pending. Escape in the notes editor blurs it and schedules this focus
+      // 150ms out; clicking straight back into the notes inside that window
+      // would otherwise have the caret yanked out again.
+      const activeEl = document.activeElement;
+      if (activeEl instanceof HTMLElement && isInputElement(activeEl)) {
+        return;
+      }
       if (this.task().id === scheduledForTaskId) {
         focusFn();
       }


### PR DESCRIPTION
The notes editor's Escape blurs it and schedules the panel's focus 150ms
out (keyboardUnToggle -> focusItem). Clicking straight back into the
notes inside that window let the pending timer yank the caret out again,
leaving the live markdown editor unfocused — so no line revealed its raw
source. That is what made the #9910 e2e "renders markdown inline and
toggles a checklist item from its checkbox" fail in CI: the click landed
within the 150ms window and the editor never regained focus.

Guard the deferred focus the same way the add-subtask draft already is:
skip it when a text field owns focus by the time the timer fires. The
normal Escape path is unaffected — the blur runs synchronously, so focus
is on <body> when the timer fires.

Also wait for the focus handoff to settle in the e2e before clicking
back into the editor, matching the sibling test in the same file.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S6Zuokdh89fbNrzKUshfWU