### PR TITLE
feat(planner): add keyboard navigation, shortcuts, and multiselect

### DIFF
--- a/docs/plans/2026-09-12-planner-keyboard-navigation.md
+++ b/docs/plans/2026-09-12-planner-keyboard-navigation.md
@@ -171,3 +171,17 @@ border and color as regular tasks. The changed TS/SCSS files pass `checkFile`.
 
 The scope exclusions above remain intentional: deadline markers, calendar events,
 repeat previews, bulk drag, full inline task editing, and touch selection parity.
+
+## Post-review corrections
+
+- Timed day moves use the actual scheduled date when the displayed logical day
+  differs, and preserve modern `remindAt` values, including disabled reminders.
+- Keyboard completion of overdue tasks recovers focus when the card is removed
+  after its animation; moving focus elsewhere keeps that new focus.
+- Bulk-menu focus recovery reuses `findLiveRowEl()` to exclude destroyed hosts.
+- Removed the unused mutation focus option. Planner DOM traversal remains scoped
+  to participating cards; this correction adds no registry or navigation layer.
+
+Regression tests reproduce the date/reminder and delayed-completion failures, and
+the bulk-menu tests cover replacement rows while old hosts remain rendered. A
+browser regression exercises actual overdue completion and subsequent focus.

--- a/docs/plans/2026-09-12-planner-keyboard-navigation.md
+++ b/docs/plans/2026-09-12-planner-keyboard-navigation.md
@@ -1,0 +1,173 @@
+# Planner keyboard navigation and multiselect
+
+## Objective
+
+Make Planner's real task cards usable with the keyboard and the existing task
+multiselect actions, keeping the compact Planner layout and existing shortcut
+configuration. Implementation is authorized by the request to write and execute
+this plan using Sol.
+
+## Scope and behavior
+
+- Include overdue, all-day, and timed task cards in Planner.
+- Tab can enter task cards; Up/Down follows the day's real tasks in visual order.
+  Left/Right moves between days, skipping days without real task cards and choosing
+  the corresponding row where possible. Navigation scrolls the destination into view.
+- Existing next/previous-task bindings work. Inputs and open menus/dialogs retain
+  their normal keyboard behavior; custom shortcut bindings retain precedence.
+- Reuse configured shortcuts for completion, time tracking, scheduling (including
+  today/tomorrow/next week/next month, deadline, and unschedule), delete, estimates,
+  and context menus. Enter opens task details so editing remains keyboard accessible.
+- Reorder shortcuts use existing Planner ordering actions for all-day tasks, with
+  Today's existing ordering semantics. Timed tasks retain chronological ordering.
+- Ctrl+Shift+Left/Right moves the focused task one calendar day earlier/later,
+  preserving timed tasks' clock time and reminder and restoring focus after moving.
+- Ctrl/Cmd-click and X toggle a task. Shift-click and Shift+Up/Down select ranges
+  within one day, including its all-day and timed task cards. Ctrl/Cmd+A selects
+  that day's real tasks. Overdue is its own selection scope.
+- Ctrl/Cmd-click can retain selections across days. Escape clears selection.
+  Selection styling, bulk toolbar, and existing bulk actions work for Planner.
+- Single-click focuses a task card; double-click opens its details. Enter also
+  opens details. Embedded controls retain their own focus and behavior. Modifier
+  selection must not open details, toggle completion, or activate links/drag.
+- Completing, deleting, or rescheduling tasks preserves useful focus and removes
+  selection only when the task no longer has a live selectable card. Closing the
+  bulk menu restores focus without stealing it from dialogs or inputs.
+- Deadline markers may duplicate a task shown elsewhere; they are not selectable
+  task cards in this increment. Calendar events and repeat projections are also
+  outside task multiselect. Existing interactions remain available.
+- Boards and the scheduled-list page also use PlannerTaskComponent. Enable this
+  behavior explicitly for Planner so those views retain their current behavior.
+- No new settings, dependencies, persisted fields, sync operations, or bulk drag.
+  Full inline task-row editing and touch selection parity are outside this scope.
+
+## Implementation approach
+
+Reuse TaskMultiSelectService, TaskBulkActionService, and the app-shell bulk bar.
+Extend their row discovery/focus handling to explicitly participating Planner cards.
+Keep Planner-specific navigation and reorder behavior close to Planner. Avoid
+making Planner pretend to be the full TaskComponent or copying that component's
+entire shortcut implementation. Extract only a small shared boundary if needed by
+both real consumers. Reuse existing action services and dialogs for mutations.
+
+## Ordered slices
+
+### 1. Focusable Planner cards and navigation
+
+Dependencies: none. Likely files: Planner task/day components and a focused
+navigation collaborator/spec if necessary (split wiring from navigation logic).
+
+- [x] Add Planner-only focus participation and visible focus styling.
+- [x] Implement within-day and between-day navigation, including unequal/empty days.
+- [x] Keep input, dialog, menu, and other-view behavior intact.
+
+Verification: failing behavior tests followed by focused unit tests; browser
+navigation through overdue, all-day, and timed cards, including scroll boundaries.
+
+### 2. Selection and the existing bulk UI
+
+Dependencies: slice 1. Likely files: TaskMultiSelectService/spec and Planner card
+component/template/style. Keep shared changes minimal and preserve regular lists.
+
+- [x] Implement modifier clicks, X, range extension, select-all, and Escape.
+- [x] Use a day as the range boundary and task IDs as the bulk action identity.
+- [x] Show existing selection feedback and bulk UI; prevent selection clicks from
+      triggering ordinary card or embedded-control actions.
+
+Verification: focused service/component tests for day boundaries, mixed sections,
+cross-day selection, details-panel exclusion, and nonparticipating Planner cards.
+
+Checkpoint: navigation and selection work together before adding more shortcuts.
+
+### 3. Task shortcuts and Planner ordering
+
+Dependencies: slices 1-2. Likely files: TaskShortcutService/spec plus Planner
+shortcut collaborator and day component. Split routing and ordering work if needed.
+
+- [x] Route the in-scope configured shortcuts to the actual focused Planner card.
+- [x] Existing bulk-capable shortcuts apply to selected tasks, preserving the rule
+      that a focused unselected task is acted on individually.
+- [x] Reorder all-day cards through existing Planner/Today actions, preserving focus;
+      never reorder timed cards through task-list ordering commands.
+
+Verification: focused tests for custom bindings, single/bulk targeting, stale task
+focus, overlays, and Planner ordering. Do not alter sync reducers or operation
+semantics; if that becomes necessary, first reproduce a concrete state failure and
+read the contributor sync model.
+
+### 4. Focus restoration and lifecycle
+
+Dependencies: slices 1-3. Likely files: bulk action service/spec, bulk bar/spec, and
+Planner card lifecycle implementation/spec.
+
+- [x] Restore focus after single and bulk removal, rescheduling, and menu closure.
+- [x] Prune removed cards while preserving moved cards; avoid detail-panel copies
+      and detached/destroyed hosts as focus targets.
+- [x] Keep navigation-change clearing and standard task-list behavior working.
+
+Verification: meaningful removal/move/menu regression tests and browser exercises.
+
+### 5. Documentation and integrated verification
+
+Dependencies: slices 1-4. Likely files: keyboard shortcuts wiki, focused Planner
+E2E spec, and this plan's execution record.
+
+- [x] Document supported keys, selection scope, and excluded Planner item types.
+- [x] Run checkFile on every modified TypeScript/SCSS file and format other files.
+- [x] Run affected unit suites, TypeScript/Angular checks as appropriate, and a
+      focused browser/E2E flow covering navigation, selection, and a bulk mutation.
+- [x] Review the diff for unnecessary abstractions, regressions in shared task
+      lists/Boards/scheduled list, and focus or selection performance problems.
+
+## Risks and verification priorities
+
+Focus identity must follow the actual card, not a stale full-task component. Planner
+timed tasks use wrappers, so direct-child task-list queries cannot simply be reused.
+Selection restoration must tolerate cards moving between days. Shared task-row
+changes must avoid adding per-row DOM scans or hot-path change-detection work.
+No sync format changes are expected; exercise existing scheduling and ordering
+actions through resulting UI/state behavior, not dispatch assertions alone.
+
+## Execution record
+
+Completed on 2026-09-12 by Sol implementation and E2E workers, with independent
+parent review and live-browser verification. All five slices are complete.
+
+The implementation spans ten production files because Planner cards and the shared
+shortcut, selection, bulk-action, and focus paths all needed integration. The
+remaining changes are tests and documentation. No task-list component hot-path
+changes or sync-format changes were needed.
+
+Verification passed:
+
+- 175 unit tests across seven suites: PlannerTask (25), TaskBulkAction (28),
+  TaskShortcut (53), TaskMultiSelect (33), TaskMultiSelectBar (7), PlannerDay (3),
+  and BoardPanel (26).
+- Six Planner E2E scenarios and two existing normal-list multiselect regressions,
+  with retries disabled. The Planner scenarios cover all-day/timed navigation,
+  within-day and cross-day selection, bulk completion, J/K and confirmed deletion,
+  unscheduling with focus recovery, and visible all-day reordering.
+- `npm run checkFile` on every changed TypeScript/SCSS file, including the E2E spec.
+- `npm run buildFrontend:dev`, `npm run docs:check-links`, and `git diff --check`.
+- Independent browser checks confirmed visible focus/selection, day-scoped select-all,
+  bulk menu focus restoration, and deleting every Planner card returning focus to
+  the existing Add button. The selection screenshot was inspected at 1280 × 800.
+
+Review corrections included Today ordering's insert-before semantics, native input
+selection under Shift-click, custom Meta bindings during input editing, preserving
+clock time/reminders during date shortcuts, and focus recovery after the last card
+is removed. Bulk focus fallbacks are passed with each action rather than retained
+as mutable service state.
+
+Follow-up: single-click now focuses Planner cards and double-click opens details;
+Enter remains available. Embedded controls keep their own interactions, and other
+views retain single-click detail opening. The expanded PlannerTask suite passes
+all 30 tests; live browser checks confirm the click and double-click behavior.
+
+Additional follow-up: Ctrl+Shift+Left/Right shifts the focused task by one day.
+The PlannerTask suite now passes all 35 tests, and a new browser regression verifies
+consecutive moves in both directions with retained focus. Focus uses the same thin
+border and color as regular tasks. The changed TS/SCSS files pass `checkFile`.
+
+The scope exclusions above remain intentional: deadline markers, calendar events,
+repeat previews, bulk drag, full inline task editing, and touch selection parity.

--- a/docs/wiki/3.03-Keyboard-Shortcuts.md
+++ b/docs/wiki/3.03-Keyboard-Shortcuts.md
@@ -118,6 +118,21 @@ All other task shortcuts keep acting on the focused task only.
 - `ArrowRight`: Open additional info panel for currently focused task
 - `Ctrl`+`C` / `Cmd`+`C`: Copy the currently focused task and its sub tasks to the clipboard as a markdown checklist (e.g. `- [ ] Parent`, with each sub task indented by two spaces as `- [x] Sub task`) when focus is on the task, no text is selected, and focus is not inside an input
 
+## Planner
+
+Planner supports keyboard navigation and task multiselect on overdue, all-day, and timed task cards. Click a card or use `Tab` to focus it. Double-click a card to open its details, or use these keyboard controls:
+
+- `ArrowUp` / `ArrowDown`, or your previous/next task shortcuts (`K` / `J` by default): Move between tasks in the same day.
+- `ArrowLeft` / `ArrowRight`: Move to a task in the previous/next day containing tasks.
+- `Enter`: Open task details.
+- `Ctrl+Shift+Left` / `Ctrl+Shift+Right`: Move the focused task one day earlier or later, preserving its scheduled time and reminder.
+- Task shortcuts for completion, time tracking, scheduling, deadlines, unscheduling, deletion, estimates, and the context menu use your configured bindings.
+- Task movement shortcuts reorder all-day tasks within their day. Timed tasks keep their time order.
+
+The selection controls listed under _Selecting several tasks_ also work in Planner. Shift-click, Shift+Up/Down, and Ctrl/Cmd+A stay within the focused day's tasks, including all-day and timed cards. Overdue tasks form a separate selection group. Ctrl/Cmd-click can build a selection across days. The existing bulk actions menu and bulk-capable shortcuts act on that selection.
+
+Deadline markers, calendar events, and repeat previews are outside task multiselect. The same task can appear both as a task card and a deadline marker. Planner's compact cards open details with Enter rather than editing the title inline.
+
 ## Collapsible Groups
 
 The following shortcuts apply when focus is on a collapsible group header (e.g., task groupings in Work View like From previous days, Today, Done, Recurring, etc.).

--- a/e2e/tests/planner/planner-keyboard-navigation.spec.ts
+++ b/e2e/tests/planner/planner-keyboard-navigation.spec.ts
@@ -185,6 +185,31 @@ test.describe('Planner keyboard navigation', () => {
     await expect(cards.nth(1)).toBeFocused();
   });
 
+  test('restores focus after the completion animation removes an overdue card', async ({
+    page,
+    workViewPage,
+    testPrefix,
+  }) => {
+    await workViewPage.waitForTaskList();
+    const remainingTitle = `${testPrefix}-Completion remaining`;
+    const overdueTitle = `${testPrefix}-Completion overdue`;
+    await workViewPage.addTask(remainingTitle);
+    await workViewPage.addTask(overdueTitle);
+    await openPlanner(page);
+
+    const overdueCard = cardWithTitle(page, overdueTitle);
+    const remainingCard = cardWithTitle(page, remainingTitle);
+    await overdueCard.click();
+    await page.keyboard.press('Control+Shift+ArrowLeft');
+    await expect(page.locator('planner-day-overdue').locator(overdueCard)).toBeVisible();
+    await expect(overdueCard).toBeFocused();
+
+    await page.keyboard.press('d');
+
+    await expect(overdueCard).toHaveCount(0);
+    await expect(remainingCard).toBeFocused();
+  });
+
   test('moves a focused all-day task between calendar days and keeps focus', async ({
     page,
     workViewPage,

--- a/e2e/tests/planner/planner-keyboard-navigation.spec.ts
+++ b/e2e/tests/planner/planner-keyboard-navigation.spec.ts
@@ -1,0 +1,234 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect, test } from '../../fixtures/test.fixture';
+import { PlannerPage } from '../../pages/planner.page';
+
+const selectableCards = (page: Page): Locator =>
+  page.locator('planner-task[data-task-selectable="true"]');
+
+const cardWithTitle = (page: Page, title: string): Locator =>
+  selectableCards(page).filter({ hasText: title });
+
+const openPlanner = async (page: Page): Promise<void> => {
+  const plannerPage = new PlannerPage(page);
+  await plannerPage.navigateToPlanner();
+  await plannerPage.waitForPlannerView();
+  await expect(selectableCards(page).first()).toBeVisible();
+};
+
+test.describe('Planner keyboard navigation', () => {
+  test('navigates through all-day and timed cards and across day boundaries', async ({
+    page,
+    workViewPage,
+    testPrefix,
+  }) => {
+    await workViewPage.waitForTaskList();
+    const todayFirst = `${testPrefix}-Today first`;
+    const todaySecond = `${testPrefix}-Today second`;
+    const tomorrowAllDay = `${testPrefix}-Tomorrow all day`;
+    const tomorrowTimed = `${testPrefix}-Tomorrow timed`;
+    await workViewPage.addTask(todayFirst);
+    await workViewPage.addTask(todaySecond);
+    await workViewPage.addTask(`${tomorrowAllDay} @tomorrow`, false, null);
+    await workViewPage.addTask(`${tomorrowTimed} @tomorrow 12:00`, false, null);
+
+    await openPlanner(page);
+
+    const first = cardWithTitle(page, todaySecond);
+    const second = cardWithTitle(page, todayFirst);
+    const tomorrowFirst = cardWithTitle(page, tomorrowAllDay);
+    const tomorrowSecond = cardWithTitle(page, tomorrowTimed);
+    await expect(first).toBeVisible();
+    await expect(tomorrowSecond).toBeVisible();
+
+    await first.focus();
+    await page.keyboard.press('ArrowRight');
+    await expect(tomorrowFirst).toBeFocused();
+    await page.keyboard.press('ArrowDown');
+    await expect(tomorrowSecond).toBeFocused();
+    await page.keyboard.press('ArrowLeft');
+    await expect(second).toBeFocused();
+    await page.keyboard.press('ArrowUp');
+    await expect(first).toBeFocused();
+    await page.keyboard.press('ArrowDown');
+    await expect(second).toBeFocused();
+  });
+
+  test('keeps ranges within a day while modifier click can select across days', async ({
+    page,
+    workViewPage,
+    testPrefix,
+  }) => {
+    await workViewPage.waitForTaskList();
+    const todayTitles = ['Range one', 'Range two', 'Range three'].map(
+      (title) => `${testPrefix}-${title}`,
+    );
+    const tomorrowTitle = `${testPrefix}-Cross-day task`;
+    for (const title of todayTitles) {
+      await workViewPage.addTask(title);
+    }
+    await workViewPage.addTask(`${tomorrowTitle} @tomorrow`, false, null);
+    await openPlanner(page);
+
+    const todayCards = todayTitles.map((title) => cardWithTitle(page, title));
+    await todayCards[2].click({ modifiers: ['Control'] });
+    await todayCards[0].click({ modifiers: ['Shift'] });
+    for (const card of todayCards) {
+      await expect(card).toHaveClass(/isMultiSelected/);
+    }
+
+    const tomorrowCard = cardWithTitle(page, tomorrowTitle);
+    await tomorrowCard.click({ modifiers: ['Control'] });
+    await expect(tomorrowCard).toHaveClass(/isMultiSelected/);
+    await expect(page.locator('task-multi-select-bar')).toContainText('4');
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('task-multi-select-bar')).toBeHidden();
+    for (const card of [...todayCards, tomorrowCard]) {
+      await expect(card).not.toHaveClass(/isMultiSelected/);
+    }
+  });
+
+  test('selects a day with Ctrl+A and completes it while preserving card focus', async ({
+    page,
+    workViewPage,
+    testPrefix,
+  }) => {
+    await workViewPage.waitForTaskList();
+    const firstTitle = `${testPrefix}-Bulk first`;
+    const secondTitle = `${testPrefix}-Bulk second`;
+    const tomorrowTitle = `${testPrefix}-Bulk tomorrow`;
+    await workViewPage.addTask(firstTitle);
+    await workViewPage.addTask(secondTitle);
+    await workViewPage.addTask(`${tomorrowTitle} @tomorrow`, false, null);
+    await openPlanner(page);
+
+    const focusedCard = cardWithTitle(page, secondTitle);
+    await focusedCard.focus();
+    await page.keyboard.press('Control+a');
+    await expect(page.locator('task-multi-select-bar')).toContainText('2');
+
+    await page.keyboard.press('d');
+    await expect(cardWithTitle(page, firstTitle)).toHaveClass(/isDone/);
+    await expect(focusedCard).toHaveClass(/isDone/);
+    await expect(cardWithTitle(page, tomorrowTitle)).not.toHaveClass(/isDone/);
+    await expect(focusedCard).toBeFocused();
+  });
+
+  test('uses configured J and K navigation and restores focus after deleting a card', async ({
+    page,
+    workViewPage,
+    testPrefix,
+  }) => {
+    await workViewPage.waitForTaskList();
+    const olderTitle = `${testPrefix}-Delete older`;
+    const newerTitle = `${testPrefix}-Delete newer`;
+    await workViewPage.addTask(olderTitle);
+    await workViewPage.addTask(newerTitle);
+    await openPlanner(page);
+
+    const newerCard = cardWithTitle(page, newerTitle);
+    const olderCard = cardWithTitle(page, olderTitle);
+    await newerCard.focus();
+    await page.keyboard.press('j');
+    await expect(olderCard).toBeFocused();
+    await page.keyboard.press('k');
+    await expect(newerCard).toBeFocused();
+
+    await page.keyboard.press('Backspace');
+    await expect(page.locator('mat-dialog-container')).toBeVisible();
+    await page.locator('[e2e="confirmBtn"]').click();
+    await expect(newerCard).toHaveCount(0);
+    await expect(olderCard).toBeFocused();
+  });
+
+  test('restores focus to the adjacent card after unscheduling the focused task', async ({
+    page,
+    workViewPage,
+    testPrefix,
+  }) => {
+    await workViewPage.waitForTaskList();
+    const remainingTitle = `${testPrefix}-Unschedule remaining`;
+    const removedTitle = `${testPrefix}-Unschedule removed`;
+    await workViewPage.addTask(remainingTitle);
+    await workViewPage.addTask(removedTitle);
+    await openPlanner(page);
+
+    const removedCard = cardWithTitle(page, removedTitle);
+    const remainingCard = cardWithTitle(page, remainingTitle);
+    await removedCard.focus();
+    await page.keyboard.press('u');
+
+    await expect(removedCard).toHaveCount(0);
+    await expect(remainingCard).toBeFocused();
+  });
+
+  test('reorders all-day cards with the configured move shortcut', async ({
+    page,
+    workViewPage,
+    testPrefix,
+  }) => {
+    await workViewPage.waitForTaskList();
+    const olderTitle = `${testPrefix}-Reorder older`;
+    const newerTitle = `${testPrefix}-Reorder newer`;
+    await workViewPage.addTask(olderTitle);
+    await workViewPage.addTask(newerTitle);
+    await openPlanner(page);
+
+    const cards = selectableCards(page);
+    await expect(cards).toHaveCount(2);
+    await expect(cards.nth(0)).toContainText(newerTitle);
+    await cards.nth(0).focus();
+    await page.keyboard.press('Control+Shift+ArrowDown');
+
+    await expect(cards.nth(0)).toContainText(olderTitle);
+    await expect(cards.nth(1)).toContainText(newerTitle);
+    await expect(cards.nth(1)).toBeFocused();
+  });
+
+  test('moves a focused all-day task between calendar days and keeps focus', async ({
+    page,
+    workViewPage,
+    testPrefix,
+  }) => {
+    await workViewPage.waitForTaskList();
+    const taskTitle = `${testPrefix}-Move between days`;
+    await workViewPage.addTask(taskTitle);
+    await openPlanner(page);
+
+    const card = cardWithTitle(page, taskTitle);
+    const dates = await page
+      .locator('planner-day[data-day]')
+      .evaluateAll((days) =>
+        days.map((day) => day.getAttribute('data-day')).filter((day) => day !== null),
+      );
+    const initialDate = await card
+      .locator('xpath=ancestor::planner-day')
+      .getAttribute('data-day');
+    const initialIndex = dates.indexOf(initialDate ?? '');
+    expect(initialIndex).toBeGreaterThanOrEqual(0);
+    expect(dates.length).toBeGreaterThan(initialIndex + 2);
+
+    await card.click();
+    await expect(card).toBeFocused();
+    await page.keyboard.press('Control+Shift+ArrowRight');
+    await expect(card.locator('xpath=ancestor::planner-day')).toHaveAttribute(
+      'data-day',
+      dates[initialIndex + 1],
+    );
+    await expect(card).toBeFocused();
+
+    await page.keyboard.press('Control+Shift+ArrowRight');
+    await expect(card.locator('xpath=ancestor::planner-day')).toHaveAttribute(
+      'data-day',
+      dates[initialIndex + 2],
+    );
+    await expect(card).toBeFocused();
+
+    await page.keyboard.press('Control+Shift+ArrowLeft');
+    await expect(card.locator('xpath=ancestor::planner-day')).toHaveAttribute(
+      'data-day',
+      dates[initialIndex + 1],
+    );
+    await expect(card).toBeFocused();
+  });
+});

--- a/src/app/features/boards/board-panel/board-panel.component.spec.ts
+++ b/src/app/features/boards/board-panel/board-panel.component.spec.ts
@@ -24,6 +24,27 @@ import { WorkContextService } from '../../work-context/work-context.service';
 import { ProjectService } from '../../project/project.service';
 import { signal } from '@angular/core';
 import { TODAY_TAG } from '../../tag/tag.const';
+import { GlobalConfigService } from '../../config/global-config.service';
+import { DateService } from '../../../core/date/date.service';
+import { DateAdapter } from '@angular/material/core';
+
+const PLANNER_TASK_PROVIDERS = [
+  {
+    provide: GlobalConfigService,
+    useValue: {
+      cfg: () => null,
+      appFeatures: () => ({ isTimeTrackingEnabled: false }),
+    },
+  },
+  {
+    provide: DateService,
+    useValue: { todayStr: () => '2026-09-12' },
+  },
+  {
+    provide: DateAdapter,
+    useValue: { getFirstDayOfWeek: () => 1, getDayOfWeek: () => 1 },
+  },
+];
 
 describe('BoardPanelComponent - Backlog Feature', () => {
   let component: BoardPanelComponent;
@@ -107,6 +128,7 @@ describe('BoardPanelComponent - Backlog Feature', () => {
         }),
       ],
       providers: [
+        ...PLANNER_TASK_PROVIDERS,
         provideMockStore({}),
         provideMockActions(() => actions$),
         { provide: Store, useValue: storeMock },
@@ -266,6 +288,7 @@ describe('BoardPanelComponent - Hidden Project Backlog', () => {
         }),
       ],
       providers: [
+        ...PLANNER_TASK_PROVIDERS,
         provideMockStore({}),
         provideMockActions(() => actions$),
         { provide: Store, useValue: storeMock },
@@ -358,6 +381,7 @@ describe('BoardPanelComponent - Tag match mode, sort, inline-create computeds', 
         }),
       ],
       providers: [
+        ...PLANNER_TASK_PROVIDERS,
         provideMockStore({}),
         provideMockActions(() => actions$),
         { provide: Store, useValue: storeMock },
@@ -775,6 +799,7 @@ describe('BoardPanelComponent - drop()', () => {
         }),
       ],
       providers: [
+        ...PLANNER_TASK_PROVIDERS,
         provideMockStore({}),
         provideMockActions(() => actions$),
         { provide: Store, useValue: storeMock },

--- a/src/app/features/planner/planner-day-overdue/planner-day-overdue.component.html
+++ b/src/app/features/planner/planner-day-overdue/planner-day-overdue.component.html
@@ -10,7 +10,10 @@
   </div>
 </header>
 
-<div class="normal-tasks">
+<div
+  class="normal-tasks"
+  data-planner-selection-scope="overdue"
+>
   <div
     class="normal-tasks-items"
     cdkDropList

--- a/src/app/features/planner/planner-day/planner-day.component.html
+++ b/src/app/features/planner/planner-day/planner-day.component.html
@@ -62,6 +62,7 @@
         [cdkDragLockAxis]="isXs() ? 'y' : ''"
         [task]="task"
         [day]="day.dayDate"
+        [focusable]="true"
       ></planner-task>
     }
 
@@ -145,6 +146,7 @@
               cdkDrag
               [task]="scheduledItem.task"
               [day]="day.dayDate"
+              [focusable]="true"
               [cdkDragData]="scheduledItem.task"
               [cdkDragStartDelay]="dragDelayForTouch()"
               [cdkDragLockAxis]="isXs() ? 'y' : ''"

--- a/src/app/features/planner/planner-day/planner-day.component.ts
+++ b/src/app/features/planner/planner-day/planner-day.component.ts
@@ -78,6 +78,11 @@ export class PlannerDayComponent {
     return this.day?.dayDate;
   }
 
+  @HostBinding('attr.data-planner-selection-scope')
+  get selectionScopeAttr(): string | undefined {
+    return this.day?.dayDate;
+  }
+
   protected readonly T = T;
   protected readonly SCHEDULE_ITEM_TYPE = ScheduleItemType;
   protected readonly dragDelayForTouch = dragDelayForTouch;

--- a/src/app/features/planner/planner-task/planner-task.component.html
+++ b/src/app/features/planner/planner-task/planner-task.component.html
@@ -10,6 +10,7 @@
   <div class="task-content">
     <done-toggle
       [isDone]="task().isDone"
+      [isMultiSelectAware]="focusable()"
       [isCurrent]="isCurrent()"
       [showDoneAnimation]="showDoneAnimation()"
       [showUndoneAnimation]="showUndoneAnimation()"

--- a/src/app/features/planner/planner-task/planner-task.component.scss
+++ b/src/app/features/planner/planner-task/planner-task.component.scss
@@ -29,6 +29,15 @@
   }
 }
 
+:host:focus {
+  outline: none;
+  border: 1px solid var(--palette-primary-400);
+}
+
+:host.isMultiSelected {
+  box-shadow: inset 0 0 0 var(--focus-ring-width) var(--focus-ring-color);
+}
+
 :host.isDragReady:not(.cdk-drag-placeholder) {
   background: var(--bg-lighter);
   box-shadow: var(--whiteframe-shadow-8dp);

--- a/src/app/features/planner/planner-task/planner-task.component.spec.ts
+++ b/src/app/features/planner/planner-task/planner-task.component.spec.ts
@@ -1,7 +1,7 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA, signal, WritableSignal } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { PlannerTaskComponent } from './planner-task.component';
 import { TaskService } from '../../tasks/task.service';
 import { DEFAULT_TASK, TaskCopy } from '../../tasks/task.model';
@@ -9,6 +9,22 @@ import { DoneToggleComponent } from '../../../ui/done-toggle/done-toggle.compone
 import { MsToStringPipe } from '../../../ui/duration/ms-to-string.pipe';
 import { RenderLinksPipe } from '../../../ui/pipes/render-links.pipe';
 import { TranslatePipe } from '@ngx-translate/core';
+import { GlobalConfigService } from '../../config/global-config.service';
+import { MatDialog } from '@angular/material/dialog';
+import { Store } from '@ngrx/store';
+import { DateService } from '../../../core/date/date.service';
+import { DateAdapter } from '@angular/material/core';
+import { TaskMultiSelectService } from '../../tasks/task-multi-select.service';
+import { DEFAULT_GLOBAL_CONFIG } from '../../config/default-global-config.const';
+import { PlannerActions } from '../store/planner.actions';
+import {
+  moveTaskDownInTodayList,
+  moveTaskToBottomInTodayList,
+  moveTaskToTopInTodayList,
+  moveTaskUpInTodayList,
+} from '../../work-context/store/work-context-meta.actions';
+import { WorkContextType } from '../../work-context/work-context.model';
+import { TODAY_TAG } from '../../tag/tag.const';
 
 const makeTask = (overrides: Partial<TaskCopy> = {}): TaskCopy =>
   ({
@@ -22,15 +38,35 @@ const makeTask = (overrides: Partial<TaskCopy> = {}): TaskCopy =>
 describe('PlannerTaskComponent', () => {
   let currentTaskId: WritableSignal<string | null>;
   let taskServiceMock: { toggleDoneWithAnimation: jasmine.Spy };
+  let storeMock: jasmine.SpyObj<Store>;
+  let matDialogMock: jasmine.SpyObj<MatDialog>;
+  let config: typeof DEFAULT_GLOBAL_CONFIG;
+  let logicalToday: Date;
+  let firstDayOfWeek: number;
+  let multiSelectMock: {
+    selectedIds: WritableSignal<Set<string>>;
+    isActive: WritableSignal<boolean>;
+    toggle: jasmine.Spy;
+    selectRange: jasmine.Spy;
+    clear: jasmine.Spy;
+    has: jasmine.Spy;
+    requestMenuOpen: jasmine.Spy;
+    removeWhenUnrendered: jasmine.Spy;
+    findLiveRowEl: jasmine.Spy;
+  };
 
   const create = (
     task: TaskCopy,
+    focusable = false,
+    day?: string,
   ): {
     fixture: ComponentFixture<PlannerTaskComponent>;
     component: PlannerTaskComponent;
   } => {
     const fixture = TestBed.createComponent(PlannerTaskComponent);
     fixture.componentRef.setInput('task', task);
+    fixture.componentRef.setInput('focusable', focusable);
+    fixture.componentRef.setInput('day', day);
     fixture.detectChanges();
     return { fixture, component: fixture.componentInstance };
   };
@@ -40,17 +76,64 @@ describe('PlannerTaskComponent', () => {
     taskServiceMock = {
       ...jasmine.createSpyObj('TaskService', [
         'setSelectedId',
+        'setCurrentId',
+        'scheduleForTodayById',
+        'scheduleTask',
+        'remove',
         'toggleDoneWithAnimation',
         'update',
       ]),
       currentTaskId,
       getByIdLive$: () => of(null),
+      getByIdWithSubTaskData$: () => of(null),
+    };
+    config = DEFAULT_GLOBAL_CONFIG;
+    logicalToday = new Date(2026, 8, 12);
+    firstDayOfWeek = 1;
+    storeMock = jasmine.createSpyObj('Store', ['dispatch']);
+    matDialogMock = jasmine.createSpyObj('MatDialog', ['open']);
+    multiSelectMock = {
+      selectedIds: signal(new Set<string>()),
+      isActive: signal(false),
+      toggle: jasmine.createSpy('toggle'),
+      selectRange: jasmine.createSpy('selectRange'),
+      clear: jasmine.createSpy('clear'),
+      has: jasmine.createSpy('has').and.returnValue(false),
+      requestMenuOpen: jasmine.createSpy('requestMenuOpen'),
+      removeWhenUnrendered: jasmine.createSpy('removeWhenUnrendered'),
+      findLiveRowEl: jasmine.createSpy('findLiveRowEl').and.returnValue(null),
     };
 
     TestBed.configureTestingModule({
       imports: [PlannerTaskComponent, TranslateModule.forRoot()],
       schemas: [NO_ERRORS_SCHEMA],
-      providers: [{ provide: TaskService, useValue: taskServiceMock }],
+      providers: [
+        { provide: TaskService, useValue: taskServiceMock },
+        {
+          provide: GlobalConfigService,
+          useValue: {
+            cfg: () => config,
+            appFeatures: () => ({ isTimeTrackingEnabled: true }),
+          },
+        },
+        { provide: MatDialog, useValue: matDialogMock },
+        { provide: Store, useValue: storeMock },
+        {
+          provide: DateService,
+          useValue: {
+            getLogicalTodayDate: () => new Date(logicalToday),
+            todayStr: () => '2026-09-12',
+          },
+        },
+        {
+          provide: DateAdapter,
+          useValue: {
+            getFirstDayOfWeek: () => firstDayOfWeek,
+            getDayOfWeek: (date: Date) => date.getDay(),
+          },
+        },
+        { provide: TaskMultiSelectService, useValue: multiSelectMock },
+      ],
     });
 
     // Isolate the component from its heavyweight child components (tag-list etc.)
@@ -66,6 +149,384 @@ describe('PlannerTaskComponent', () => {
         schemas: [NO_ERRORS_SCHEMA],
       },
     });
+  });
+
+  describe('Planner keyboard shortcuts', () => {
+    const shortcutEvent = (key: string): CustomEvent<{ keyboardEvent: KeyboardEvent }> =>
+      new CustomEvent('planner-task-shortcut', {
+        cancelable: true,
+        detail: {
+          keyboardEvent: new KeyboardEvent('keydown', {
+            key,
+            code: key.startsWith('F') ? key : `Key${key}`,
+          }),
+        },
+      });
+
+    const moveDayEvent = (
+      component: PlannerTaskComponent,
+      key: 'ArrowLeft' | 'ArrowRight',
+      target?: HTMLElement,
+    ): KeyboardEvent => {
+      const event = new KeyboardEvent('keydown', {
+        key,
+        code: key,
+        ctrlKey: true,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const host = (
+        component as unknown as { _elementRef: { nativeElement: HTMLElement } }
+      )._elementRef.nativeElement;
+      Object.defineProperty(event, 'target', { value: target ?? host });
+      return event;
+    };
+
+    for (const [key, expectedDay] of [
+      ['ArrowLeft', '2025-12-31'],
+      ['ArrowRight', '2026-01-02'],
+    ] as const) {
+      it(`moves an all-day Planner card one day with ${key}`, () => {
+        const task = makeTask();
+        const { component } = create(task, true, '2026-01-01');
+        const event = moveDayEvent(component, key);
+
+        component.onKeydown(event);
+
+        expect(storeMock.dispatch).toHaveBeenCalledWith(
+          PlannerActions.planTaskForDay({ task, day: expectedDay, isShowSnack: true }),
+        );
+        expect(event.defaultPrevented).toBeTrue();
+      });
+    }
+
+    it('uses an overdue timed task date and preserves its local time and reminder', () => {
+      const dueWithTime = new Date(2025, 11, 31, 23, 15).getTime();
+      const thirtyMinutes = 30 * 60 * 1000;
+      const task = makeTask({
+        dueWithTime,
+        reminderId: 'reminder',
+        remindAt: dueWithTime - thirtyMinutes,
+      });
+      const { component } = create(task, true, '');
+
+      component.onKeydown(moveDayEvent(component, 'ArrowRight'));
+
+      expect(taskServiceMock['scheduleTask']).toHaveBeenCalledWith(
+        task,
+        new Date(2026, 0, 1, 23, 15).getTime(),
+        'm30',
+        false,
+      );
+    });
+
+    it('leaves the move-day shortcut untouched in an input and for opt-out cards', () => {
+      const optedIn = create(makeTask(), true, '2026-01-01').component;
+      const input = document.createElement('input');
+      const inputEvent = moveDayEvent(optedIn, 'ArrowRight', input);
+      optedIn.onKeydown(inputEvent);
+
+      const optedOut = create(makeTask(), false, '2026-01-01').component;
+      const optOutEvent = moveDayEvent(optedOut, 'ArrowRight');
+      optedOut.onKeydown(optOutEvent);
+
+      expect(storeMock.dispatch).not.toHaveBeenCalled();
+      expect(inputEvent.defaultPrevented).toBeFalse();
+      expect(optOutEvent.defaultPrevented).toBeFalse();
+    });
+
+    it('lets a configured shortcut override the move-day combination', () => {
+      config = {
+        ...DEFAULT_GLOBAL_CONFIG,
+        keyboard: {
+          ...DEFAULT_GLOBAL_CONFIG.keyboard,
+          taskToggleDone: 'Ctrl+Shift+ArrowRight',
+        },
+      };
+      const { component } = create(makeTask(), true, '2026-01-01');
+      const event = moveDayEvent(component, 'ArrowRight');
+
+      component.onKeydown(event);
+
+      expect(storeMock.dispatch).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBeFalse();
+    });
+
+    it('plans an all-day task for tomorrow with the existing Planner action', () => {
+      config = {
+        ...DEFAULT_GLOBAL_CONFIG,
+        keyboard: { ...DEFAULT_GLOBAL_CONFIG.keyboard, taskScheduleTomorrow: 'M' },
+      };
+      const { component } = create(makeTask());
+
+      component.onTaskShortcut(shortcutEvent('m'));
+
+      expect(storeMock.dispatch).toHaveBeenCalledWith(
+        PlannerActions.planTaskForDay({
+          task: makeTask(),
+          day: '2026-09-13',
+          isShowSnack: true,
+        }),
+      );
+    });
+
+    it('uses the locale first weekday when planning for next week', () => {
+      logicalToday = new Date(2026, 8, 13); // Sunday
+      firstDayOfWeek = 1; // Monday
+      config = {
+        ...DEFAULT_GLOBAL_CONFIG,
+        keyboard: { ...DEFAULT_GLOBAL_CONFIG.keyboard, taskScheduleNextWeek: 'W' },
+      };
+      const task = makeTask();
+      const { component } = create(task);
+
+      component.onTaskShortcut(shortcutEvent('w'));
+
+      expect(storeMock.dispatch).toHaveBeenCalledWith(
+        PlannerActions.planTaskForDay({
+          task,
+          day: '2026-09-14',
+          isShowSnack: true,
+        }),
+      );
+    });
+
+    it('plans next month for the first day across a year boundary', () => {
+      logicalToday = new Date(2026, 11, 31);
+      config = {
+        ...DEFAULT_GLOBAL_CONFIG,
+        keyboard: { ...DEFAULT_GLOBAL_CONFIG.keyboard, taskScheduleNextMonth: 'M' },
+      };
+      const task = makeTask();
+      const { component } = create(task);
+
+      component.onTaskShortcut(shortcutEvent('m'));
+
+      expect(storeMock.dispatch).toHaveBeenCalledWith(
+        PlannerActions.planTaskForDay({
+          task,
+          day: '2027-01-01',
+          isShowSnack: true,
+        }),
+      );
+    });
+
+    it('preserves a timed task time and reminder offset when moving it', () => {
+      const dueWithTime = new Date(2026, 8, 12, 14, 45).getTime();
+      const thirtyMinutes = 30 * 60 * 1000;
+      const task = makeTask({
+        dueWithTime,
+        reminderId: 'reminder',
+        remindAt: dueWithTime - thirtyMinutes,
+      });
+      config = {
+        ...DEFAULT_GLOBAL_CONFIG,
+        keyboard: { ...DEFAULT_GLOBAL_CONFIG.keyboard, taskScheduleTomorrow: 'M' },
+      };
+      const { component } = create(task);
+
+      component.onTaskShortcut(shortcutEvent('m'));
+
+      expect(taskServiceMock['scheduleTask']).toHaveBeenCalledWith(
+        task,
+        new Date(2026, 8, 13, 14, 45).getTime(),
+        'm30',
+        false,
+      );
+    });
+
+    it('does not consume time tracking when the feature is disabled', () => {
+      TestBed.overrideProvider(GlobalConfigService, {
+        useValue: {
+          cfg: () => ({
+            ...DEFAULT_GLOBAL_CONFIG,
+            keyboard: { ...DEFAULT_GLOBAL_CONFIG.keyboard, togglePlay: 'Y' },
+          }),
+          appFeatures: () => ({ isTimeTrackingEnabled: false }),
+        },
+      });
+      const { component } = create(makeTask());
+      const event = shortcutEvent('y');
+
+      component.onTaskShortcut(event);
+
+      expect(event.defaultPrevented).toBeFalse();
+    });
+
+    it('routes the native context-menu key to the Planner card menu', () => {
+      const { component } = create(makeTask());
+      spyOn(component, 'openContextMenu');
+      const event = new CustomEvent<{ keyboardEvent: KeyboardEvent }>(
+        'planner-task-shortcut',
+        {
+          cancelable: true,
+          detail: {
+            keyboardEvent: new KeyboardEvent('keydown', {
+              key: 'ContextMenu',
+              code: 'ContextMenu',
+            }),
+          },
+        },
+      );
+
+      component.onTaskShortcut(event);
+
+      expect(event.defaultPrevented).toBeTrue();
+    });
+
+    it('focuses the local add button when a schedule dialog moves the last card', fakeAsync(() => {
+      config = {
+        ...DEFAULT_GLOBAL_CONFIG,
+        keyboard: { ...DEFAULT_GLOBAL_CONFIG.keyboard, taskSchedule: 'S' },
+      };
+      const closed = new Subject<void>();
+      matDialogMock.open.and.returnValue({ afterClosed: () => closed } as never);
+      const scope = document.createElement('planner-day');
+      scope.setAttribute('data-planner-selection-scope', '2026-09-12');
+      const add = document.createElement('button');
+      const addTask = document.createElement('add-task-inline');
+      addTask.appendChild(add);
+      scope.appendChild(addTask);
+      document.body.appendChild(scope);
+      const { fixture, component } = create(makeTask(), true);
+      scope.appendChild(fixture.nativeElement);
+      spyOn(add, 'focus');
+
+      component.onTaskShortcut(shortcutEvent('s'));
+      fixture.nativeElement.remove();
+      closed.next();
+      tick();
+
+      expect(add.focus).toHaveBeenCalled();
+      scope.remove();
+    }));
+
+    for (const [name, expectedAction] of [
+      ['up', moveTaskUpInTodayList],
+      ['down', moveTaskDownInTodayList],
+      ['top', moveTaskToTopInTodayList],
+      ['bottom', moveTaskToBottomInTodayList],
+    ] as const) {
+      it(`uses Today ordering semantics for an all-day move ${name}`, () => {
+        const scope = document.createElement('planner-day');
+        scope.setAttribute('data-planner-selection-scope', '2026-09-12');
+        const normal = document.createElement('div');
+        normal.className = 'normal-tasks';
+        scope.appendChild(normal);
+        document.body.appendChild(scope);
+        const first = document.createElement('planner-task');
+        first.setAttribute('data-task-id', 'first');
+        first.setAttribute('data-task-selectable', 'true');
+        normal.appendChild(first);
+        const { component } = create(makeTask(), true, '2026-09-12');
+        const middle = document.createElement('planner-task');
+        middle.setAttribute('data-task-id', 't1');
+        middle.setAttribute('data-task-selectable', 'true');
+        normal.appendChild(middle);
+        (
+          component as unknown as { _elementRef: { nativeElement: HTMLElement } }
+        )._elementRef.nativeElement = middle;
+        const last = document.createElement('planner-task');
+        last.setAttribute('data-task-id', 'last');
+        last.setAttribute('data-task-selectable', 'true');
+        normal.appendChild(last);
+        (
+          component as unknown as {
+            _reorderAllDay: (direction: 'up' | 'down' | 'top' | 'bottom') => void;
+          }
+        )._reorderAllDay(name);
+
+        expect(storeMock.dispatch).toHaveBeenCalledWith(
+          expectedAction({
+            taskId: 't1',
+            workContextType: WorkContextType.TAG,
+            workContextId: TODAY_TAG.id,
+            doneTaskIds: ['first', 't1', 'last'],
+          }),
+        );
+        scope.remove();
+      });
+    }
+  });
+
+  it('intercepts a modifier click before an embedded control activates', () => {
+    const { fixture } = create(makeTask(), true);
+    const embedded = fixture.nativeElement.querySelector('done-toggle') as HTMLElement;
+    embedded.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true, ctrlKey: true }),
+    );
+
+    expect(multiSelectMock.toggle).toHaveBeenCalledWith('t1');
+    expect(taskServiceMock.toggleDoneWithAnimation).not.toHaveBeenCalled();
+  });
+
+  it('preserves Shift selection inside an embedded input', () => {
+    const { fixture } = create(makeTask(), true);
+    const input = document.createElement('input');
+    fixture.nativeElement.appendChild(input);
+    const event = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+      shiftKey: true,
+    });
+
+    input.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBeFalse();
+  });
+
+  it('focuses an opted-in Planner card on a plain click', () => {
+    const { component } = create(makeTask(), true);
+    const host = (component as unknown as { _elementRef: { nativeElement: HTMLElement } })
+      ._elementRef.nativeElement;
+    spyOn(host, 'focus');
+    const title = host.querySelector('.title') as HTMLElement;
+
+    title.click();
+
+    expect(host.focus).toHaveBeenCalled();
+    expect(taskServiceMock['setSelectedId']).not.toHaveBeenCalled();
+  });
+
+  it('opens details for an opted-in Planner card on double click', () => {
+    const { fixture } = create(makeTask(), true);
+    const title = fixture.nativeElement.querySelector('.title') as HTMLElement;
+
+    title.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+
+    expect(taskServiceMock['setSelectedId']).toHaveBeenCalledOnceWith('t1');
+  });
+
+  it('does not open details for a modifier double click', () => {
+    const { fixture } = create(makeTask(), true);
+    const title = fixture.nativeElement.querySelector('.title') as HTMLElement;
+
+    title.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, ctrlKey: true }));
+
+    expect(taskServiceMock['setSelectedId']).not.toHaveBeenCalled();
+  });
+
+  it('keeps single-click detail opening for non-Planner consumers', () => {
+    const { fixture } = create(makeTask());
+    const title = fixture.nativeElement.querySelector('.title') as HTMLElement;
+
+    title.click();
+
+    expect(taskServiceMock['setSelectedId']).toHaveBeenCalledOnceWith('t1');
+  });
+
+  it('does not move focus to the card when an embedded input is clicked', () => {
+    const { component } = create(makeTask(), true);
+    const host = (component as unknown as { _elementRef: { nativeElement: HTMLElement } })
+      ._elementRef.nativeElement;
+    const input = document.createElement('input');
+    host.appendChild(input);
+    spyOn(host, 'focus');
+
+    input.click();
+
+    expect(host.focus).not.toHaveBeenCalled();
   });
 
   it('renders the template without throwing', () => {

--- a/src/app/features/planner/planner-task/planner-task.component.spec.ts
+++ b/src/app/features/planner/planner-task/planner-task.component.spec.ts
@@ -4,7 +4,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { of, Subject } from 'rxjs';
 import { PlannerTaskComponent } from './planner-task.component';
 import { TaskService } from '../../tasks/task.service';
-import { DEFAULT_TASK, TaskCopy } from '../../tasks/task.model';
+import { DEFAULT_TASK, TaskCopy, TaskReminderOptionId } from '../../tasks/task.model';
 import { DoneToggleComponent } from '../../../ui/done-toggle/done-toggle.component';
 import { MsToStringPipe } from '../../../ui/duration/ms-to-string.pipe';
 import { RenderLinksPipe } from '../../../ui/pipes/render-links.pipe';
@@ -221,6 +221,26 @@ describe('PlannerTaskComponent', () => {
       );
     });
 
+    for (const [key, expectedDate] of [
+      ['ArrowLeft', new Date(2026, 8, 13, 1, 0).getTime()],
+      ['ArrowRight', new Date(2026, 8, 15, 1, 0).getTime()],
+    ] as const) {
+      it(`moves a timed task from its scheduled date with ${key} when its displayed logical day differs`, () => {
+        const dueWithTime = new Date(2026, 8, 14, 1, 0).getTime();
+        const task = makeTask({ dueWithTime, remindAt: undefined });
+        const { component } = create(task, true, '2026-09-13');
+
+        component.onKeydown(moveDayEvent(component, key));
+
+        expect(taskServiceMock['scheduleTask']).toHaveBeenCalledWith(
+          task,
+          expectedDate,
+          TaskReminderOptionId.DoNotRemind,
+          false,
+        );
+      });
+    }
+
     it('leaves the move-day shortcut untouched in an input and for opt-out cards', () => {
       const optedIn = create(makeTask(), true, '2026-01-01').component;
       const input = document.createElement('input');
@@ -335,6 +355,190 @@ describe('PlannerTaskComponent', () => {
         false,
       );
     });
+
+    it('preserves a modern timed task reminder without a legacy reminder id', () => {
+      const dueWithTime = new Date(2026, 8, 12, 14, 45).getTime();
+      const thirtyMinutes = 30 * 60 * 1000;
+      const task = makeTask({
+        dueWithTime,
+        reminderId: null,
+        remindAt: dueWithTime - thirtyMinutes,
+      });
+      config = {
+        ...DEFAULT_GLOBAL_CONFIG,
+        keyboard: { ...DEFAULT_GLOBAL_CONFIG.keyboard, taskScheduleTomorrow: 'M' },
+      };
+      const { component } = create(task);
+
+      component.onTaskShortcut(shortcutEvent('m'));
+
+      expect(taskServiceMock['scheduleTask']).toHaveBeenCalledWith(
+        task,
+        new Date(2026, 8, 13, 14, 45).getTime(),
+        TaskReminderOptionId.m30,
+        false,
+      );
+    });
+
+    it('keeps reminders disabled when moving a modern timed task', () => {
+      const dueWithTime = new Date(2026, 8, 12, 14, 45).getTime();
+      const task = makeTask({ dueWithTime, reminderId: null, remindAt: undefined });
+      config = {
+        ...DEFAULT_GLOBAL_CONFIG,
+        keyboard: { ...DEFAULT_GLOBAL_CONFIG.keyboard, taskScheduleTomorrow: 'M' },
+      };
+      const { component } = create(task);
+
+      component.onTaskShortcut(shortcutEvent('m'));
+
+      expect(taskServiceMock['scheduleTask']).toHaveBeenCalledWith(
+        task,
+        new Date(2026, 8, 13, 14, 45).getTime(),
+        TaskReminderOptionId.DoNotRemind,
+        false,
+      );
+    });
+
+    it('moves focus after delayed completion removes the focused card', fakeAsync(() => {
+      config = {
+        ...DEFAULT_GLOBAL_CONFIG,
+        keyboard: { ...DEFAULT_GLOBAL_CONFIG.keyboard, taskToggleDone: 'D' },
+      };
+      const scope = document.createElement('planner-day-overdue');
+      scope.setAttribute('data-planner-selection-scope', '2026-09-12');
+      document.body.appendChild(scope);
+      const { fixture, component } = create(makeTask(), true);
+      const host = fixture.nativeElement as HTMLElement;
+      const next = document.createElement('planner-task');
+      next.setAttribute('data-task-id', 'next');
+      next.setAttribute('data-task-selectable', 'true');
+      scope.append(host, next);
+      multiSelectMock.findLiveRowEl.and.callFake((id: string) =>
+        id === 'next' ? next : null,
+      );
+      spyOn(next, 'focus');
+      host.focus();
+      taskServiceMock.toggleDoneWithAnimation.and.callFake(() =>
+        window.setTimeout(() => {
+          component.ngOnDestroy();
+          host.remove();
+        }, 200),
+      );
+
+      component.onTaskShortcut(shortcutEvent('d'));
+      tick(200);
+      tick();
+
+      expect(next.focus).toHaveBeenCalled();
+      scope.remove();
+    }));
+
+    it('does not steal focus after delayed completion when the user moved it', fakeAsync(() => {
+      config = {
+        ...DEFAULT_GLOBAL_CONFIG,
+        keyboard: { ...DEFAULT_GLOBAL_CONFIG.keyboard, taskToggleDone: 'D' },
+      };
+      const scope = document.createElement('planner-day-overdue');
+      scope.setAttribute('data-planner-selection-scope', '2026-09-12');
+      document.body.appendChild(scope);
+      const { fixture, component } = create(makeTask(), true);
+      const host = fixture.nativeElement as HTMLElement;
+      const next = document.createElement('planner-task');
+      next.setAttribute('data-task-id', 'next');
+      next.setAttribute('data-task-selectable', 'true');
+      const userTarget = document.createElement('button');
+      scope.append(host, next, userTarget);
+      multiSelectMock.findLiveRowEl.and.returnValue(next);
+      spyOn(next, 'focus');
+      host.focus();
+      taskServiceMock.toggleDoneWithAnimation.and.callFake(() =>
+        window.setTimeout(() => {
+          component.ngOnDestroy();
+          host.remove();
+        }, 200),
+      );
+
+      component.onTaskShortcut(shortcutEvent('d'));
+      userTarget.focus();
+      tick(200);
+      tick();
+
+      expect(next.focus).not.toHaveBeenCalled();
+      expect(document.activeElement).toBe(userTarget);
+      scope.remove();
+    }));
+
+    it('uses the move fallback when an overdue completion is still pending', fakeAsync(() => {
+      config = {
+        ...DEFAULT_GLOBAL_CONFIG,
+        keyboard: { ...DEFAULT_GLOBAL_CONFIG.keyboard, taskToggleDone: 'D' },
+      };
+      const scope = document.createElement('planner-day-overdue');
+      scope.setAttribute('data-planner-selection-scope', 'overdue');
+      document.body.appendChild(scope);
+      const task = makeTask({ dueWithTime: new Date(2026, 8, 11, 14, 45).getTime() });
+      const { fixture, component } = create(task, true, '2026-09-11');
+      const host = fixture.nativeElement as HTMLElement;
+      const next = document.createElement('planner-task');
+      next.setAttribute('data-task-id', 'next');
+      next.setAttribute('data-task-selectable', 'true');
+      const moved = document.createElement('planner-task');
+      scope.append(host, next, moved);
+      multiSelectMock.findLiveRowEl.and.callFake((id: string) =>
+        id === task.id ? moved : id === 'next' ? next : null,
+      );
+      spyOn(next, 'focus');
+      spyOn(moved, 'focus');
+      host.focus();
+      taskServiceMock['scheduleTask'].and.callFake(() => {
+        component.ngOnDestroy();
+        host.remove();
+      });
+
+      component.onTaskShortcut(shortcutEvent('d'));
+      component.onKeydown(moveDayEvent(component, 'ArrowRight'));
+      tick();
+
+      expect(moved.focus).toHaveBeenCalled();
+      expect(next.focus).not.toHaveBeenCalled();
+      scope.remove();
+    }));
+
+    it('restores focus when a moved task stays overdue until completion', fakeAsync(() => {
+      config = {
+        ...DEFAULT_GLOBAL_CONFIG,
+        keyboard: { ...DEFAULT_GLOBAL_CONFIG.keyboard, taskToggleDone: 'D' },
+      };
+      const scope = document.createElement('planner-day-overdue');
+      scope.setAttribute('data-planner-selection-scope', 'overdue');
+      document.body.appendChild(scope);
+      const task = makeTask({ dueWithTime: new Date(2026, 8, 9, 14, 45).getTime() });
+      const { fixture, component } = create(task, true, '2026-09-09');
+      const host = fixture.nativeElement as HTMLElement;
+      const next = document.createElement('planner-task');
+      next.setAttribute('data-task-id', 'next');
+      next.setAttribute('data-task-selectable', 'true');
+      scope.append(host, next);
+      multiSelectMock.findLiveRowEl.and.callFake((id: string) =>
+        id === 'next' ? next : null,
+      );
+      spyOn(next, 'focus');
+      host.focus();
+      taskServiceMock.toggleDoneWithAnimation.and.callFake(() =>
+        window.setTimeout(() => {
+          component.ngOnDestroy();
+          host.remove();
+        }, 200),
+      );
+
+      component.onTaskShortcut(shortcutEvent('d'));
+      component.onKeydown(moveDayEvent(component, 'ArrowRight'));
+      tick(200);
+      tick();
+
+      expect(next.focus).toHaveBeenCalled();
+      scope.remove();
+    }));
 
     it('does not consume time tracking when the feature is disabled', () => {
       TestBed.overrideProvider(GlobalConfigService, {

--- a/src/app/features/planner/planner-task/planner-task.component.ts
+++ b/src/app/features/planner/planner-task/planner-task.component.ts
@@ -45,7 +45,6 @@ import { getNextWeekDayOffset } from '../../../util/get-next-week-day-offset';
 import { getDbDateStr } from '../../../util/get-db-date-str';
 import { combineDateAndTime } from '../../../util/combine-date-and-time';
 import { millisecondsDiffToRemindOption } from '../../tasks/util/remind-option-to-milliseconds';
-import { DEFAULT_GLOBAL_CONFIG } from '../../config/default-global-config.const';
 import { PlannerActions } from '../store/planner.actions';
 import { DialogConfirmComponent } from '../../../ui/dialog-confirm/dialog-confirm.component';
 import { first } from 'rxjs/operators';
@@ -103,6 +102,10 @@ export class PlannerTaskComponent implements OnInit, OnDestroy, AfterViewInit {
   private _dateService = inject(DateService);
   private _dateAdapter = inject(DateAdapter);
   private _isTaskDeleteTriggered = false;
+  private _completionFocusFallback?: {
+    id: string | null;
+    element: HTMLElement | null;
+  };
 
   readonly task = input.required<TaskCopy>();
 
@@ -289,6 +292,16 @@ export class PlannerTaskComponent implements OnInit, OnDestroy, AfterViewInit {
     window.clearTimeout(this._doneAnimationTimeout);
     window.clearTimeout(this._dragReadyTimeout);
     this._touchListenerCleanups.forEach((fn) => fn());
+    if (
+      this._completionFocusFallback &&
+      document.activeElement === this._elementRef.nativeElement
+    ) {
+      this._restoreFocus(
+        this.task().id,
+        this._completionFocusFallback.id,
+        this._completionFocusFallback.element,
+      );
+    }
   }
 
   @HostListener('keydown', ['$event'])
@@ -401,7 +414,7 @@ export class PlannerTaskComponent implements OnInit, OnDestroy, AfterViewInit {
     } else if (checkKeyCombo(keyboardEvent, keys.selectNextTask)) {
       this._moveFocus('ArrowDown');
     } else if (checkKeyCombo(keyboardEvent, keys.taskToggleDone)) {
-      this._runMutationWithFocus(() => this.toggleTaskDone());
+      this._runCompletionWithFocus();
     } else if (
       checkKeyCombo(keyboardEvent, keys.togglePlay) &&
       this._configService.appFeatures().isTimeTrackingEnabled
@@ -464,10 +477,10 @@ export class PlannerTaskComponent implements OnInit, OnDestroy, AfterViewInit {
   private _moveOneDay(dayDelta: -1 | 1): void {
     const task = this.task();
     const displayedDay = this.day();
-    const baseDate = displayedDay
-      ? parseDbDateStr(displayedDay)
-      : task.dueWithTime
-        ? new Date(task.dueWithTime)
+    const baseDate = task.dueWithTime
+      ? new Date(task.dueWithTime)
+      : displayedDay
+        ? parseDbDateStr(displayedDay)
         : task.dueDay
           ? parseDbDateStr(task.dueDay)
           : null;
@@ -482,10 +495,7 @@ export class PlannerTaskComponent implements OnInit, OnDestroy, AfterViewInit {
     const task = this.task();
     if (task.dueWithTime) {
       const timestamp = combineDateAndTime(date, new Date(task.dueWithTime)).getTime();
-      const remindCfg = task.reminderId
-        ? millisecondsDiffToRemindOption(task.dueWithTime, task.remindAt)
-        : (this._configService.cfg()?.reminder.defaultTaskRemindOption ??
-          DEFAULT_GLOBAL_CONFIG.reminder.defaultTaskRemindOption!);
+      const remindCfg = millisecondsDiffToRemindOption(task.dueWithTime, task.remindAt);
       this._taskService.scheduleTask(task, timestamp, remindCfg, false);
       return;
     }
@@ -595,7 +605,7 @@ export class PlannerTaskComponent implements OnInit, OnDestroy, AfterViewInit {
     this._restoreFocus(this.task().id, null, fallbackEl);
   }
 
-  private _runMutationWithFocus(mutation: () => void, preferTask = true): void {
+  private _runMutationWithFocus(mutation: () => void): void {
     const rows = this._plannerRows();
     const host = this._elementRef.nativeElement as HTMLElement;
     const index = rows.indexOf(host);
@@ -605,7 +615,25 @@ export class PlannerTaskComponent implements OnInit, OnDestroy, AfterViewInit {
       null;
     const fallbackEl = this._localAddButton();
     mutation();
-    this._restoreFocus(preferTask ? this.task().id : null, fallbackId, fallbackEl);
+    this._restoreFocus(this.task().id, fallbackId, fallbackEl);
+  }
+
+  private _runCompletionWithFocus(): void {
+    const host = this._elementRef.nativeElement as HTMLElement;
+    if (this.task().isDone || !host.closest('planner-day-overdue')) {
+      this._runMutationWithFocus(() => this.toggleTaskDone());
+      return;
+    }
+    const rows = this._plannerRows();
+    const index = rows.indexOf(host);
+    this._completionFocusFallback = {
+      id:
+        rows[index + 1]?.getAttribute('data-task-id') ??
+        rows[index - 1]?.getAttribute('data-task-id') ??
+        null,
+      element: this._localAddButton(),
+    };
+    this.toggleTaskDone();
   }
 
   private _restoreFocus(

--- a/src/app/features/planner/planner-task/planner-task.component.ts
+++ b/src/app/features/planner/planner-task/planner-task.component.ts
@@ -30,6 +30,35 @@ import { hasLinkHints, RenderLinksPipe } from '../../../ui/pipes/render-links.pi
 import { DoneToggleComponent } from '../../../ui/done-toggle/done-toggle.component';
 import { SwipeBlockComponent } from '../../../ui/swipe-block/swipe-block.component';
 import { TranslatePipe } from '@ngx-translate/core';
+import { TaskMultiSelectService } from '../../tasks/task-multi-select.service';
+import { GlobalConfigService } from '../../config/global-config.service';
+import { checkKeyCombo } from '../../../util/check-key-combo';
+import { MatDialog } from '@angular/material/dialog';
+import { DialogScheduleTaskComponent } from '../dialog-schedule-task/dialog-schedule-task.component';
+import { DialogDeadlineComponent } from '../../tasks/dialog-deadline/dialog-deadline.component';
+import { DialogTimeEstimateComponent } from '../../tasks/dialog-time-estimate/dialog-time-estimate.component';
+import { Store } from '@ngrx/store';
+import { TaskSharedActions } from '../../../root-store/meta/task-shared.actions';
+import { DateService } from '../../../core/date/date.service';
+import { DateAdapter } from '@angular/material/core';
+import { getNextWeekDayOffset } from '../../../util/get-next-week-day-offset';
+import { getDbDateStr } from '../../../util/get-db-date-str';
+import { combineDateAndTime } from '../../../util/combine-date-and-time';
+import { millisecondsDiffToRemindOption } from '../../tasks/util/remind-option-to-milliseconds';
+import { DEFAULT_GLOBAL_CONFIG } from '../../config/default-global-config.const';
+import { PlannerActions } from '../store/planner.actions';
+import { DialogConfirmComponent } from '../../../ui/dialog-confirm/dialog-confirm.component';
+import { first } from 'rxjs/operators';
+import { isInputElement } from '../../../util/dom-element';
+import { parseDbDateStr } from '../../../util/parse-db-date-str';
+import {
+  moveTaskDownInTodayList,
+  moveTaskToBottomInTodayList,
+  moveTaskToTopInTodayList,
+  moveTaskUpInTodayList,
+} from '../../work-context/store/work-context-meta.actions';
+import { WorkContextType } from '../../work-context/work-context.model';
+import { TODAY_TAG } from '../../tag/tag.const';
 
 @Component({
   selector: 'planner-task',
@@ -50,16 +79,15 @@ import { TranslatePipe } from '@ngx-translate/core';
   ],
   /* eslint-disable @typescript-eslint/naming-convention */
   host: {
-    // data-task-id + tabindex only where the id-based schedule-today shortcut
-    // needs them (the Planner overdue list, #8851). Elsewhere data-task-id
-    // must stay absent: the e2e page object (e2e/pages/task.page.ts) picks its
-    // done-confirmation strategy based on its presence, and tabindex would add
-    // a Tab stop to every planner-day/scheduled card board-wide.
+    // Planner explicitly opts cards into keyboard and selection behavior.
+    // Other PlannerTask consumers (Boards and scheduled-list) stay unchanged.
     '[attr.data-task-id]': 'focusable() ? task().id : null',
+    '[attr.data-task-selectable]': 'focusable() ? "true" : null',
     '[attr.tabindex]': 'focusable() ? "0" : null',
     '[class.isDone]': 'task().isDone',
     '[class.isDragReady]': 'isDragReady()',
     '[class.isCurrent]': 'isCurrent()',
+    '[class.isMultiSelected]': 'isMultiSelected()',
   },
   /* eslint-enable @typescript-eslint/naming-convention */
 })
@@ -68,6 +96,13 @@ export class PlannerTaskComponent implements OnInit, OnDestroy, AfterViewInit {
   private _cd = inject(ChangeDetectorRef);
   private _destroyRef = inject(DestroyRef);
   private _elementRef = inject(ElementRef);
+  private _multiSelect = inject(TaskMultiSelectService);
+  private _configService = inject(GlobalConfigService);
+  private _matDialog = inject(MatDialog);
+  private _store = inject(Store);
+  private _dateService = inject(DateService);
+  private _dateAdapter = inject(DateAdapter);
+  private _isTaskDeleteTriggered = false;
 
   readonly task = input.required<TaskCopy>();
 
@@ -79,9 +114,11 @@ export class PlannerTaskComponent implements OnInit, OnDestroy, AfterViewInit {
   // TODO remove
   readonly day = input<string | undefined>();
   readonly tagsToHide = input<string[]>();
-  // Opt-in DOM focusability (only the Planner overdue list needs it, for the
-  // schedule-today shortcut). Off everywhere else to avoid stray Tab stops.
+  // Explicit opt-in keeps Boards and scheduled-list cards out of Planner navigation.
   readonly focusable = input<boolean>(false);
+  readonly isMultiSelected = computed(() =>
+    this.focusable() ? this._multiSelect.selectedIds().has(this.task().id) : false,
+  );
 
   readonly T = T;
   readonly isTouchActive = isTouchActive;
@@ -108,17 +145,62 @@ export class PlannerTaskComponent implements OnInit, OnDestroy, AfterViewInit {
       event.preventDefault();
       return;
     }
+    if (this.focusable() && this._multiSelect.has(this.task().id)) {
+      event.preventDefault();
+      event.stopPropagation();
+      const rect = (
+        this._elementRef.nativeElement as HTMLElement
+      ).getBoundingClientRect();
+      const halfWidth = rect.width / 2;
+      const halfHeight = rect.height / 2;
+      this._multiSelect.requestMenuOpen({
+        x: rect.left + halfWidth,
+        y: rect.top + halfHeight,
+      });
+      return;
+    }
     this.openContextMenu(event);
   }
 
   @HostListener('click', ['$event'])
   async clickHandler(event: MouseEvent): Promise<void> {
     const target = event.target as HTMLElement | null;
+    if (this.focusable() && this._multiSelect.isActive()) {
+      this._multiSelect.clear();
+    }
     if (target?.tagName === 'A' || target?.closest('a')) {
+      return;
+    }
+    if (this.focusable()) {
+      if (!this._isInteractiveClickTarget(target)) {
+        (this._elementRef.nativeElement as HTMLElement).focus();
+      }
       return;
     }
     // Use bottom panel on mobile, dialog on desktop
     this._taskService.setSelectedId(this.task().id);
+  }
+
+  @HostListener('dblclick', ['$event'])
+  onDoubleClick(event: MouseEvent): void {
+    if (
+      !this.focusable() ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey ||
+      this._isInteractiveClickTarget(event.target as HTMLElement | null)
+    ) {
+      return;
+    }
+    this._taskService.setSelectedId(this.task().id);
+  }
+
+  private _isInteractiveClickTarget(target: HTMLElement | null): boolean {
+    const host = this._elementRef.nativeElement as HTMLElement;
+    const interactive = target?.closest<HTMLElement>(
+      'a, button, input, textarea, select, [contenteditable="true"], [tabindex]',
+    );
+    return !!interactive && interactive !== host;
   }
 
   readonly timeEstimate = computed<number>(() => {
@@ -161,12 +243,440 @@ export class PlannerTaskComponent implements OnInit, OnDestroy, AfterViewInit {
         () => el.removeEventListener('touchmove', onEnd),
       ];
     }
+    if (this.focusable()) {
+      const host = this._elementRef.nativeElement as HTMLElement;
+      const selectFromModifierClick = (event: MouseEvent): void => {
+        const target = event.target;
+        if (
+          !(event.ctrlKey || event.metaKey || event.shiftKey) ||
+          (target instanceof HTMLElement && isInputElement(target))
+        ) {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        host.focus();
+        if (event.shiftKey) {
+          this._multiSelect.selectRange(this.task().id, event.ctrlKey || event.metaKey);
+        } else {
+          this._multiSelect.toggle(this.task().id);
+        }
+      };
+      const preventShiftSelection = (event: MouseEvent): void => {
+        if (
+          event.shiftKey &&
+          !(event.target instanceof HTMLElement && isInputElement(event.target))
+        ) {
+          event.preventDefault();
+        }
+      };
+      host.addEventListener('click', selectFromModifierClick, true);
+      host.addEventListener('mousedown', preventShiftSelection, true);
+      this._touchListenerCleanups.push(
+        () => host.removeEventListener('click', selectFromModifierClick, true),
+        () => host.removeEventListener('mousedown', preventShiftSelection, true),
+      );
+    }
   }
 
   ngOnDestroy(): void {
+    if (this.focusable()) {
+      this._multiSelect.removeWhenUnrendered(
+        this.task().id,
+        this._elementRef.nativeElement,
+      );
+    }
     window.clearTimeout(this._doneAnimationTimeout);
     window.clearTimeout(this._dragReadyTimeout);
     this._touchListenerCleanups.forEach((fn) => fn());
+  }
+
+  @HostListener('keydown', ['$event'])
+  onKeydown(event: KeyboardEvent): void {
+    const host = this._elementRef.nativeElement as HTMLElement;
+    if (!this.focusable() || event.target !== host) {
+      return;
+    }
+    const keys = this._configService.cfg()?.keyboard;
+    if (
+      keys &&
+      Object.values(keys).some(
+        (combo) => typeof combo === 'string' && combo && checkKeyCombo(event, combo),
+      )
+    ) {
+      return;
+    }
+    if (
+      event.ctrlKey &&
+      event.shiftKey &&
+      !event.altKey &&
+      !event.metaKey &&
+      (event.key === 'ArrowLeft' || event.key === 'ArrowRight')
+    ) {
+      this._moveOneDay(event.key === 'ArrowLeft' ? -1 : 1);
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    if (event.altKey || event.ctrlKey || event.metaKey) {
+      return;
+    }
+    if (event.key === 'Enter') {
+      this._taskService.setSelectedId(this.task().id);
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)) {
+      return;
+    }
+    if (event.shiftKey && (event.key === 'ArrowUp' || event.key === 'ArrowDown')) {
+      return;
+    }
+    this._moveFocus(event.key as 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight');
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  private _moveFocus(key: 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight'): void {
+    const rows = this._plannerRows();
+    const host = this._elementRef.nativeElement as HTMLElement;
+    const current = host;
+    const currentIndex = rows.indexOf(current);
+    let target: HTMLElement | undefined;
+    if (key === 'ArrowUp' || key === 'ArrowDown') {
+      const scope = current.closest('[data-planner-selection-scope]');
+      const scopedRows = rows.filter(
+        (row) => row.closest('[data-planner-selection-scope]') === scope,
+      );
+      const index = scopedRows.indexOf(current);
+      target = scopedRows[key === 'ArrowDown' ? index + 1 : index - 1];
+    } else {
+      const scopes = Array.from(
+        document.querySelectorAll<HTMLElement>('[data-planner-selection-scope]'),
+      ).filter((scope) =>
+        scope.querySelector('planner-task[data-task-selectable="true"]'),
+      );
+      const scope = current.closest<HTMLElement>('[data-planner-selection-scope]');
+      const scopeIndex = scope ? scopes.indexOf(scope) : -1;
+      const nextScope = scopes[key === 'ArrowRight' ? scopeIndex + 1 : scopeIndex - 1];
+      if (nextScope) {
+        const currentScopeRows = scope
+          ? Array.from(
+              scope.querySelectorAll<HTMLElement>(
+                'planner-task[data-task-selectable="true"]',
+              ),
+            )
+          : [];
+        const rowIndex = Math.max(0, currentScopeRows.indexOf(current));
+        const nextRows = Array.from(
+          nextScope.querySelectorAll<HTMLElement>(
+            'planner-task[data-task-selectable="true"]',
+          ),
+        );
+        target = nextRows[Math.min(rowIndex, nextRows.length - 1)];
+      }
+    }
+    if (target && currentIndex !== -1) {
+      target.focus();
+      target.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    }
+  }
+
+  private _plannerRows(): HTMLElement[] {
+    return Array.from(
+      document.querySelectorAll<HTMLElement>('planner-task[data-task-selectable="true"]'),
+    );
+  }
+
+  @HostListener('planner-task-shortcut', ['$event'])
+  onTaskShortcut(event: CustomEvent<{ keyboardEvent: KeyboardEvent }>): void {
+    const keyboardEvent = event.detail.keyboardEvent;
+    const keys = this._configService.cfg()?.keyboard;
+    if (!keys) {
+      return;
+    }
+    if (checkKeyCombo(keyboardEvent, keys.selectPreviousTask)) {
+      this._moveFocus('ArrowUp');
+    } else if (checkKeyCombo(keyboardEvent, keys.selectNextTask)) {
+      this._moveFocus('ArrowDown');
+    } else if (checkKeyCombo(keyboardEvent, keys.taskToggleDone)) {
+      this._runMutationWithFocus(() => this.toggleTaskDone());
+    } else if (
+      checkKeyCombo(keyboardEvent, keys.togglePlay) &&
+      this._configService.appFeatures().isTimeTrackingEnabled
+    ) {
+      this._taskService.setCurrentId(this.isCurrent() ? null : this.task().id);
+    } else if (checkKeyCombo(keyboardEvent, keys.taskScheduleToday)) {
+      this._runMutationWithFocus(() =>
+        this._taskService.scheduleForTodayById(this.task().id),
+      );
+    } else if (checkKeyCombo(keyboardEvent, keys.taskScheduleTomorrow)) {
+      this._scheduleForOffset('tomorrow');
+    } else if (checkKeyCombo(keyboardEvent, keys.taskScheduleNextWeek)) {
+      this._scheduleForOffset('nextWeek');
+    } else if (checkKeyCombo(keyboardEvent, keys.taskScheduleNextMonth)) {
+      this._scheduleForOffset('nextMonth');
+    } else if (checkKeyCombo(keyboardEvent, keys.taskUnschedule)) {
+      this._runMutationWithFocus(() =>
+        this._store.dispatch(TaskSharedActions.unscheduleTask({ id: this.task().id })),
+      );
+    } else if (checkKeyCombo(keyboardEvent, keys.taskDelete)) {
+      this._deleteTask();
+    } else if (checkKeyCombo(keyboardEvent, keys.taskSchedule)) {
+      this._openTaskDialog(DialogScheduleTaskComponent);
+    } else if (checkKeyCombo(keyboardEvent, keys.taskScheduleDeadline)) {
+      this._openTaskDialog(DialogDeadlineComponent);
+    } else if (checkKeyCombo(keyboardEvent, keys.taskOpenEstimationDialog)) {
+      this._openTaskDialog(DialogTimeEstimateComponent);
+    } else if (
+      checkKeyCombo(keyboardEvent, keys.taskOpenContextMenu) ||
+      this._isNativeContextMenuKey(keyboardEvent)
+    ) {
+      this._openContextMenuFromKeyboard();
+    } else if (checkKeyCombo(keyboardEvent, keys.moveTaskUp)) {
+      this._reorderAllDay('up');
+    } else if (checkKeyCombo(keyboardEvent, keys.moveTaskDown)) {
+      this._reorderAllDay('down');
+    } else if (checkKeyCombo(keyboardEvent, keys.moveTaskToTop)) {
+      this._reorderAllDay('top');
+    } else if (checkKeyCombo(keyboardEvent, keys.moveTaskToBottom)) {
+      this._reorderAllDay('bottom');
+    } else {
+      return;
+    }
+    event.preventDefault();
+  }
+
+  private _scheduleForOffset(offset: 'tomorrow' | 'nextWeek' | 'nextMonth'): void {
+    const date = this._dateService.getLogicalTodayDate();
+    if (offset === 'tomorrow') {
+      date.setDate(date.getDate() + 1);
+    } else if (offset === 'nextWeek') {
+      date.setDate(date.getDate() + getNextWeekDayOffset(this._dateAdapter, date));
+    } else {
+      date.setDate(1);
+      date.setMonth(date.getMonth() + 1);
+    }
+    this._runMutationWithFocus(() => this._scheduleForDay(date));
+  }
+
+  private _moveOneDay(dayDelta: -1 | 1): void {
+    const task = this.task();
+    const displayedDay = this.day();
+    const baseDate = displayedDay
+      ? parseDbDateStr(displayedDay)
+      : task.dueWithTime
+        ? new Date(task.dueWithTime)
+        : task.dueDay
+          ? parseDbDateStr(task.dueDay)
+          : null;
+    if (!baseDate) {
+      return;
+    }
+    baseDate.setDate(baseDate.getDate() + dayDelta);
+    this._runMutationWithFocus(() => this._scheduleForDay(baseDate));
+  }
+
+  private _scheduleForDay(date: Date): void {
+    const task = this.task();
+    if (task.dueWithTime) {
+      const timestamp = combineDateAndTime(date, new Date(task.dueWithTime)).getTime();
+      const remindCfg = task.reminderId
+        ? millisecondsDiffToRemindOption(task.dueWithTime, task.remindAt)
+        : (this._configService.cfg()?.reminder.defaultTaskRemindOption ??
+          DEFAULT_GLOBAL_CONFIG.reminder.defaultTaskRemindOption!);
+      this._taskService.scheduleTask(task, timestamp, remindCfg, false);
+      return;
+    }
+    this._store.dispatch(
+      PlannerActions.planTaskForDay({ task, day: getDbDateStr(date), isShowSnack: true }),
+    );
+  }
+
+  private _deleteTask(): void {
+    if (this._isTaskDeleteTriggered) {
+      return;
+    }
+    if (this._configService.cfg()?.tasks?.isConfirmBeforeDelete ?? true) {
+      this._matDialog
+        .open(DialogConfirmComponent, {
+          data: {
+            okTxt: T.F.TASK.D_CONFIRM_DELETE.OK,
+            message: T.F.TASK.D_CONFIRM_DELETE.MSG,
+            translateParams: { title: this.task().title },
+          },
+        })
+        .afterClosed()
+        .pipe(takeUntilDestroyed(this._destroyRef))
+        .subscribe((isConfirm) => {
+          if (isConfirm) {
+            this._performDelete();
+          } else {
+            this._restoreFocus(this.task().id, null, this._localAddButton());
+          }
+        });
+      return;
+    }
+    this._performDelete();
+  }
+
+  private _performDelete(): void {
+    this._isTaskDeleteTriggered = true;
+    const rows = this._plannerRows();
+    const index = rows.indexOf(this._elementRef.nativeElement);
+    const fallbackId =
+      rows[index + 1]?.getAttribute('data-task-id') ??
+      rows[index - 1]?.getAttribute('data-task-id') ??
+      null;
+    const fallbackEl = this._localAddButton();
+    this._taskService
+      .getByIdWithSubTaskData$(this.task().id)
+      .pipe(first(), takeUntilDestroyed(this._destroyRef))
+      .subscribe((task) => {
+        if (task) {
+          this._taskService.remove(task);
+          this._restoreFocus(null, fallbackId, fallbackEl);
+        }
+      });
+  }
+
+  private _reorderAllDay(direction: 'up' | 'down' | 'top' | 'bottom'): void {
+    const host = this._elementRef.nativeElement as HTMLElement;
+    if (host.closest('.scheduled-items')) {
+      return;
+    }
+    const scope = host.closest<HTMLElement>('[data-planner-selection-scope]');
+    const rows = scope
+      ? Array.from(
+          scope.querySelectorAll<HTMLElement>(
+            '.normal-tasks planner-task[data-task-selectable="true"]',
+          ),
+        )
+      : [];
+    const fromIndex = rows.indexOf(host);
+    const toIndex =
+      direction === 'up'
+        ? fromIndex - 1
+        : direction === 'down'
+          ? fromIndex + 1
+          : direction === 'top'
+            ? 0
+            : rows.length - 1;
+    if (fromIndex < 0 || toIndex < 0 || toIndex >= rows.length || fromIndex === toIndex) {
+      return;
+    }
+    const day = this.day();
+    if (!day) {
+      return;
+    }
+    const fallbackEl = this._localAddButton();
+    if (day === this._dateService.todayStr()) {
+      const props = {
+        taskId: this.task().id,
+        workContextType: WorkContextType.TAG,
+        workContextId: TODAY_TAG.id,
+        doneTaskIds: rows.map((row) => row.getAttribute('data-task-id') as string),
+      };
+      const action =
+        direction === 'up'
+          ? moveTaskUpInTodayList(props)
+          : direction === 'down'
+            ? moveTaskDownInTodayList(props)
+            : direction === 'top'
+              ? moveTaskToTopInTodayList(props)
+              : moveTaskToBottomInTodayList(props);
+      this._store.dispatch(action);
+    } else {
+      this._store.dispatch(
+        PlannerActions.moveInList({ targetDay: day, fromIndex, toIndex }),
+      );
+    }
+    this._restoreFocus(this.task().id, null, fallbackEl);
+  }
+
+  private _runMutationWithFocus(mutation: () => void, preferTask = true): void {
+    const rows = this._plannerRows();
+    const host = this._elementRef.nativeElement as HTMLElement;
+    const index = rows.indexOf(host);
+    const fallbackId =
+      rows[index + 1]?.getAttribute('data-task-id') ??
+      rows[index - 1]?.getAttribute('data-task-id') ??
+      null;
+    const fallbackEl = this._localAddButton();
+    mutation();
+    this._restoreFocus(preferTask ? this.task().id : null, fallbackId, fallbackEl);
+  }
+
+  private _restoreFocus(
+    preferredId: string | null,
+    fallbackId: string | null,
+    fallbackEl: HTMLElement | null,
+  ): void {
+    setTimeout(() => {
+      const active = document.activeElement;
+      if (active && active !== document.body && active.isConnected) {
+        return;
+      }
+      const row =
+        (preferredId && this._multiSelect.findLiveRowEl(preferredId)) ||
+        (fallbackId && this._multiSelect.findLiveRowEl(fallbackId));
+      if (row) {
+        row.focus({ preventScroll: true });
+        row.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+      } else if (fallbackEl?.isConnected) {
+        fallbackEl.focus({ preventScroll: true });
+      }
+    });
+  }
+
+  private _localAddButton(): HTMLElement | null {
+    return (
+      (this._elementRef.nativeElement as HTMLElement)
+        .closest<HTMLElement>('[data-planner-selection-scope]')
+        ?.querySelector<HTMLElement>('add-task-inline button') ??
+      document.querySelector<HTMLElement>(
+        'planner-day[data-planner-selection-scope] add-task-inline button',
+      )
+    );
+  }
+
+  private _openContextMenuFromKeyboard(): void {
+    const host = this._elementRef.nativeElement as HTMLElement;
+    if (!this.isContextMenuLoaded()) {
+      this.isContextMenuLoaded.set(true);
+      setTimeout(() => this.taskContextMenu()?.open(undefined, true, host));
+      return;
+    }
+    this.taskContextMenu()?.open(undefined, true, host);
+  }
+
+  private _isNativeContextMenuKey(event: KeyboardEvent): boolean {
+    return (
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.metaKey &&
+      !event.shiftKey &&
+      (event.key === 'ContextMenu' ||
+        event.key === 'Menu' ||
+        event.code === 'ContextMenu')
+    );
+  }
+
+  private _openTaskDialog(component: Parameters<MatDialog['open']>[0]): void {
+    const rows = this._plannerRows();
+    const index = rows.indexOf(this._elementRef.nativeElement);
+    const fallbackId =
+      rows[index + 1]?.getAttribute('data-task-id') ??
+      rows[index - 1]?.getAttribute('data-task-id') ??
+      null;
+    const fallbackEl = this._localAddButton();
+    this._matDialog
+      .open(component, { autoFocus: false, data: { task: this.task() } })
+      .afterClosed()
+      .subscribe(() => {
+        this._restoreFocus(this.task().id, fallbackId, fallbackEl);
+      });
   }
 
   // A confirmed horizontal swipe (open menu / mark done) is not a drag, so

--- a/src/app/features/tasks/task-bulk-action.service.spec.ts
+++ b/src/app/features/tasks/task-bulk-action.service.spec.ts
@@ -40,7 +40,7 @@ describe('TaskBulkActionService', () => {
     clear: jasmine.Spy;
     isBulkFeedbackSuppressed: Signal<boolean>;
     setBulkFeedbackSuppressed: (v: boolean) => void;
-    isDestroyedHost: () => boolean;
+    isDestroyedHost: (el: Element) => boolean;
     findLiveRowEl: () => HTMLElement | null;
     isTouchSelectionMode: ReturnType<typeof signal<boolean>>;
   };
@@ -122,7 +122,7 @@ describe('TaskBulkActionService', () => {
       isBulkFeedbackSuppressed: suppressed,
       setBulkFeedbackSuppressed: (v: boolean) =>
         suppressionDepth.update((depth) => (v ? depth + 1 : Math.max(0, depth - 1))),
-      isDestroyedHost: () => false,
+      isDestroyedHost: (_el: Element) => false,
       findLiveRowEl: () => null,
       isTouchSelectionMode: signal(false),
     };
@@ -231,6 +231,34 @@ describe('TaskBulkActionService', () => {
   });
 
   describe('deleteSelected', () => {
+    it('focuses the Planner add button when every selected card is removed', async () => {
+      isConfirmBeforeDelete = false;
+      select([t('only')]);
+      const day = document.createElement('planner-day');
+      day.setAttribute('data-planner-selection-scope', '2026-09-12');
+      const row = document.createElement('planner-task');
+      row.setAttribute('data-task-id', 'only');
+      row.setAttribute('data-task-selectable', 'true');
+      row.tabIndex = 0;
+      const addTask = document.createElement('add-task-inline');
+      const add = document.createElement('button');
+      addTask.appendChild(add);
+      day.append(row, addTask);
+      document.body.appendChild(day);
+      row.focus();
+      let isDestroyed = false;
+      multiSelect.isDestroyedHost = (el: Element) => isDestroyed && el === row;
+      taskService.remove.and.callFake(() => {
+        isDestroyed = true;
+      });
+      spyOn(add, 'focus');
+
+      await service.deleteSelected();
+
+      expect(add.focus).toHaveBeenCalled();
+      day.remove();
+    });
+
     it('confirms, dedupes subtasks of selected parents, and splits lone subtasks off', async () => {
       select([
         t('parent', { subTaskIds: ['sub'] }),

--- a/src/app/features/tasks/task-bulk-action.service.ts
+++ b/src/app/features/tasks/task-bulk-action.service.ts
@@ -713,12 +713,16 @@ export class TaskBulkActionService {
    * (they leave together with it). Resolved to an element only afterwards,
    * since rows may re-mount.
    */
-  private _getFocusTargetAfterRemoval(): string | null {
+  private _getFocusTargetAfterRemoval(): string | HTMLElement | null {
     if (isTouchActive()) {
       return null;
     }
     const selected = this._multiSelect.selectedIds();
-    const rows = Array.from(document.querySelectorAll<HTMLElement>('task')).filter(
+    const rows = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        'task, planner-task[data-task-selectable="true"]',
+      ),
+    ).filter(
       (el) => !el.closest('task-detail-panel') && !this._multiSelect.isDestroyedHost(el),
     );
     const idOf = (el: HTMLElement): string => el.getAttribute('data-task-id') ?? '';
@@ -748,7 +752,14 @@ export class TaskBulkActionService {
     const target =
       rows.slice(lastSelectedIndex + 1).find(isCandidate) ??
       rows.slice(0, lastSelectedIndex).reverse().find(isCandidate);
-    return target ? idOf(target) : null;
+    if (target) {
+      return idOf(target);
+    }
+    return rows.some((row) => row.matches('planner-task') && selected.has(idOf(row)))
+      ? document.querySelector<HTMLElement>(
+          'planner-day[data-planner-selection-scope] add-task-inline button',
+        )
+      : null;
   }
 
   /**
@@ -757,12 +768,12 @@ export class TaskBulkActionService {
    * selection is a working set that survives, so only keyboard focus is
    * restored. Cancelled dialogs and "nothing to do" never get here.
    */
-  private _finish(focusTargetId: string | null = null): void {
+  private _finish(focusTarget: string | HTMLElement | null = null): void {
     if (this._multiSelect.isTouchSelectionMode()) {
       this._multiSelect.clear();
       return;
     }
-    this._restoreFocus(focusTargetId);
+    this._restoreFocus(focusTarget);
   }
 
   /**
@@ -771,12 +782,9 @@ export class TaskBulkActionService {
    * DOM while its leave animation runs, so "gone" is asked from the selection
    * service, which knows the destroyed hosts.
    */
-  private _restoreFocus(targetId: string | null): void {
-    if (!targetId) {
-      return;
-    }
+  private _restoreFocus(target: string | HTMLElement | null): void {
     const active = document.activeElement;
-    const activeRow = active?.closest('task');
+    const activeRow = active?.closest('task, planner-task[data-task-selectable="true"]');
     const isFocusIntact =
       !!active &&
       active !== document.body &&
@@ -785,6 +793,10 @@ export class TaskBulkActionService {
     if (isFocusIntact) {
       return;
     }
-    this._multiSelect.findLiveRowEl(targetId)?.focus({ preventScroll: true });
+    const targetEl =
+      typeof target === 'string' ? this._multiSelect.findLiveRowEl(target) : target;
+    if (targetEl?.isConnected) {
+      targetEl.focus({ preventScroll: true });
+    }
   }
 }

--- a/src/app/features/tasks/task-multi-select-bar/task-multi-select-bar.component.spec.ts
+++ b/src/app/features/tasks/task-multi-select-bar/task-multi-select-bar.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { signal } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
@@ -158,4 +158,30 @@ describe('TaskMultiSelectBarComponent', () => {
     fixture.destroy();
     expect(multiSelect.count()).toBe(0);
   });
+
+  for (const tag of ['task', 'planner-task']) {
+    it(`restores menu focus to the live ${tag} when its old host is still rendered`, fakeAsync(() => {
+      const container = document.createElement('div');
+      const oldRow = document.createElement(tag);
+      const liveRow = document.createElement(tag);
+      for (const row of [oldRow, liveRow]) {
+        row.setAttribute('data-task-id', 'a');
+        row.setAttribute('data-task-selectable', 'true');
+        row.tabIndex = 0;
+        container.appendChild(row);
+      }
+      document.body.appendChild(container);
+      try {
+        multiSelect.toggle('a');
+        multiSelect.removeWhenUnrendered('a', oldRow);
+
+        fixture.componentInstance.onMenuClosed();
+
+        expect(document.activeElement).toBe(liveRow);
+        tick();
+      } finally {
+        container.remove();
+      }
+    }));
+  }
 });

--- a/src/app/features/tasks/task-multi-select-bar/task-multi-select-bar.component.ts
+++ b/src/app/features/tasks/task-multi-select-bar/task-multi-select-bar.component.ts
@@ -187,7 +187,11 @@ export class TaskMultiSelectBarComponent {
     if (!anchorId || isTouchActive() || this._matDialog.openDialogs.length > 0) {
       return;
     }
-    const rowEl = Array.from(document.querySelectorAll<HTMLElement>('task')).find(
+    const rowEl = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        'task, planner-task[data-task-selectable="true"]',
+      ),
+    ).find(
       (el) =>
         el.getAttribute('data-task-id') === anchorId && !el.closest('task-detail-panel'),
     );

--- a/src/app/features/tasks/task-multi-select-bar/task-multi-select-bar.component.ts
+++ b/src/app/features/tasks/task-multi-select-bar/task-multi-select-bar.component.ts
@@ -187,14 +187,7 @@ export class TaskMultiSelectBarComponent {
     if (!anchorId || isTouchActive() || this._matDialog.openDialogs.length > 0) {
       return;
     }
-    const rowEl = Array.from(
-      document.querySelectorAll<HTMLElement>(
-        'task, planner-task[data-task-selectable="true"]',
-      ),
-    ).find(
-      (el) =>
-        el.getAttribute('data-task-id') === anchorId && !el.closest('task-detail-panel'),
-    );
+    const rowEl = this.multiSelect.findLiveRowEl(anchorId);
     rowEl?.focus({ preventScroll: true });
   }
 }

--- a/src/app/features/tasks/task-multi-select.service.spec.ts
+++ b/src/app/features/tasks/task-multi-select.service.spec.ts
@@ -29,6 +29,13 @@ describe('TaskMultiSelectService', () => {
           <task data-task-id="b1" tabindex="0"></task>
         </div>
       </task-detail-panel>
+      <planner-day data-planner-selection-scope="2026-09-12">
+        <div><planner-task data-task-id="p1" data-task-selectable="true" tabindex="0"></planner-task></div>
+        <div><planner-task data-task-id="p2" data-task-selectable="true" tabindex="0"></planner-task></div>
+      </planner-day>
+      <planner-day data-planner-selection-scope="2026-09-13">
+        <planner-task data-task-id="p3" data-task-selectable="true" tabindex="0"></planner-task>
+      </planner-day>
     `;
     document.body.appendChild(root);
   };
@@ -45,7 +52,7 @@ describe('TaskMultiSelectService', () => {
   };
 
   const focusRow = (id: string): void => {
-    stubActiveElement(root.querySelector(`task[data-task-id="${id}"]`));
+    stubActiveElement(root.querySelector(`[data-task-id="${id}"]`));
   };
 
   const extend = (direction: 'up' | 'down'): HTMLElement | null => {
@@ -103,6 +110,15 @@ describe('TaskMultiSelectService', () => {
   });
 
   describe('selectRange', () => {
+    it('ranges across all-day and timed Planner rows within one day only', () => {
+      stubActiveElement(root.querySelector('planner-task[data-task-id="p1"]'));
+      service.toggle('p1');
+      service.selectRange('p2');
+      expect(selected()).toEqual(['p1', 'p2']);
+
+      service.selectRange('p3');
+      expect(selected()).toEqual(['p3']);
+    });
     it('selects the target alone when there is no anchor', () => {
       service.selectRange('c');
       expect(selected()).toEqual(['c']);
@@ -178,6 +194,11 @@ describe('TaskMultiSelectService', () => {
   });
 
   describe('selectAllInListOfFocused', () => {
+    it('selects all participating Planner rows in the focused day', () => {
+      focusRow('p2');
+      service.selectAllInListOfFocused();
+      expect(selected()).toEqual(['p1', 'p2']);
+    });
     it('selects the direct rows of the focused list only', () => {
       focusRow('c');
       service.selectAllInListOfFocused();

--- a/src/app/features/tasks/task-multi-select.service.ts
+++ b/src/app/features/tasks/task-multi-select.service.ts
@@ -10,7 +10,7 @@ export type MultiSelectDirection = 'up' | 'down';
  * - UI-only: not in NgRx state, never persisted, never synced. Pure state with
  *   no injected dependencies; the app-shell bar component wires the clearing
  *   on route and work-context change (TaskMultiSelectBarComponent).
- * - Only ever holds ids of tasks currently rendered as a `<task>` row; rows
+ * - Only ever holds ids of tasks currently rendered as a participating row; rows
  *   prune themselves on destroy.
  * - Ranges and keyboard extension are scoped to the anchor's list, i.e. the
  *   direct `<task>` children of its `.task-list-inner`, so expanded subtasks
@@ -226,7 +226,7 @@ export class TaskMultiSelectService {
     return this._findRowEl(id);
   }
 
-  /** True for a `<task>` host whose component is already destroyed (animating out). */
+  /** True for a row host whose component is already destroyed (animating out). */
   isDestroyedHost(el: Element): boolean {
     return this._destroyedHosts.has(el);
   }
@@ -314,16 +314,26 @@ export class TaskMultiSelectService {
 
   /** The focused main-list row (detail-panel copies are never selectable). */
   private _focusedRow(): { el: HTMLElement; id: string } | null {
-    const el = document.activeElement?.closest('task') as HTMLElement | null;
+    const el = document.activeElement?.closest(
+      'task, planner-task[data-task-selectable="true"]',
+    ) as HTMLElement | null;
     const id = el?.getAttribute('data-task-id');
-    if (!el || !id || el.closest('task-detail-panel')) {
+    if (!el || !id || this._destroyedHosts.has(el) || el.closest('task-detail-panel')) {
       return null;
     }
     return { el, id };
   }
 
-  /** Direct `<task>` children of the list that contains `el`. */
+  /** Participating rows in the selection scope containing `el`. */
   private _listRowsFor(el: HTMLElement): HTMLElement[] {
+    const plannerScope = el.closest<HTMLElement>('[data-planner-selection-scope]');
+    if (plannerScope) {
+      return Array.from(
+        plannerScope.querySelectorAll<HTMLElement>(
+          'planner-task[data-task-selectable="true"]',
+        ),
+      ).filter((row) => !this._destroyedHosts.has(row));
+    }
     const list = el.parentElement?.closest('.task-list-inner');
     if (!list) {
       return [el];
@@ -342,8 +352,10 @@ export class TaskMultiSelectService {
   }
 
   private _getAllTaskEls(): HTMLElement[] {
-    return Array.from(document.querySelectorAll<HTMLElement>('task')).filter(
-      (el) => !this._destroyedHosts.has(el) && !el.closest('task-detail-panel'),
-    );
+    return Array.from(
+      document.querySelectorAll<HTMLElement>(
+        'task, planner-task[data-task-selectable="true"]',
+      ),
+    ).filter((el) => !this._destroyedHosts.has(el) && !el.closest('task-detail-panel'));
   }
 }

--- a/src/app/features/tasks/task-shortcut.service.spec.ts
+++ b/src/app/features/tasks/task-shortcut.service.spec.ts
@@ -850,6 +850,56 @@ describe('TaskShortcutService', () => {
     });
   });
 
+  it('routes a configured modified navigation key to the focused Planner card', () => {
+    mockConfigService.cfg.set({
+      keyboard: { ...defaultKeyboardConfig, selectNextTask: 'Ctrl+Alt+J' },
+      appFeatures: { isTimeTrackingEnabled: true },
+    });
+    const plannerEl = document.createElement('planner-task');
+    plannerEl.setAttribute('data-task-id', 'planner-task');
+    plannerEl.setAttribute('data-task-selectable', 'true');
+    document.body.appendChild(plannerEl);
+    stubActiveElement(plannerEl);
+    const routed = jasmine.createSpy('routed');
+    plannerEl.addEventListener('planner-task-shortcut', (event) => {
+      routed();
+      event.preventDefault();
+    });
+
+    const result = service.handleTaskShortcuts(
+      createKeyboardEvent('j', 'KeyJ', { ctrlKey: true, altKey: true }),
+    );
+
+    expect(result).toBeTrue();
+    expect(routed).toHaveBeenCalled();
+    plannerEl.remove();
+  });
+
+  it('leaves a configured Meta shortcut untouched while editing inside Planner', () => {
+    mockConfigService.cfg.set({
+      keyboard: { ...defaultKeyboardConfig, taskToggleDone: 'Meta+D' },
+      appFeatures: { isTimeTrackingEnabled: true },
+    });
+    const plannerEl = document.createElement('planner-task');
+    plannerEl.setAttribute('data-task-id', 'planner-task');
+    plannerEl.setAttribute('data-task-selectable', 'true');
+    const input = document.createElement('input');
+    plannerEl.appendChild(input);
+    document.body.appendChild(plannerEl);
+    stubActiveElement(input);
+    const routed = jasmine.createSpy('routed');
+    plannerEl.addEventListener('planner-task-shortcut', routed);
+
+    const event = createKeyboardEvent('d', 'KeyD', { metaKey: true });
+    Object.defineProperty(event, 'target', { value: input });
+    const result = service.handleTaskShortcuts(event);
+
+    expect(result).toBeFalse();
+    expect(routed).not.toHaveBeenCalled();
+    expect(mockBulkActions['toggleDone']).not.toHaveBeenCalled();
+    plannerEl.remove();
+  });
+
   describe('schedule-today shortcut (#8851)', () => {
     let hostEl: HTMLElement;
 

--- a/src/app/features/tasks/task-shortcut.service.ts
+++ b/src/app/features/tasks/task-shortcut.service.ts
@@ -69,14 +69,35 @@ export class TaskShortcutService {
 
     const keys = cfg.keyboard;
     const focusedTaskId: TaskId | null = getDomFocusedTaskId();
+    const plannerRow = document.activeElement?.closest<HTMLElement>(
+      'planner-task[data-task-selectable="true"]',
+    );
+    const shortcutTargetId =
+      focusedTaskId ?? plannerRow?.getAttribute('data-task-id') ?? null;
+    if (plannerRow && ev.target instanceof HTMLElement && isInputElement(ev.target)) {
+      return false;
+    }
 
     // Multi-selection: Esc clears; Shift+Arrow extends from the focused row;
     // the bulk-capable task shortcuts act on the whole selection. These run
     // before the focused-task gate so they also work when focus sits on the
     // selection bar or a dialog just closed. (ShortcutService already bails
     // out for inputs and open overlays, so Esc/typing there are untouched.)
-    if (this._handleMultiSelectShortcuts(ev, keys, focusedTaskId)) {
+    if (this._handleMultiSelectShortcuts(ev, keys, shortcutTargetId)) {
       return true;
+    }
+
+    if (plannerRow) {
+      const plannerEvent = new CustomEvent('planner-task-shortcut', {
+        cancelable: true,
+        detail: { keyboardEvent: ev },
+      });
+      plannerRow.dispatchEvent(plannerEvent);
+      if (plannerEvent.defaultPrevented) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        return true;
+      }
     }
 
     // Schedule for today (Shift+T). This is the one task shortcut wired to work
@@ -483,7 +504,9 @@ export class TaskShortcutService {
   /** Opens the bulk actions menu next to the focused row (or the bar). */
   private _requestBulkMenu(focusedTaskId: TaskId | null): void {
     const rowEl = focusedTaskId
-      ? (document.activeElement?.closest('task') as HTMLElement | null)
+      ? (document.activeElement?.closest(
+          'task, planner-task[data-task-selectable="true"]',
+        ) as HTMLElement | null)
       : null;
     const rect = rowEl?.getBoundingClientRect();
     this._multiSelect.requestMenuOpen(


### PR DESCRIPTION
## Problem

Planner task cards lack the keyboard navigation, configured task shortcuts, and multiselect available in regular task lists, making keyboard-driven planning cumbersome.

## Solution

- Enable navigation and task selection for overdue, all-day, and timed Planner cards, reusing the existing bulk-action toolbar and services.
- Single-click focuses a card with the regular task focus border; double-click or Enter opens task details.
- Support configured task actions and all-day reordering. Ctrl+Shift+Left/Right moves a task one calendar day while preserving its time and reminder.
- Restore focus after deletion, scheduling, completion animations, and bulk-menu closure, including overlapping completion and movement.
- Keep Boards and scheduled-list interactions unchanged. Calendar events, deadline markers, and repeat previews remain outside task multiselect.

No new dependencies, settings, or persisted-state formats. Updated the keyboard-shortcuts wiki and implementation plan.

## Validation

- Initial implementation: 175 unit tests across seven affected suites, six Planner browser scenarios, and two regular-list multiselect regressions passed; development build passed.
- Final fixes: 52 Planner task and multiselect-bar unit tests passed, including regressions reproduced before the fixes.
- Eight Planner browser scenarios passed with retries disabled; the two affected focus/movement scenarios passed again after the final adjustment.
- `checkFile` passed for every changed TypeScript/SCSS file; documentation links, formatting, and diff checks passed.
- Six-perspective review followed by fixes and an independent follow-up review; no remaining material findings.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have included relevant changes to the documentation/[wiki](https://github.com/super-productivity/super-productivity/tree/master/docs/wiki).
- [x] I have run `npm run checkFile` on changed `.ts`/`.scss` files
- [x] I have added tests for my changes (if applicable)
- [x] Existing tests still pass (affected suites listed above)
- [x] My commit messages follow the Angular format (`type(scope): description`)
