### PR TITLE
test(e2e): clamp the #10047 event to the local day and drop a false retry rationale

### DIFF
--- a/e2e/tests/calendar/issue-10047-poll-reschedule-remind-at.spec.ts
+++ b/e2e/tests/calendar/issue-10047-poll-reschedule-remind-at.spec.ts
@@ -52,25 +52,39 @@ const icalDateTimeUtc = (d: Date): string =>
 let icsPhase: 'allDay' | 'timed' = 'allDay';
 
 /**
- * The timed DTSTART, frozen on first use so every poll in one run sees the same
- * remote event and the reschedule is applied exactly once.
+ * The timed DTSTART has to satisfy two things at once:
  *
- * It must be derived from `now` rather than written as a fixed UTC hour: the
- * suite rotates the wall-clock timezone (`e2e/utils/test-timezone.ts`) so local
- * time lands near midday, so a literal like `T180000Z` falls on the *next* local
- * day in the eastern candidates (the run that caught this was Pacific/Guadalcanal,
- * UTC+11). The task then leaves the Today list and the assertion below cannot
- * see it — a failure that has nothing to do with the reminder under test.
- * `now + 1h` stays on today's local date with ~10h of margin to midnight.
+ * - it must fall on **today's local date**. `dueWithTime` beats `dueDay` in
+ *   `selectLaterTodayStructure`, so an event on tomorrow drops the task off the
+ *   Today list and the icon asserted below is simply not on screen — a failure
+ *   that looks exactly like the #10047 regression but is not one. That is the
+ *   bug a literal `T180000Z` had: the suite rotates the wall clock
+ *   (`e2e/utils/test-timezone.ts`) and 18:00Z is the next local day in the three
+ *   eastern candidates (Dhaka, Shanghai, Guadalcanal — a third of all runs, and
+ *   every scheduled one, since the 02:00 UTC cron always picks Guadalcanal).
+ * - it must stay in the **future**, or the derived `remindAt` fires immediately.
+ *
+ * `now + 1h` satisfies both only while local time is before 23:00. The zone
+ * picker keeps local time in [10:00, 14:00), so that always holds in CI — but
+ * `E2E_TZ` pins an arbitrary zone, and there one hour in every 24 puts
+ * `now + 1h` on tomorrow. Clamp to the local day and assert the precondition, so
+ * a run that cannot express this scenario says so instead of failing as a
+ * phantom #10047 regression.
  */
-let timedStart: Date | null = null;
+const buildTimedStart = (now: Date): Date => {
+  const lastMinuteOfLocalDay = new Date(now);
+  lastMinuteOfLocalDay.setHours(23, 59, 0, 0);
+  const oneHourOut = new Date(now.getTime() + ONE_HOUR_MS);
+  return oneHourOut <= lastMinuteOfLocalDay ? oneHourOut : lastMinuteOfLocalDay;
+};
+
+/** Fixed once per run, so both polls in a run see one stable remote event. */
+let timedStart = new Date();
 
 const buildIcal = (): string => {
   const now = new Date();
   const today = icalDate(now);
   const tomorrow = icalDate(new Date(now.getTime() + ONE_DAY_MS));
-
-  timedStart = timedStart ?? new Date(now.getTime() + ONE_HOUR_MS);
 
   const [dtstart, dtend] =
     icsPhase === 'allDay'
@@ -100,9 +114,18 @@ test.describe('Calendar #10047', () => {
     workViewPage,
     taskPage,
   }) => {
-    // Module-level feed state, so reset it for a retry of this same test.
+    // Module-level feed state. Playwright re-imports the spec module for every
+    // retry and every worker (and `retries` is 0 here anyway), so this matters
+    // only if a second test is ever added to this file — two tests in one file
+    // do share a module instance.
     icsPhase = 'allDay';
-    timedStart = null;
+    const now = new Date();
+    timedStart = buildTimedStart(now);
+    expect(
+      timedStart.getDate(),
+      'started too close to local midnight to express this scenario',
+    ).toBe(now.getDate());
+    expect(timedStart.getTime()).toBeGreaterThan(now.getTime());
 
     await page.route(ICAL_URL, (route) =>
       route.fulfill({


### PR DESCRIPTION
Follow-up to #10078. An adversarial review of that change turned up two problems with it.

## Problem

**1. `now + 1h` is only safe while local time is before 23:00.**

The zone picker (`e2e/utils/test-timezone.ts`) keeps CI in `[10:00, 14:00)` local, so #10078 is sound on every scheduled run — a sweep of all 1440 minutes of the day against the picker's exact reduce gives 0 crossings of local midnight, worst-case margin 9h01m. But `e2e/global-setup.ts` documents `E2E_TZ` as *the* way to reproduce a timezone-dependent bug, and under a pinned zone one hour in every 24 (4.2% of the day, independent of offset) puts `now + 1h` on tomorrow.

Reproduced at `E2E_TZ=America/Adak`, local 23:32: `dueWithTime` moves to the next local day, `dueWithTime` beats `dueDay` in `selectLaterTodayStructure`, the task leaves the Today list, and the alarm assertion fails with `element(s) not found` — bit-for-bit the signature of the bug it is meant to detect. A phantom #10047 regression, on the one path a developer reaches for when chasing a real one.

**2. The retry justification in #10078 was wrong.**

It claimed the module-level feed state had to be reset because "it was left at `timed` after a first attempt, so a retry would have started from the wrong phase". Playwright re-imports the spec module for every retry and every worker — verified by probing `process.pid` plus a per-module-load id across `--retries` and `--repeat-each` — and `e2e/playwright.config.ts` sets `retries: 0` deliberately. That reset could never have fired for the stated reason.

## Solution

Clamp the timed `DTSTART` to 23:59 local and assert the precondition, so a run too close to midnight to express the scenario says so instead of failing as a regression.

Keep the state reset — it becomes load-bearing the moment a second test joins this file, since two tests in one file *do* share a module instance (also verified) — but state the reason that is actually true. Per `AGENTS.md` → "Hardening needs an observed instance", a guard ships with a real occurrence behind it or not at all.

Verified passing at `E2E_TZ=America/Adak` (local 23:48), where the merged version fails, and at `Asia/Shanghai` (16:49). The five rotation zones not covered by #10078 — `America/Regina`, `America/Sao_Paulo`, `Africa/Lagos`, `Africa/Nairobi`, `Asia/Shanghai` — all pass.

The same review confirmed the spec is not a false-negative machine: reverting the `IssueService._updateTaskFromPoll` fix makes it fail in both `Africa/Nairobi` and `Pacific/Guadalcanal`, with the task rendering under `Later Today (1)` showing the `@else if (t.dueWithTime)` reschedule branch and no `alarm`.

Test-only change; no product code touched.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki). — n/a, no user-facing change
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable) — the change *is* to a test
- [x] Existing tests still pass
- [x] My commit messages follow the Angular format (`type(scope): description`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GeLHPkKHfjCLkfBeVH8ro


---
_Generated by [Claude Code](https://claude.ai/code/session_019GeLHPkKHfjCLkfBeVH8ro)_